### PR TITLE
session_new change for no connection and conn_open implemented.

### DIFF
--- a/tcl/conn.tcl
+++ b/tcl/conn.tcl
@@ -198,3 +198,8 @@ proc qc::conn_if_modified_since {} {
         return ""
     }
 }
+
+proc qc::conn_open {} {
+    #| Check if the client connection is open
+    return [expr {[ns_conn isconnected] && !(0x1 & [ns_conn flags])}]
+}

--- a/tcl/session.tcl
+++ b/tcl/session.tcl
@@ -14,7 +14,11 @@ proc qc::session_new { user_id } {
     set uuid [uuid::uuid generate]
     set session_id [qc::sha1 "$uuid $entropy1"]
     set authenticity_token [qc::sha1 $entropy2]
-    set ip [qc::conn_remote_ip]
+    if { [qc::conn_open]} {
+        set ip [qc::conn_remote_ip]
+    } else {
+        set ip ""
+    }
     db_dml "insert into session [sql_insert session_id ip user_id authenticity_token]"    
     return $session_id
 }


### PR DESCRIPTION
`qc::session_new` now sets the IP to be the IP of the connected client otherwise the empty string. Useful for anonymous sessions.

`qc::conn_open` implemented to abstract unreadable connection check.
