### PR TITLE
db_column_table_primary fix

### DIFF
--- a/tcl/db.tcl
+++ b/tcl/db.tcl
@@ -721,7 +721,7 @@ proc qc::db_column_table_primary {column} {
         SELECT tc.table_name
         FROM information_schema.table_constraints tc
         JOIN information_schema.constraint_column_usage ccu
-        ON ccu.constraint_name=tc.constraint_name
+        USING (table_name, constraint_name)
         WHERE column_name=:column
         AND constraint_type='PRIMARY KEY'
         LIMIT 1;


### PR DESCRIPTION
The query in this proc would return unwanted results such that a table would be returned even though the given column was not a primary key within that table. The updated query ensures that only a table where the given column is a primary key will be returned.
