### PR TITLE
Cast, Castable, Is additions and documentation.

### DIFF
--- a/doc/procs/castable-bigint.md
+++ b/doc/procs/castable-bigint.md
@@ -1,0 +1,29 @@
+qc::castable bigint
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable bigint string`
+
+Description
+-----------
+Test if the given string can be cast to a bigint.
+
+A big int is an integer in the range of -9223372036854775808 to +9223372036854775807
+
+Examples
+--------
+```tcl
+
+% qc::castable bigint {1,234}
+true
+% qc::castable bigint foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-boolean.md
+++ b/doc/procs/castable-boolean.md
@@ -1,0 +1,31 @@
+qc::castable boolean
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable boolean string`
+
+Description
+-----------
+Test if the given string can be cast to a boolean.
+
+Examples
+--------
+```tcl
+
+% qc::castable boolean 1
+true
+% qc::castable boolean 5
+false
+% qc::castable boolean yes
+true
+% qc::castable boolean foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-char.md
+++ b/doc/procs/castable-char.md
@@ -1,0 +1,27 @@
+qc::castable char
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable char length string`
+
+Description
+-----------
+Test if the given string can be cast to char of the given length.
+
+Examples
+--------
+```tcl
+
+% qc::castable char 5 Hello
+true
+% qc::castable char 2 World
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-creditcard.md
+++ b/doc/procs/castable-creditcard.md
@@ -1,0 +1,27 @@
+qc::castable creditcard
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable creditcard string`
+
+Description
+-----------
+Test if the given string can be cast to a credit card number.
+
+Examples
+--------
+```tcl
+
+% qc::castable creditcard "4111 1111 1111 1111"
+true
+% qc::castable creditcard "4213 3222 1121 1112"
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-date.md
+++ b/doc/procs/castable-date.md
@@ -1,0 +1,31 @@
+qc::castable date
+====================
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable date string`
+
+Description
+-----------
+Test if the given string can be cast to a date.
+
+Examples
+--------
+```tcl
+
+% qc::castable date 10
+true
+% qc::castable date "June 22nd"
+true
+% qc::castable date tomorrow
+true
+% qc::castable date May
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-decimal.md
+++ b/doc/procs/castable-decimal.md
@@ -1,0 +1,35 @@
+qc::castable decimal
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable decimal ?-precision int? ?-scale int? string`
+
+Description
+-----------
+Test if the given string can be cast to a decimal with the precision and/or scale if given.
+
+Examples
+--------
+```tcl
+
+% qc::castable decimal 1.234
+true
+% qc::castable decimal -precision 4 -scale 3 1.234
+true
+% qc::castable decimal -scale 2 1.234
+true
+% qc::castable decimal -precision 4 1.234
+true
+% qc::castable decimal -precision 2 123.4
+false
+% qc::castable decimal foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-domain.md
+++ b/doc/procs/castable-domain.md
@@ -1,0 +1,27 @@
+qc::castable domain
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable domain name value`
+
+Description
+-----------
+Test if the given value can be cast to domain $name.
+
+Examples
+--------
+```tcl
+
+% qc::castable domain plain_text "Hellow World"
+true
+% qc::castable domain plain_text "<div>Foo</div>"
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-enumeration.md
+++ b/doc/procs/castable-enumeration.md
@@ -1,0 +1,27 @@
+qc::castable enumeration
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable enumeration name value`
+
+Description
+-----------
+Test if the given value can be cast to an enumeration value in $name.
+
+Examples
+--------
+```tcl
+
+% qc::castable enumeration post_state live
+true
+% qc::castable enumeration post_state foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-integer.md
+++ b/doc/procs/castable-integer.md
@@ -1,0 +1,27 @@
+qc::castable integer
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable integer string`
+
+Description
+-----------
+Test if the given string can be cast to an integer.
+
+Examples
+--------
+```tcl
+
+% qc::castable integer {1,234}
+true
+% qc::castable integer foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-period.md
+++ b/doc/procs/castable-period.md
@@ -1,0 +1,49 @@
+qc::castable period
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable period string`
+
+Description
+-----------
+Test if the given string can be cast to a period.
+
+Examples
+--------
+```tcl
+
+% qc::castable period "2014-01-01"
+true
+
+% qc::castable period "Jan 1st 2014"
+true
+
+% qc::castable period "2014"
+true
+
+% qc::castable period "Jan"
+true
+
+% qc::castable period "January"
+true
+
+% qc::castable period "Jan 2013"
+true
+
+% qc::castable period "January 2013"
+true
+
+% qc::castable period "January 2013 to March 2013"
+true
+
+% qc::castable period "1st Jan 2013 to 14th Jan 2013"
+true
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-postcode.md
+++ b/doc/procs/castable-postcode.md
@@ -1,0 +1,34 @@
+qc::castable postcode
+====================
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable postcode string`
+
+Description
+-----------
+Test if the given string can be cast to a UK postcode.
+
+Examples
+--------
+```tcl
+
+% qc::castable postcode AB12CD
+true
+% qc::castable postcode AB123CD
+true
+
+# Yzero should be YO
+% qc::castable postcode Y023 3CD
+true
+
+% qc::castable postcode 123
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-safe_html.md
+++ b/doc/procs/castable-safe_html.md
@@ -1,0 +1,27 @@
+qc::castable safe_html
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable safe_html text`
+
+Description
+-----------
+Test if the given text can be cast to safe html.
+
+Examples
+--------
+```tcl
+
+% qc::castable safe_html {Hello <a href="http://www.google.co.uk">World</a>}
+1
+% qc::castable safe_html {<script>alert('Foo')</script>}
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-safe_markdown.md
+++ b/doc/procs/castable-safe_markdown.md
@@ -1,0 +1,27 @@
+qc::castable safe_markdown
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable safe_markdown text`
+
+Description
+-----------
+Test if the given text can be cast to safe markdown.
+
+Examples
+--------
+```tcl
+
+% qc::castable safe_markdown {# Hello `World`}
+1
+% qc::castable safe_markdown {<script>alert('Foo')</script>}
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-smallint.md
+++ b/doc/procs/castable-smallint.md
@@ -1,0 +1,29 @@
+qc::castable smallint
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable smallint string`
+
+Description
+-----------
+Test if the given string can be cast to a smallint.
+
+A small int is an integer in the range of -32768 to +32767
+
+Examples
+--------
+```tcl
+
+% qc::castable smallint {1,234}
+true
+% qc::castable smallint foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-text.md
+++ b/doc/procs/castable-text.md
@@ -1,0 +1,25 @@
+qc::castable text
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable text string`
+
+Description
+-----------
+Test if the given string can be cast to text.
+
+Examples
+--------
+```tcl
+
+% qc::castable text Hello
+true
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-timestamp.md
+++ b/doc/procs/castable-timestamp.md
@@ -1,0 +1,29 @@
+qc::castable timestamp
+=========================
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable timestamp string`
+
+Description
+-----------
+Test if the given string can be cast to a timestamp without timezone.
+
+Examples
+--------
+```tcl
+
+% qc::castable timestamp today
+true
+% qc::castable timestamp 12/5/12
+true
+% qc::castable timestamp foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-timestamptz.md
+++ b/doc/procs/castable-timestamptz.md
@@ -1,0 +1,29 @@
+qc::castable timestamptz
+=========================
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable timestamptz string`
+
+Description
+-----------
+Test if the given string can be cast to a timestamp with timezone.
+
+Examples
+--------
+```tcl
+
+% qc::castable timestamptz today
+true
+% qc::castable timestamptz 12/5/12
+true
+% qc::castable timestamptz foo
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/castable-varchar.md
+++ b/doc/procs/castable-varchar.md
@@ -1,0 +1,27 @@
+qc::castable varchar
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::castable varchar length string`
+
+Description
+-----------
+Test if the given string can be cast to varchar of the given length.
+
+Examples
+--------
+```tcl
+
+% qc::castable varchar 25 Hello
+true
+% qc::castable varchar 2 World
+false
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-base64.md
+++ b/doc/procs/is-base64.md
@@ -1,0 +1,31 @@
+qc::is base64
+=============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is base64 string`
+
+Description
+-----------
+Checks if the given string has only allowable base64 characters and is of the correct format.
+
+Examples
+--------
+```tcl
+
+% qc::is base64 RG9sbHkgUGFydG9uCg==
+1
+% qc::is base64 RG9sbHkgUGFydG9uCg
+0
+% qc::is base64 RG9sbHkgUGFydG9uCg=
+0
+% qc::is base64 ^^RG9sbHkgUGFydG9uCg
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-bigint.md
+++ b/doc/procs/is-bigint.md
@@ -1,0 +1,30 @@
+qc::is bigint
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is bigint int`
+
+Description
+-----------
+Checks if the given string is a big integer.
+A bigint is an integer in the range of -9223372036854775808 to +9223372036854775807
+
+Examples
+--------
+```tcl
+
+% qc::is bigint -9223372036854775808
+1
+% qc::is bigint -9223372036854775809
+0
+% qc::is bigint foo
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-boolean.md
+++ b/doc/procs/is-boolean.md
@@ -1,24 +1,28 @@
-qc::is_non_zero_decimal
-=======================
+qc::is boolean
+==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_non_zero_decimal number`
+`qc::is boolean string`
 
 Description
 -----------
-Deprecated
+Checks if the given string is a boolean.
 
 Examples
 --------
 ```tcl
 
-% qc::is_non_zero_decimal -9.99999
+% qc::is boolean 1
 1
-%  qc::is_non_zero_decimal 0
+% qc::is boolean foo
 0
+% qc::is boolean true
+1
+% qc::is boolean no
+1
 ```
 
 ----------------------------------

--- a/doc/procs/is-char.md
+++ b/doc/procs/is-char.md
@@ -1,23 +1,23 @@
-qc::is_non_zero_decimal
-=======================
+qc::is char
+==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_non_zero_decimal number`
+`qc::is char length string`
 
 Description
 -----------
-Deprecated
+Checks if the given string would fit exactly into a character string of the given length.
 
 Examples
 --------
 ```tcl
 
-% qc::is_non_zero_decimal -9.99999
+% qc::is char 11 "Hello World"
 1
-%  qc::is_non_zero_decimal 0
+% qc::is char 10 "Hello World"
 0
 ```
 

--- a/doc/procs/is-cidrnetv4.md
+++ b/doc/procs/is-cidrnetv4.md
@@ -1,25 +1,23 @@
-qc::is_date
-===========
+qc::is cidrnetv4
+================
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_date date`
+`qc::is cidrnetv4 string`
 
 Description
------------
-Deprecated - see [qc::is date]
+----------
+Checks if the given string follows the CIDR NETv4 format.
 
 Examples
 --------
 ```tcl
 
-% qc::is_date 12/12/12
+% qc::is cidrnetv4 192.168.1.1
 0
-% qc::is_date 12:38:00
-0
-% qc::is_date 2012-08-12
+% qc::is cidrnetv4 192.168.1.0/24
 1
 ```
 
@@ -27,4 +25,3 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
-[qc::is date]: is-date.md

--- a/doc/procs/is-creditcard.md
+++ b/doc/procs/is-creditcard.md
@@ -1,0 +1,31 @@
+qc::is creditcard
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is creditcard string`
+
+Description
+-----------
+Checks if the given string is an allowable credit card number.
+Checks number of digits are >13 & <19, all characters are integers, luhn 10 check
+
+Examples
+--------
+```tcl
+% qc::is_creditcard 4111111111111111
+1
+% qc::is_creditcard 4111111111111112
+0
+% qc::is_creditcard 41
+0
+% qc::is_creditcard 41111111i1111111
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-creditcard.md
+++ b/doc/procs/is-creditcard.md
@@ -15,13 +15,13 @@ Checks number of digits are >13 & <19, all characters are integers, luhn 10 chec
 Examples
 --------
 ```tcl
-% qc::is_creditcard 4111111111111111
+% qc::is creditcard 4111111111111111
 1
-% qc::is_creditcard 4111111111111112
+% qc::is creditcard 4111111111111112
 0
-% qc::is_creditcard 41
+% qc::is creditcard 41
 0
-% qc::is_creditcard 41111111i1111111
+% qc::is creditcard 41111111i1111111
 0
 ```
 

--- a/doc/procs/is-creditcard_masked.md
+++ b/doc/procs/is-creditcard_masked.md
@@ -14,13 +14,13 @@ Checks if the given string is a creditcard number masked to PCI requirements.
 Examples
 --------
 ```tcl
-% qc::is_creditcard_masked 4111111111111111
+% qc::is creditcard_masked 4111111111111111
 0
-% qc::is_creditcard_masked 411111****111111
+% qc::is creditcard_masked 411111****111111
 0
-% qc::is_creditcard_masked 411111******1111
+% qc::is creditcard_masked 411111******1111
 1
-% qc::is_creditcard_masked 411111**********
+% qc::is creditcard_masked 411111**********
 1
 ```
 

--- a/doc/procs/is-creditcard_masked.md
+++ b/doc/procs/is-creditcard_masked.md
@@ -1,0 +1,30 @@
+qc::is creditcard_masked
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is creditcard_masked string`
+
+Description
+-----------
+Checks if the given string is a creditcard number masked to PCI requirements.
+
+Examples
+--------
+```tcl
+% qc::is_creditcard_masked 4111111111111111
+0
+% qc::is_creditcard_masked 411111****111111
+0
+% qc::is_creditcard_masked 411111******1111
+1
+% qc::is_creditcard_masked 411111**********
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-date.md
+++ b/doc/procs/is-date.md
@@ -1,0 +1,30 @@
+qc::is date
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is date string`
+
+Description
+-----------
+Checks if the given string is a date.
+Dates are expected to be in ISO format: YYYY-MM-DD
+
+Examples
+--------
+```tcl
+
+% qc::is date 2015-01-16
+1
+% qc::is date 01-01-2015
+0
+% qc::is date "text"
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-decimal.md
+++ b/doc/procs/is-decimal.md
@@ -1,24 +1,26 @@
-qc::is_non_zero_decimal
-=======================
+qc::is decimal
+==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_non_zero_decimal number`
+`qc::is decimal int`
 
 Description
 -----------
-Deprecated
+Checks if the given string is a decimal number.
 
 Examples
 --------
 ```tcl
 
-% qc::is_non_zero_decimal -9.99999
+% qc::is decimal 1234
 1
-%  qc::is_non_zero_decimal 0
+% qc::is decimal foo
 0
+% qc::is decimal 1.234
+1
 ```
 
 ----------------------------------

--- a/doc/procs/is-domain.md
+++ b/doc/procs/is-domain.md
@@ -1,0 +1,29 @@
+qc::is domain
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is domain domain_name value`
+
+Description
+-----------
+Checks if the given value follows the constraints of the given domain in the database.
+
+Examples
+--------
+```tcl
+
+% qc::is domain plain_text "Hello World"
+1
+% qc::is domain plain_text "<div>Foo</div>"
+0
+% qc::is domain foo bar 
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-email.md
+++ b/doc/procs/is-email.md
@@ -1,0 +1,31 @@
+qc::is email
+============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is email email`
+
+Description
+-----------
+Checks if the given string follows the form of an email address.
+
+Examples
+--------
+```tcl
+
+% qc::is email @gmail.com
+0
+% qc::is email dave.@gmail.com
+0
+% qc::is email dave@gmail
+0
+% qc::is email dave.smith@gmail.co.uk
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-enumeration.md
+++ b/doc/procs/is-enumeration.md
@@ -1,0 +1,27 @@
+qc::is enumeration
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is enumeration enum_name value`
+
+Description
+-----------
+Checks if the given value is belongs to the given enumeration in the database.
+
+Examples
+--------
+```tcl
+
+% qc::is enumeration post_state LIVE
+1
+% qc::is enumeration foo bar
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-hex.md
+++ b/doc/procs/is-hex.md
@@ -1,25 +1,27 @@
-qc::is_date
-===========
+qc::is hex
+==========
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_date date`
+`qc::is hex string`
 
 Description
 -----------
-Deprecated - see [qc::is date]
+Checks if the given string is a hex number.
 
 Examples
 --------
 ```tcl
 
-% qc::is_date 12/12/12
+%  qc::is hex 9F
+1
+%  qc::is hex 1a
+1
+%  qc::is hex 9G
 0
-% qc::is_date 12:38:00
-0
-% qc::is_date 2012-08-12
+% qc::is hex 9FFFFFF
 1
 ```
 
@@ -27,4 +29,3 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
-[qc::is date]: is-date.md

--- a/doc/procs/is-integer.md
+++ b/doc/procs/is-integer.md
@@ -1,23 +1,27 @@
-qc::is_non_zero_decimal
-=======================
+qc::is integer
+==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_non_zero_decimal number`
+`qc::is integer int`
 
 Description
 -----------
-Deprecated
+Checks if the given string is an integer.
 
 Examples
 --------
 ```tcl
 
-% qc::is_non_zero_decimal -9.99999
+% qc::is integer 999
 1
-%  qc::is_non_zero_decimal 0
+% qc::is integer 0.1
+0
+% qc::is integer 0
+1
+% qc::is integer true
 0
 ```
 

--- a/doc/procs/is-ipv4.md
+++ b/doc/procs/is-ipv4.md
@@ -1,0 +1,29 @@
+qc::is ipv4
+===========
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is ipv4 string`
+
+Description
+-----------
+Checks if the given string follows the IPv4 format.
+
+Examples
+--------
+```tcl
+
+% qc::is ipv4  2001:0db8:85a3:0042:0000:8a2e:0370:7334
+0
+% qc::is ipv4 192.0.1
+0
+% qc::is ipv4 192.168.1.1
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-mobile_number.md
+++ b/doc/procs/is-mobile_number.md
@@ -1,0 +1,31 @@
+qc::is mobile_number
+====================
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is mobile_number string`
+
+Description
+-----------
+Checks if the given string is of the form of a UK mobile telephone number.
+
+Examples
+--------
+```tcl
+
+% qc::is mobile_number " 0 7  986 21299     9"
+1
+% qc::is mobile_number 09777112112
+0
+% qc::is mobile_number 013155511111
+0
+% qc::is mobile_number 07512122122
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-period.md
+++ b/doc/procs/is-period.md
@@ -1,0 +1,44 @@
+qc::is period
+=============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is period string`
+
+Description
+-----------
+Check if the given string can represent a period of time.
+
+Examples
+--------
+```tcl
+% qc::is period "2014-01-01"
+1
+% qc::is period "Jan 1st 2014"
+1
+% qc::is period "2014"
+1
+% qc::is period "Jan"
+1
+% qc::is period "January"
+1
+% qc::is period "Jan 2013"
+1
+% qc::is period "January 2013"
+1
+% qc::is period "January 2013 to March 2013"
+1
+& qc::is period "Jan2013"
+0
+% qc::is period "January 2013 March 2013"
+0
+% qc::is period "1st Jan 2013 to 14th Jan 2013"
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-postcode.md
+++ b/doc/procs/is-postcode.md
@@ -1,25 +1,25 @@
-qc::is_date
-===========
+qc::is postcode
+===============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_date date`
+`qc::is postcode postcode`
 
 Description
 -----------
-Deprecated - see [qc::is date]
+Checks if the given string is a UK postcode.
 
 Examples
 --------
 ```tcl
 
-% qc::is_date 12/12/12
+% qc::is postcode EH3
 0
-% qc::is_date 12:38:00
-0
-% qc::is_date 2012-08-12
+% qc::is postcode "BFPO 61"
+1
+% qc::is postcode "EH3 9EE"
 1
 ```
 
@@ -27,4 +27,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
-[qc::is date]: is-date.md
+[qc::is postcode]: is-postcode.md

--- a/doc/procs/is-safe_html.md
+++ b/doc/procs/is-safe_html.md
@@ -1,0 +1,34 @@
+qc::is safe_html
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is safe_html string`
+
+Description
+-----------
+Checks if the given string containts only safe HTML elements and attributes.
+
+See [Safe HTML] for more information regarding safe elements, attributes, and values.
+
+Examples
+--------
+```tcl
+
+% qc::is safe_html {<foo>bar</foo>}
+0
+% qc::is safe_html {<img src="http://link.to.image" />}
+1
+% qc::is safe_html {It doesn't have to be just HTML. There can be content that might include HTML <pre><code class="language-tcl">puts Hello World</code></pre>}
+1
+% qc::is safe_html {<div id="content">Foo</div>}
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"
+[Safe HTML]: ../safe_html.md

--- a/doc/procs/is-safe_markdown.md
+++ b/doc/procs/is-safe_markdown.md
@@ -1,0 +1,32 @@
+qc::is safe_markdown
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is safe_markdown markdown`
+
+Description
+-----------
+Checks if the given markdown contains only safe HTML elements and attributes.
+
+See [Safe HTML] for more information regarding safe elements, attributes, and values.
+
+Examples
+--------
+```tcl
+
+% qc::is safe_markdown {*markdown*}
+1
+% qc::is safe_html {A code example ```tcl puts "Hello World"```}
+1
+% qc::is safe_html {<div id="content">Foo</div>}
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"
+[Safe HTML]: ../safe_html.md

--- a/doc/procs/is-smallint.md
+++ b/doc/procs/is-smallint.md
@@ -1,0 +1,32 @@
+qc::is smallint
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is smallint int`
+
+Description
+-----------
+Checks if the given string is a small integer.
+A small integer is an integer in the range of -32768 to +32767.
+
+Examples
+--------
+```tcl
+
+% qc::is smallint 123
+1
+% qc::is smallint -35000
+0
+% qc::is smallint 1,234
+1
+% qc::is smallint foo
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-text.md
+++ b/doc/procs/is-text.md
@@ -1,0 +1,29 @@
+qc::is text
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is text string`
+
+Description
+-----------
+Checks if the given string is text.
+
+Examples
+--------
+```tcl
+
+% qc::is text "Hello World"
+1
+% qc::is text 12345
+1
+% qc::is text "" 
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-timestamp.md
+++ b/doc/procs/is-timestamp.md
@@ -1,23 +1,25 @@
-qc::is_non_zero_decimal
-=======================
+qc::is timestamp
+==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_non_zero_decimal number`
+`qc::is timestamp string`
 
 Description
 -----------
-Deprecated
+Checks if the given string is a timestamp (in ISO format).
 
 Examples
 --------
 ```tcl
 
-% qc::is_non_zero_decimal -9.99999
+% qc::is timestamp "2015-01-15 17:15:33"
 1
-%  qc::is_non_zero_decimal 0
+% qc::is timestamp "2015-01-15"
+0
+% qc::is timestamp foo
 0
 ```
 

--- a/doc/procs/is-timestampt_http.md
+++ b/doc/procs/is-timestampt_http.md
@@ -1,0 +1,30 @@
+qc::is timestamp_http
+==============
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is timestamp_http date`
+
+Description
+-----------
+Checks if the given date is an acceptable HTTP timestamp.
+Accepts RFC 1123, RFC 850, and ANCI C date formats.
+
+Examples
+--------
+```tcl
+
+% qc::is timestamp_http {Fri, 16 Jan 2015 09:35:37 GMT}
+1
+% qc::is timestamp_http {Friday, 16-Jan-15 09:35:37 GMT}
+1
+% qc::is timestamp_http {Fri Jan  6 09:35:37 2015}
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-timestamptz.md
+++ b/doc/procs/is-timestamptz.md
@@ -1,25 +1,25 @@
-qc::is_pnz_int
+qc::is timestamptz
 ==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_pnz_int int`
+`qc::is timestamptz string`
 
 Description
 -----------
-Deprecated
+Checks if the given string is a timestamp with a time zone (in ISO format).
 
 Examples
 --------
 ```tcl
 
-% qc::is_pnz_int 10
+% qc::is timestamptz "2015-01-15 17:15:33+01"
 1
-% qc::is_pnz_int 10.5
+% qc::is timestamptz "2015-01-15"
 0
-% qc::is_pnz_int 0
+% qc::is timestamptz foo
 0
 ```
 

--- a/doc/procs/is-uri.md
+++ b/doc/procs/is-uri.md
@@ -1,0 +1,33 @@
+qc::is uri
+==========
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is uri uri`
+
+Description
+-----------
+Test if the given uri is valid according to rfc3986 (https://tools.ietf.org/html/rfc3986)
+
+Examples
+--------
+```tcl
+
+% qc::is uri www.google.com
+1
+% qc::is uri http://www.google.co.uk
+1
+% qc::is uri https://www.google.co.uk:443/subdir?formvar1=foo&formvar2=bar#anchor 
+1
+% qc::is uri /subdir?formvar1=foo&formvar2=bar#anchor 
+1
+% qc::is uri "http://test.co$%^&m"
+0
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-url.md
+++ b/doc/procs/is-url.md
@@ -1,0 +1,30 @@
+qc::is url
+==========
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`qc::is url args`
+
+Description
+-----------
+Checks if the given string is a URL.
+This is a more restrictive subset of all legal uri's defined by RFC 3986.
+
+Examples
+--------
+```tcl
+
+% qc::is url www.google.com
+0
+% qc::is url http://www.google.co.uk
+1
+% qc::is url https://www.google.co.uk:443/subdir?formvar1=foo&formvar2=bar#anchor 
+1
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/is-varchar.md
+++ b/doc/procs/is-varchar.md
@@ -1,26 +1,26 @@
-qc::is_pnz_int
+qc::is varchar
 ==============
 
 part of [Docs](../index.md)
 
 Usage
 -----
-`qc::is_pnz_int int`
+`qc::is varchar length string`
 
 Description
 -----------
-Deprecated
+Checks if the given string fits the given length. 
 
 Examples
 --------
 ```tcl
 
-% qc::is_pnz_int 10
+% qc::is varchar 10 hello
 1
-% qc::is_pnz_int 10.5
+% qc::is varchar 2 foo
 0
-% qc::is_pnz_int 0
-0
+% qc::is varchar "" "Empty length specified means any length is allowed."
+1
 ```
 
 ----------------------------------

--- a/doc/procs/is_base64.md
+++ b/doc/procs/is_base64.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is base64]
 Checks input has only allowable base64 characters and is of the correct format
 
 Examples
@@ -29,3 +30,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is base64]: is-base64.md

--- a/doc/procs/is_boolean.md
+++ b/doc/procs/is_boolean.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is boolean]
 
 Examples
 --------
@@ -31,3 +31,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is boolean]: is-boolean.md

--- a/doc/procs/is_cidrnetv4.md
+++ b/doc/procs/is_cidrnetv4.md
@@ -8,8 +8,8 @@ Usage
 `qc::is_cidrnetv4 string`
 
 Description
------------
-
+----------
+Deprecated - see [qc::is cidrnetv4]
 
 Examples
 --------
@@ -25,3 +25,4 @@ true
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is cidrnetv4]: is-cidrnetv4.md

--- a/doc/procs/is_creditcard.md
+++ b/doc/procs/is_creditcard.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated = see [qc::is creditcard]
 Checks if no is an allowable credit card number<br/>Checks, number of digits are >13 & <19, all characters are integers, luhn 10 check
 
 Examples
@@ -29,3 +30,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is creditcard]: is-creditcard.md

--- a/doc/procs/is_creditcard_masked.md
+++ b/doc/procs/is_creditcard_masked.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is creditcard_masked]
 Check the credit card number is masked to PCI requirements
 
 Examples
@@ -29,3 +30,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is creditcard_masked]: is-creditcard_masked.md

--- a/doc/procs/is_date_castable.md
+++ b/doc/procs/is_date_castable.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::castable date]
 Can string be cast into date format?
 
 Examples
@@ -29,3 +30,4 @@ false
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::castable date]: castable-date.md

--- a/doc/procs/is_decimal.md
+++ b/doc/procs/is_decimal.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is decimal]
 
 Examples
 --------
@@ -25,3 +25,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is decimal]: is-decimal.md

--- a/doc/procs/is_decimal_castable.md
+++ b/doc/procs/is_decimal_castable.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::castable decimal]
 
 Examples
 --------
@@ -27,3 +27,4 @@ false
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::castable decimal]: castable-decimal.md

--- a/doc/procs/is_email.md
+++ b/doc/procs/is_email.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is email]
 
 Examples
 --------
@@ -29,3 +29,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is email]: is-email.md

--- a/doc/procs/is_hex.md
+++ b/doc/procs/is_hex.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is hex]
 Does the input look like a hex number?
 
 Examples
@@ -29,3 +30,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is hex]: is-hex.md

--- a/doc/procs/is_int_castable.md
+++ b/doc/procs/is_int_castable.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::castable integer]
 Can input be cast to an integer?
 
 Examples
@@ -29,3 +30,4 @@ false
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::castable integer]: castable-integer.md

--- a/doc/procs/is_integer.md
+++ b/doc/procs/is_integer.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is integer]
 
 Examples
 --------
@@ -29,3 +29,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is integer]: is-integer.md

--- a/doc/procs/is_ipv4.md
+++ b/doc/procs/is_ipv4.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_ipv4.md
+++ b/doc/procs/is_ipv4.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-Deprecated
+Deprecated - see [qc::is ipv4]
 
 Examples
 --------
@@ -27,3 +27,4 @@ true
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is ipv4]: is-ipv4.md

--- a/doc/procs/is_mobile_number.md
+++ b/doc/procs/is_mobile_number.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is mobile_number]
 
 Examples
 --------
@@ -29,3 +29,4 @@ true
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is mobile_number]: is-mobile_number.md

--- a/doc/procs/is_non_zero.md
+++ b/doc/procs/is_non_zero.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_non_zero_integer.md
+++ b/doc/procs/is_non_zero_integer.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_period.md
+++ b/doc/procs/is_period.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is period]
 Test if string can be casted to a pair of dates defining a period.
 
 Examples
@@ -53,3 +54,4 @@ true
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is period]: is-period.md

--- a/doc/procs/is_pnz.md
+++ b/doc/procs/is_pnz.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_pnz_decimal.md
+++ b/doc/procs/is_pnz_decimal.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_pos.md
+++ b/doc/procs/is_pos.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_positive_decimal.md
+++ b/doc/procs/is_positive_decimal.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated
 
 Examples
 --------

--- a/doc/procs/is_postcode.md
+++ b/doc/procs/is_postcode.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is postcode]
 
 Examples
 --------
@@ -27,3 +27,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is postcode]: is-postcode.md

--- a/doc/procs/is_timestamp.md
+++ b/doc/procs/is_timestamp.md
@@ -9,7 +9,7 @@ Usage
 
 Description
 -----------
-
+Deprecated - see [qc::is timestamp]
 
 Examples
 --------
@@ -25,3 +25,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is timestamp]: is-timestamp.md

--- a/doc/procs/is_timestamp_castable.md
+++ b/doc/procs/is_timestamp_castable.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::castable timestamp]
 Can string be cast into timestamp format?
 
 Examples
@@ -27,3 +28,4 @@ false
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::castable timestamp]: castable-timestamp.md

--- a/doc/procs/is_timestamp_http.md
+++ b/doc/procs/is_timestamp_http.md
@@ -9,9 +9,11 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is timestamp_http]
 Returns true if date is an acceptable HTTP timestamp. Note although all three should be accepted,<br/>only RFC 1123 format should be generated.
 
 ----------------------------------
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is timestamp_http]: is-timestamp_http.md

--- a/doc/procs/is_uri_valid.md
+++ b/doc/procs/is_uri_valid.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is uri]
 Test if the given uri is valid according to rfc3986 (https://tools.ietf.org/html/rfc3986)
 
 Examples
@@ -31,3 +32,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is uri]: is-uri.md

--- a/doc/procs/is_url.md
+++ b/doc/procs/is_url.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is url]
 This is a more restrictive subset of all legal uri's defined by RFC 3986<br/>Relax as needed
 
 Examples
@@ -27,3 +28,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is url]: is-url.md

--- a/doc/procs/is_varchar.md
+++ b/doc/procs/is_varchar.md
@@ -9,6 +9,7 @@ Usage
 
 Description
 -----------
+Deprecated - see [qc::is varchar]
 Checks string would fit in a varchar of length $length
 
 Examples
@@ -25,3 +26,4 @@ Examples
 *[Qcode Software Limited] [qcode]*
 
 [qcode]: http://www.qcode.co.uk "Qcode Software"
+[qc::is varchar]: is-varchar.md

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -291,6 +291,7 @@ proc qc::cast_period {string} {
 }
 
 proc qc::is_period {string} {
+    #| Deprecated - see qc::is period
     #| Test if string can be casted to a pair of dates defining a period.
     set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
     set regexp_map [list \$month_names_regexp [join $month_names |]]
@@ -371,63 +372,6 @@ proc qc::is_period {string} {
     }  else {
         # could not parse string
         return false
-    }
-}
-
-proc qc::cast_values2model {args} {
-    #| Check the data types of the values against the definitions for these names.
-    #| Returns a new list of values after casting to appropriate type.
-    #| Throws an error if type-checking fails.
-    if { [llength $args]%2 != 0 } {
-        return -code error "usage cast_values2model name value ?name value?"
-    }
-    set casted_dict {}
-    set errors {}
-    
-    dict for {name value} $args {
-        set table ""
-        # Check if name is fully qualified
-        if {![regexp {^([^\.]+)\.([^\.]+)$} $name -> table column] } {
-            lassign [qc::db_qualified_table_column $name] table column
-        }
-        
-        set data_type [qc::db_column_type $table $column]
-        set nullable [qc::db_column_nullable $table $column]
-
-        # Check if nullable
-        if {! $nullable && $value eq ""} {
-            lappend errors "$column cannot be empty."
-            continue
-        } elseif {$nullable && $value eq ""} {
-            lappend casted_dict $name $value
-            continue
-        }
-
-        # Check value against data type
-        if {[qc::castable $data_type $value]} {
-            lappend casted_dict $name [qc::cast $data_type $value]
-        } else {           
-            lappend errors [qc::html_escape [qc::data_type_error_check $data_type $value]]
-        }
-
-        # Check constraints
-        set results [qc::db_eval_column_constraints $table $column $args]
-        if { [llength $results]>0 && ! [expr [join [dict values $results] " && "]] } {
-            set failed_constraints {}
-            dict for {constraint passed} $results {
-                if {!$passed} {
-                    lappend failed_constraints $constraint
-                }
-            }
-            set error_message [qc::html_escape "Value \"$value\" for column \"$column\" failed the following constraint(s) [join $failed_constraints ", "]"]
-            lappend errors $error_message
-        }
-    }
-    
-    if {[llength $errors] > 0} {
-        return -code error -errorcode USER [qc::html_list $errors]
-    } else {
-        return $casted_dict
     }
 }
 
@@ -533,7 +477,7 @@ proc qc::data_type_error_check {data_type value} {
 
 namespace eval qc::cast {
     
-    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown values2model date postcode creditcard period
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -647,12 +591,12 @@ namespace eval qc::cast {
 
     proc timestamp {string} {
         #| Try to convert the given string into an ISO datetime.
-        return [clock format [qc::cast_epoch $string] -format "%Y-%m-%d %H:%M:%S"]
+        return [clock format [epoch $string] -format "%Y-%m-%d %H:%M:%S"]
     }
 
     proc timestamptz {string} {
         #| Try to convert the given string into an ISO datetime with timezone.
-        return [clock format [qc::cast_epoch $string] -format "%Y-%m-%d %H:%M:%S %z"]
+        return [clock format [epoch $string] -format "%Y-%m-%d %H:%M:%S %z"]
     }
 
     proc char {length string} {
@@ -720,5 +664,281 @@ namespace eval qc::cast {
         } else {
             return -code error -errorcode CAST "Can't cast \"[qc::trunc $text 100]...\": not safe markdown."
         }
+    }
+
+    proc values2model {args} {
+        #| Check the data types of the values against the definitions for these names.
+        #| Returns a new list of values after casting to appropriate type.
+        #| Throws an error if type-checking fails.
+        if { [llength $args]%2 != 0 } {
+            return -code error "usage cast_values2model name value ?name value?"
+        }
+        set casted_dict {}
+        set errors {}
+        
+        dict for {name value} $args {
+            set table ""
+            # Check if name is fully qualified
+            if {![regexp {^([^\.]+)\.([^\.]+)$} $name -> table column] } {
+                lassign [qc::db_qualified_table_column $name] table column
+            }
+            
+            set data_type [qc::db_column_type $table $column]
+            set nullable [qc::db_column_nullable $table $column]
+
+            # Check if nullable
+            if {! $nullable && $value eq ""} {
+                lappend errors "$column cannot be empty."
+                continue
+            } elseif {$nullable && $value eq ""} {
+                lappend casted_dict $name $value
+                continue
+            }
+
+            # Check value against data type
+            if {[qc::castable $data_type $value]} {
+                lappend casted_dict $name [qc::cast $data_type $value]
+            } else {           
+                lappend errors [qc::html_escape [qc::data_type_error_check $data_type $value]]
+            }
+
+            # Check constraints
+            set results [qc::db_eval_column_constraints $table $column $args]
+            if { [llength $results]>0 && ! [expr [join [dict values $results] " && "]] } {
+                set failed_constraints {}
+                dict for {constraint passed} $results {
+                    if {!$passed} {
+                        lappend failed_constraints $constraint
+                    }
+                }
+                set error_message [qc::html_escape "Value \"$value\" for column \"$column\" failed the following constraint(s) [join $failed_constraints ", "]"]
+                lappend errors $error_message
+            }
+        }
+        
+        if {[llength $errors] > 0} {
+            return -code error -errorcode USER [qc::html_list $errors]
+        } else {
+            return $casted_dict
+        }
+    }
+
+    proc date {string} {
+        #| Try to convert the given string into an ISO date.
+        return [clock format [epoch $string] -format "%Y-%m-%d"]
+    }
+
+    proc epoch {string} {
+        #| Try to convert the given string into an epoch.
+        set string [string map [list "&#8209;" -] $string]
+        #### EXACT MATCHES ####
+        if { [string equal $string ""] } {
+            return -code error -errorcode CAST "Can't cast an empty string to epoch"
+        }
+        # Looks like a number but really an iso date without delimitor.
+        if { [regexp {^(19\d\d|20\d\d)(\d\d)(\d\d)$} $string -> year month day] } {
+            return [clock scan "$year-$month-$day"]
+        }
+        # Already an epoch
+        if { [string is wideinteger -strict $string] } {
+            if { $string > [clock scan "5000-01-01"] } {
+                # Interpret as milliseconds past epoch
+                return [expr {${string}/1000}]
+            } elseif { $string>31 } {
+                return $string
+            }
+        }
+        # Exact ISO date
+        if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})$} $string -> year month day] } {
+            return [clock scan "$year-$month-$day"]
+        }
+        # Exact ISO datetime
+        if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})( |T)(\d{1,2}:\d{1,2}(:\d{1,2})?)$} $string -> year month day . time] } {
+            return [clock scan "$year-$month-$day $time"]
+        }
+        # Exact ISO datetime with offset timezone e.g. "2012-08-13 10:21:23.7777 -06:00"
+        # Accepts offsets in formats -hh, -hhmm, or -hh:mm
+        if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})(?: |T)(\d{1,2}:\d{1,2})(?::(\d{1,2})(?:\.\d+)?)?\s?(Z|[-+]\d\d(:?\d\d)?)$} $string -> year month day time sec timezone] } {
+            if { $timezone eq "Z" } {
+                set timezone "+00"
+            }
+            if { $sec ne "" } {
+                set time "$time:$sec"
+            }
+            return [clock scan "$year-$month-$day $time" -timezone "$timezone"]
+        }
+        # rfc-822 style dates used in emails.
+        # "Fri, 17 Aug 2012 12:51:36 +0100"
+        if { [regexp {(\d{1,2}) +(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December) +(\d{4}) +(\d{1,2}:\d{1,2})(?::(\d{1,2})(?:\.\d+)?)?\s?(Z|[-+]\d\d(:?\d\d)?)} $string -> day mon year time sec timezone] } {
+            if { $timezone eq "Z" } {
+                set timezone "+00"
+            }
+            if { $sec ne "" } {
+                set time "$time:$sec"
+            }
+            set month [expr {[lsearch {January February March April May June July August September October November December} "${mon}*"]+1}]
+            return [clock scan "$year-$month-$day $time" -timezone "$timezone"]
+        }
+        # ISO datetime Don't match the end of line for e.g. "2009-04-06 12:25:18.343"
+        if { [regexp {^(19\d\d|20\d\d)(\d\d)(\d\d)( |T)(\d{1,2}:\d{1,2}(:\d{1,2})?)} $string -> year month day . time] } {
+            return [clock scan "$year-$month-$day $time"]
+        }
+        # dd/mm/yyYY
+        if { [regexp {^(\d{1,2})[/\.](\d{1,2})[/\.](\d{4}|\d{2}|\d)$} $string -> day month year] } {
+            # Assume UK locale dd/mm/yy or dd.mm.yy
+            return [clock scan "$year-$month-$day"]
+        }
+        #### RELATIVE ####
+        if { [regexp -nocase -- {(\+-)? ?(this|last|next|[0-9]+) ?(year|month|week|day|hour|minute)s?( ago)?} $string] \
+                 || [regexp -nocase -- {(this|last|next) (Mon|Monday|Tue|Tuesday|Wed|Wednesday|Thu|Thurs|Thursday|Fri|Friday|Sat|Saturday|Sun|Sunday)} $string] \
+                 || [regexp -nocase -- {today|yesterday|tomorrow} $string] } {
+            return [clock scan $string]
+        }
+        #### RELAXED ####
+        # Look for time hh:mm or hh:mm:ss
+        if { ![regexp {(^|\W)(\d{1,2}:\d{1,2}(:\d{1,2})?)(\W|$)} $string -> ~ time ~] } { set time "" }
+        # ISO format
+        if { [regexp {(^|[^0-9])(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})([^0-9]|$)} $string -> start year month day end] } {
+            return [clock scan "$year-$month-$day $time"]
+        }
+        if { [regexp {(^|[^0-9])(\d{1,2})[/\.](\d{1,2})[/\.](\d{4}|\d{2}|\d)([^0-9]|$)} $string -> start day month year end] } {
+            # Assume UK locale dd/mm/yy or dd.mm.yy
+            return [clock scan "$year-$month-$day $time"]
+        }
+        # dd/mm or dd.mm
+        if { [regexp {(^|\W)(\d{1,2})[/\.](\d{1,2})(\W|$)} $string -> start day month end] } {
+            set year [clock format [clock seconds] -format "%Y"]
+            return [clock scan "$year-$month-$day $time"]
+        }
+        if { [regexp {(^|[^0-9])(\d{4})([^0-9]|$)} $string -> start year end] } {
+            #### Matched YEAR ####
+            # year && month && dom
+            # 23 June 2006 or June 23rd 2006
+            if { [regexp -nocase -- {(^|[^a-zA-Z])(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)([^a-zA-Z]|$)} $string -> start month_name end] \
+                     && [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)?(\W|$)} $string -> start dom suffix end] } {
+                # month and dom
+                return [clock scan "$dom $month_name $year $time"]
+            }
+        } else {
+            #### NO YEAR ####
+            # no year && month && dom
+            # 23rd June or Sept 11th
+            if { [regexp -nocase -- {(^|[^a-zA-Z])(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)([^a-zA-Z]|$)} $string -> start month_name end] \
+                     && [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)(\W|$)} $string -> start dom suffix end] } {	 
+                set year [clock format [clock seconds] -format "%Y"]
+                return [clock scan "$dom $month_name $year $time"]
+            }
+            # dd or dd+suffix eg 23rd or 2nd ONLY 
+            if { [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)?(\W|$)} $string -> start day suffix end] } {
+                set year [clock format [clock seconds] -format "%Y"]
+                set month [clock format [clock seconds] -format "%m"]
+                return [clock scan "$year-$month-$day $time"]
+            }	
+            if { [regexp -nocase -- {(^|\W)(Mon|Monday|Tue|Tuesday|Wed|Wednesday|Thu|Thurs|Thursday|Fri|Friday|Sat|Saturday|Sun|Sunday)(\W|$)} $string -> start dow end] } {
+                return [clock scan "$dow $time"]
+            }
+        }
+        # try TCL
+        return [clock scan $string]
+    }
+
+    proc postcode {string} {
+        #| Try to cast a string into UK Postcode form
+        set saved $string
+        set postcode [string toupper $string]
+        # BFPO 
+        if { [eq [string range $postcode 0 3] BFPO] } {
+            return $postcode
+        }
+        # convert AB12CD -> AB1 2CD or AB123CD -> AB12 3CD
+        if { [string first " " $postcode] == -1 } {
+            set cut [expr {[string length $postcode]-3-1}]
+            set postcode "[string range $postcode 0 $cut] [string range $postcode [expr {$cut+1}] end]"
+        }
+        if { [is_postcode $postcode] } {
+            return $postcode
+        }
+        # Convert zero -> CAPITAL O e.g. "Y023 3CD" -> "YO23 3CD"
+        regsub {^([A-Z])0([0-9]{1,2}) (.+)$} $postcode {\1O\2 \3} postcode
+
+        if { [is_postcode $postcode] } {
+            return $postcode
+        } else {
+            return -code error -errorcode CAST "Could not cast $saved to postcode."
+        }
+    }
+
+    proc creditcard {string} {
+        #| Cast the given string to a credit card number.
+        regsub -all {[^0-9]} $string "" number
+        if { [qc::is creditcard $number] } {
+            return $number
+        } else {
+            return -code error -errorcode CAST "$number is not a valid credit card number"
+        }
+    }
+
+    proc period {string} {
+        #| Return a pair of dates defining the period.
+        set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
+        set regexp_map [list \$month_names_regexp [join $month_names |]]
+
+        if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
+            # Period defined by two periods eg "Jan 2011 to March 2011"
+            lassign [period $period1] from_date .
+            lassign [period $period2] . to_date
+
+        } elseif { [qc::is date $string] } {
+            # String is an iso date eg "2014-01-01"
+            set from_date $string
+            set to_date $from_date
+
+        } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
+            # Exact match for year eg "2006"
+            set from_date [date_year_start $year-01-01]
+            set to_date [date_year_end $year-01-01]
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([12]\d{3})$}] $string -> month_name year] } {
+            # Exact match in format "Jan 2006"
+            set epoch [clock scan "01 $month_name $year"]
+            set from_date [date_month_start $epoch]
+            set to_date [date_month_end $epoch]
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)$}] $string -> month_name] } {
+            # Exact match in format "Jan" (assume current year)
+            set epoch [clock scan "01 $month_name [date_year now]"]
+            set from_date [date_month_start $epoch]
+            set to_date [date_month_end $epoch]
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)\s+([12]\d{3})$}] $string -> dom month_name year] } {
+            # Exact match for castable date in format "1st Jan 2014"
+            set epoch [clock scan "$dom $month_name $year"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)$}] $string -> dom month_name] } {
+            # Exact match for castable date in format "1st Jan" (assume current year)
+            set epoch [clock scan "$dom $month_name [date_year now]"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?\s+([12]\d{3})$}] $string -> month_name dom year] } {
+            # Exact match for castable date in format "Jan 1st 2014"
+            set epoch [clock scan "$dom $month_name $year"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?$}] $string -> month_name dom] } {
+            # Exact match for castable date in format "Jan 1st" (assume current year)
+            set epoch [clock scan "$dom $month_name [date_year now]"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } else {
+            # error - could not parse string
+            return -code error -errorcode CAST "Could not parse string \"$string\" into dates that define a period."
+        }
+        
+        return [list $from_date $to_date]
     }
 }

--- a/tcl/castable.tcl
+++ b/tcl/castable.tcl
@@ -1,6 +1,6 @@
 namespace eval qc::castable {
     
-    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date postcode creditcard period
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -35,10 +35,10 @@ namespace eval qc::castable {
         }
     }
 
-    proc decimal {string {precision ""}} {
-        #| Test if the given string can be cast to a decimal.
+    proc decimal {args} {
+        #| Test if the given value can be cast to a decimal.
         try {
-            qc::cast decimal $string
+            qc::cast decimal {*}$args
             return true
         } on error [list error_message options] {
             return false
@@ -131,7 +131,47 @@ namespace eval qc::castable {
     }
 
     proc safe_markdown {text} {
-        #| Test if the given text can be case to safe markdown.
+        #| Test if the given text can be cast to safe markdown.
         return [qc::is safe_markdown $text]
+    }
+
+    proc date {string} {
+        #| Test if the given string can be cast to a date.
+        try {
+            qc::cast date $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc postcode {string} {
+        #| Test if the given string can be cast to a UK postcode.
+        try {
+            qc::cast postcode $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc creditcard {string} {
+        #| Test if the given string can be cast to a credit card number.
+        try {
+            qc::cast creditcard $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc period {string} {
+        #| Test if the given string can be cast to a period.
+        try {
+            qc::cast period $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
     }
 }

--- a/tcl/ensemble_handlers.tcl
+++ b/tcl/ensemble_handlers.tcl
@@ -11,10 +11,11 @@ proc data_type_parser {args} {
             return [list $namespace char [lindex $numbers 1]]
         }
         {^(decimal|numeric)\(([0-9]+,[0-9]+)\)$} {
-            return [list $namespace decimal]
+            set values [split [lindex $numbers 2] ,]
+            return [list $namespace decimal -precision [lindex $values 0] -scale [lindex $values 1]]
         }
         {^(decimal|numeric)\(([0-9]+)\)$} {
-            return [list $namespace decimal]
+            return [list $namespace decimal -precision [lindex $numbers 2]]
         }
         ^numeric$ {
             return [list $namespace decimal]

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -74,7 +74,7 @@ namespace eval qc::handlers {
         }
         set pattern [lindex $command 0]
         set args_dict [qc::dict_zipper [args $pattern $method] [lrange $command 1 end]]
-        return [[proc_name $pattern $method] {*}[dict values [qc::cast values2model {*}$args_dict]]]
+        return [[proc_name $pattern $method] {*}[dict values [qc::cast_values2model {*}$args_dict]]]
     }
 
     proc exists {path method} {

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -74,7 +74,7 @@ namespace eval qc::handlers {
         }
         set pattern [lindex $command 0]
         set args_dict [qc::dict_zipper [args $pattern $method] [lrange $command 1 end]]
-        return [[proc_name $pattern $method] {*}[dict values [qc::cast_values2model {*}$args_dict]]]
+        return [[proc_name $pattern $method] {*}[dict values [qc::cast values2model {*}$args_dict]]]
     }
 
     proc exists {path method} {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -707,13 +707,13 @@ namespace eval qc::is {
 
         if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
             # Period defined by two periods eg "Jan 2011 to March 2011"
-            if { [qc::is_period $period1] && [qc::is_period $period2] } {
+            if { [qc::is period $period1] && [qc::is period $period2] } {
                 return 1
             } else {
                 return 0
             }
 
-        } elseif { [qc::is_date $string] } {
+        } elseif { [qc::is date $string] } {
             # String is an iso date eg "2014-01-01"
             return 1
 
@@ -752,13 +752,13 @@ namespace eval qc::is {
 
         if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
             # Period defined by two periods eg "Jan 2011 to March 2011"
-            if { [qc::is_period $period1] && [qc::is_period $period2] } {
+            if { [qc::is period $period1] && [qc::is period $period2] } {
                 return 1
             } else {
                 return 0
             }
 
-        } elseif { [qc::is_date $string] } {
+        } elseif { [qc::is date $string] } {
             # String is an iso date eg "2014-01-01"
             return 1
 

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -3,10 +3,12 @@ namespace eval qc {
 }
 
 proc qc::is_boolean {bool} {
+    #| Deprecated - see qc::is boolean
     return [in {Y N YES NO TRUE FALSE T F 0 1} [upper $bool]]
 }
 
 proc qc::is_integer {int} {
+    #| Deprecated - see qc::is integer
     if { [string is integer -strict $int] && $int >= -2147483648 && $int <= 2147483647 } {
 	return 1
     } else {
@@ -15,6 +17,7 @@ proc qc::is_integer {int} {
 }
 
 proc qc::is_pos {number} {
+    #| Deprecated
     if { [is_decimal $number] && $number>=0 } {
 	return 1
     } else {
@@ -23,6 +26,7 @@ proc qc::is_pos {number} {
 }
 
 proc qc::is_pnz {number} {
+    #| Deprecated
     if { [is_decimal $number] && $number>0 } {
 	return 1
     } else {
@@ -31,6 +35,7 @@ proc qc::is_pnz {number} {
 }
 
 proc qc::is_non_zero_integer {int} {
+    #| Deprecated
     if { [is_integer $int] && $int!=0 } {
 	return 1
     } else {
@@ -39,6 +44,7 @@ proc qc::is_non_zero_integer {int} {
 }
 
 proc qc::is_non_zero {number} {
+    #| Deprecated
     if { [is_decimal $number] && $number!=0 } {
 	return 1
     } else {
@@ -47,6 +53,7 @@ proc qc::is_non_zero {number} {
 }
 
 proc qc::is_pnz_int { int } {
+    #| Deprecated
     # positive non zero integer
     if { [is_integer $int] && $int > 0 } {
 	return 1
@@ -56,6 +63,7 @@ proc qc::is_pnz_int { int } {
 }
 
 proc qc::is_decimal { number } {
+    #| Deprecated - see qc::is decimal
     if { [string is double -strict $number]} {
 	return 1
     } else {
@@ -64,6 +72,7 @@ proc qc::is_decimal { number } {
 }
 
 proc qc::is_positive_decimal { number } {
+    #| Deprecated
     if { [string is double -strict $number] && $number>=0 } {
 	return 1
     } else {
@@ -72,6 +81,7 @@ proc qc::is_positive_decimal { number } {
 }
 
 proc qc::is_non_zero_decimal { number } {
+    #| Deprecated
     if { [string is double -strict $number] && $number!=0 } {
 	return 1
     } else {
@@ -80,6 +90,7 @@ proc qc::is_non_zero_decimal { number } {
 }
 
 proc qc::is_pnz_decimal { price } {
+    #| Deprecated
     # positive non-zero double
     if { [string is double -strict $price] && $price>0 } {
 	return 1
@@ -89,11 +100,13 @@ proc qc::is_pnz_decimal { price } {
 }
 
 proc qc::is_date { date } {
+    #| Deprecated - see qc::is date
     # dates are expected to be in iso format 
     return [regexp {^\d{4}-\d{2}-\d{2}$} $date]   
 }
 
 proc qc::is_timestamp_http { date } {
+    #| Deprecated - see qc::is timestamp_http
     #| Returns true if date is an acceptable HTTP timestamp. Note although all three should be accepted,
     #| only RFC 1123 format should be generated.
     # RFC 1123 - Sun, 06 Nov 1994 08:49:37 GMT
@@ -112,20 +125,24 @@ proc qc::is_timestamp_http { date } {
 }
 
 proc qc::is_timestamp { date } {
+    #| Deprecated - see qc::is timestamp
     # timestamps are expected to be in iso format 
     return [regexp {^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$} $date]   
 }
 
 proc qc::is_email { email } {
+    #| Deprecated - see qc::is email
     return [regexp {^[a-zA-Z0-9_\-]+([\.\+][a-zA-Z0-9_\-]+)*@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+$} $email]
 }
 
 proc qc::is_postcode { postcode } {
+    #| Deprecated - see qc::is postcode
     # uk postcode
     return [expr [regexp {^[A-Z]{1,2}[0-9R][0-9A-Z]? [0-9][ABD-HJLNP-UW-Z]{2}$} $postcode] || [regexp {^BFPO ?[0-9]+$} $postcode]]
 }
 
 proc qc::is_creditcard { no } {
+    #| Deprecated - see qc::is creditcard
     #| Checks if no is an allowable credit card number
     #| Checks, number of digits are >13 & <19, all characters are integers, luhn 10 check
     regsub -all {[ -]} $no "" no
@@ -154,6 +171,7 @@ proc qc::is_creditcard { no } {
 }
 
 proc qc::is_creditcard_masked { no } {
+    #| Deprecated - see qc::is creditcard_masked
     #| Check the credit card number is masked to PCI requirements
     regsub -all {[^0-9\*]} $no "" no
 
@@ -162,6 +180,7 @@ proc qc::is_creditcard_masked { no } {
 }
 
 proc qc::is_varchar {string length} {
+    #| Deprecated - see qc::is varchar
     #| Checks string would fit in a varchar of length $length
     if { [string length $string]<=$length } {
 	return 1
@@ -171,6 +190,7 @@ proc qc::is_varchar {string length} {
 }
 
 proc qc::is_base64 {string} {
+    #| Deprecated - see qc::is base64
     #| Checks input has only allowable base64 characters and is of the correct format
     if { [regexp {^[A-Za-z0-9/+\r\n]+=*$} $string] \
 	&& ([string length $string]-[regexp -all -- \r?\n $string])*6%8==0 } {
@@ -181,6 +201,7 @@ proc qc::is_base64 {string} {
 }
 
 proc qc::is_int_castable {string} {
+    #| Deprecated - see qc::castable integer
     #| Can input be cast to an integer?
     qc::try {
 	cast_integer $string
@@ -191,6 +212,7 @@ proc qc::is_int_castable {string} {
 }
 
 proc qc::is_decimal_castable {string} {
+    #| Deprecated - see qc::castable decimal
     qc::try {
 	qc::cast_decimal $string
 	return true
@@ -200,6 +222,7 @@ proc qc::is_decimal_castable {string} {
 }
 
 proc qc::is_date_castable {string} {
+    #| Deprecated - see qc::castable date
     #| Can string be cast into date format?
     qc::try {
 	cast_date $string
@@ -210,6 +233,7 @@ proc qc::is_date_castable {string} {
 }
 
 proc qc::is_timestamp_castable {string} {
+    #| Deprecated - see qc::castable timestamp
     #| Can string be cast into timestamp format?
     qc::try {
 	cast_timestamp $string
@@ -220,6 +244,7 @@ proc qc::is_timestamp_castable {string} {
 }
 
 proc qc::is_mobile_number {string} {
+    #| Deprecated - see qc::is mobile_number
     # uk mobile telephone number
     regsub -all {[^0-9]} $string {} tel_no
     if {  [regexp {^07(5|7|8|9)[0-9]{8}$} $tel_no] } {
@@ -251,11 +276,13 @@ proc qc::contains_creditcard {string} {
 }
 
 proc qc::is_hex {string} {
+    #| Deprecated - see qc::is hex
     #| Does the input look like a hex number?
     return [regexp -nocase {^[0-9a-f]*$} $string]
 }
 
 proc qc::is_url {args} {
+    #| Deprecated - see qc::is url
     #| This is a more restrictive subset of all legal uri's defined by RFC 3986
     #| Relax as needed
     args $args -relative -- url
@@ -290,6 +317,7 @@ proc qc::is_url {args} {
 }
 
 proc qc::is_ipv4 {string} {
+    #| Deprecated - see qc::is ipv4
     # TODO checks structure only, will allow 9999.9999.9999.9999
     if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$} $string] } {
         return true
@@ -299,6 +327,7 @@ proc qc::is_ipv4 {string} {
 }
 
 proc qc::is_cidrnetv4 {string} {
+    #| Deprecated - see qc::is cidrnetv4
     if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$} $string] } {
         return true
     } else {
@@ -596,6 +625,239 @@ namespace eval qc::is {
             qc::commonmark2html $markdown
             return 1
         } on error [list error_message options] {
+            return 0
+        }
+    }
+
+    proc date {string} {
+        #| Checks if the given string is a date.
+        #| Dates are expected to be in ISO format.
+        return [regexp {^\d{4}-\d{2}-\d{2}$} $string]
+    }
+
+    proc timestamp_http {date} {
+        #| Returns true if date is an acceptable HTTP timestamp. Note although all three should be accepted,
+        #| only RFC 1123 format should be generated.
+        # RFC 1123 - Sun, 06 Nov 1994 08:49:37 GMT
+        if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)][,]\s\d{2}\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{4}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {
+            return 1
+        }
+        # RFC 850 - Sunday, 06-Nov-94 08:49:37 GMT
+        if { [regexp {([(Monday)|(Tuesday)|(Wednesday)|(Thursday)|(Friday)|(Saturday)|(Sunday)][,]\s\d{2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {
+            return 1
+        }
+        # ANCI C - Sun Nov  6 08:49:37 1994
+        if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)]\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\s|\d)\d\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d \d{4})} $date] } {
+            return 1
+        }
+        return 0
+    }
+
+    proc email {email} {
+        #| Checks if the given string follows the form of an email address.
+        return [regexp {^[a-zA-Z0-9_\-]+([\.\+][a-zA-Z0-9_\-]+)*@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+$} $email]
+    }
+
+    proc postcode {postcode} {
+        #| Checks if the given string is a UK postcode.
+        return [expr [regexp {^[A-Z]{1,2}[0-9R][0-9A-Z]? [0-9][ABD-HJLNP-UW-Z]{2}$} $postcode] || [regexp {^BFPO ?[0-9]+$} $postcode]]
+    }
+
+    proc creditcard {number} {
+        #| Checks if the given string is an allowable credit card number.
+        #| Checks, number of digits are >13 & <19, all characters are integers, luhn 10 check
+        regsub -all {[ -]} $number "" number
+        set mult 1
+        set sum 0
+        if { [string length $number]<13 || [string length $number]>19 } {
+            return 0
+        }
+        foreach digit [lreverse [split $number ""]] {
+            if { ![qc::is integer $digit] } {
+                return 0
+            }
+            set t [expr {$digit*$mult}]
+            if { $t >= 10 } {
+                set sum [expr {$sum + $t%10 +1}]
+            } else {
+                set sum [expr {$sum + $t}]
+            }
+            if { $mult == 1 } { set mult 2 } else { set mult 1 }
+        }
+        if { $sum%10 == 0 } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc creditcard_masked {string} {
+        #| Check the credit card number is masked to PCI requirements.
+        regsub -all {[^0-9\*]} $number "" number
+
+        # 13-19 chars masked with < 6 prefix and < 4 suffix digits
+        return [expr [regexp {[0-9\*]{13,19}} $no] && [regexp {^[3-6\*][0-9]{0,5}\*+[0-9]{0,4}$} $number]]
+    }
+
+    proc period {string} {
+        #| Check if the given string is a period.
+        set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
+        set regexp_map [list \$month_names_regexp [join $month_names |]]
+
+        if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
+            # Period defined by two periods eg "Jan 2011 to March 2011"
+            if { [qc::is_period $period1] && [qc::is_period $period2] } {
+                return 1
+            } else {
+                return 0
+            }
+
+        } elseif { [qc::is_date $string] } {
+            # String is an iso date eg "2014-01-01"
+            return 1
+
+        } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
+            # Exact match for year eg "2006"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([12]\d{3})$}] $string -> month_name year] } {
+            # Exact match in format "Jan 2006"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)$}] $string -> month_name] } {
+            # Exact match in format "Jan" (assume current year)
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)\s+([12]\d{3})$}] $string -> dom month_name year] } {
+            # Exact match for castable date in format "1st Jan 2014"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)$}] $string -> dom month_name] } {
+            # Exact match for castable date in format "1st Jan" (assume current year)
+            return 1       
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?\s+([12]\d{3})$}] $string -> month_name dom year] } {
+            # Exact match for castable date in format "Jan 1st 2014"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?$}] $string -> month_name dom] } {
+            # Exact match for castable date in format "Jan 1st" (assume current year)
+            return 1
+
+        } else {
+            # could not parse string
+            return 0
+        }
+
+        if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
+            # Period defined by two periods eg "Jan 2011 to March 2011"
+            if { [qc::is_period $period1] && [qc::is_period $period2] } {
+                return 1
+            } else {
+                return 0
+            }
+
+        } elseif { [qc::is_date $string] } {
+            # String is an iso date eg "2014-01-01"
+            return 1
+
+        } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
+            # Exact match for year eg "2006"
+            return 1
+
+        } elseif { [regexp -nocase -- {^([0-9]+)(?:st|th|nd|rd)?\s+(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)(?:\s+([12]\d{3}))?$} $string -> dom month_name year] } {
+            # Exact match for castable date in format "1st Jan 2014" or "1st Jan"
+            return 1
+
+        } elseif { [regexp -nocase -- {^(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)\s+([0-9]+)(?:st|th|nd|rd)?(?:\s+([12]\d{3}))?$} $string -> month_name dom year] } {
+            # Exact match for castable date in format "Jan 1st 2014" or "Jan 1st"
+            return 1
+
+        }  elseif { [regexp -nocase -- {^(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)(?:\s+([12]\d{3}))?$} $string -> month_name year] } {
+            # Exact match in format "Jan 2006" or "Jan"
+            return 1
+
+        }  else {
+            # could not parse string
+            return 0
+        }
+    }
+
+    proc base64 {string} {
+        #| Checks if the given string has only allowable base64 characters and is of the correct format.
+        if { [regexp {^[A-Za-z0-9/+\r\n]+=*$} $string] \
+                 && ([string length $string]-[regexp -all -- \r?\n $string])*6%8==0 } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc mobile_number {string} {
+        #| Checks if the given string is of the form of a UK mobile telephone number.
+        regsub -all {[^0-9]} $string {} tel_no
+        if {  [regexp {^07(5|7|8|9)[0-9]{8}$} $tel_no] } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc hex {string} {
+        #| Checks if the given string is a hex number.
+        return [regexp -nocase {^[0-9a-f]*$} $string]
+    }
+
+    proc url {string} {
+        #| Checks if the given string is a URL.
+        #| This is a more restrictive subset of all legal uri's defined by RFC 3986
+        #| Relax as needed
+        args $args -relative -- url
+        default relative false
+        if { $relative } {
+            return [regexp -expanded {
+                # path
+                ^([a-zA-Z0-9_\-\.~+/%]+)?
+                # query
+                (\?[a-zA-Z0-9_\-\.~+/%=&]+)?
+                # anchor
+                (\#[a-zA-Z0-9_\-\.~+/%]+)?
+                $
+            } $url]
+        } else {
+            return [regexp -expanded {
+                # protocol
+                ^https?://
+                # domain
+                [a-z0-9\-\.]+
+                # port
+                (:[0-9]+)?
+                # path
+                ([a-zA-Z0-9_\-\.~+/%]+)?
+                # query
+                (\?[a-zA-Z0-9_\-\.~+/%=&]+)?
+                # anchor
+                (\#[a-zA-Z0-9_\-\.~+/%]+)?
+                $
+            } $url]
+        }
+    }
+
+    proc ipv4 {string} {
+        #| Checks if the given string follows the IPv4 format.
+        # TODO checks structure only, will allow 9999.9999.9999.9999
+        if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$} $string] } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc cidrnetv4 {string} {
+        #| Checks if the given string follows the CIDR NETv4 format.
+        if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$} $string] } {
+            return 1
+        } else {
             return 0
         }
     }

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -636,7 +636,7 @@ namespace eval qc::is {
     }
 
     proc timestamp_http {date} {
-        #| Returns true if date is an acceptable HTTP timestamp. Note although all three should be accepted,
+        #| Checks if the given date is an acceptable HTTP timestamp. Note although all three should be accepted,
         #| only RFC 1123 format should be generated.
         # RFC 1123 - Sun, 06 Nov 1994 08:49:37 GMT
         if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)][,]\s\d{2}\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{4}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -336,6 +336,7 @@ proc qc::is_cidrnetv4 {string} {
 }
 
 proc qc::is_uri_valid {uri} {
+    #| Deprecated - see qc::is uri
     #| Test if the given uri is valid according to rfc3986 (https://tools.ietf.org/html/rfc3986)
   
     set unreserved {
@@ -496,7 +497,7 @@ proc qc::is_uri_valid {uri} {
 
 namespace eval qc::is {
     
-    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown
+    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -860,6 +861,165 @@ namespace eval qc::is {
         } else {
             return 0
         }
+    }
+
+    proc uri {uri} {
+        #| Test if the given uri is valid according to rfc3986 (https://tools.ietf.org/html/rfc3986)
+        
+        set unreserved {
+            (?:[a-zA-Z0-9\-._~])
+        }
+        
+        set sub_delims {
+            (?:[!$&'()*+,;=])
+        }
+        
+        set pct_encoded {
+            (?:%[0-9a-fA-F]{2})
+        }
+
+        set pchar [subst -nocommands -nobackslashes {
+            (?:${unreserved}|${pct_encoded}|${sub_delims}|[:@])
+        }]
+        
+        set segment [subst -nocommands -nobackslashes {
+            (?:${pchar}*)
+        }]
+
+        set segment_nz [subst -nocommands -nobackslashes {
+            (?:${pchar}+)
+        }]
+        
+        set segment_nz_nc [subst -nocommands -nobackslashes {
+            (?:(?:${unreserved}|${pct_encoded}|${sub_delims}|[@])+)
+        }]    
+
+        set scheme {
+            (?:[a-zA-Z][a-zA-Z+\-.]*)
+        }
+
+        set dec_octet {
+            (?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
+        }
+        
+        set ipv4_address [subst -nocommands -nobackslashes {
+            (?:${dec_octet}\.${dec_octet}\.${dec_octet}\.${dec_octet})
+        }]
+
+        set h16 {
+            (?:[0-9a-fA-F]{1,4})
+        }
+
+        set ls32 [subst -nocommands -nobackslashes {
+            (?:
+             ${h16}:${h16}
+             |
+             ${ipv4_address}
+             )
+        }]
+
+        set ipv6_address [subst -nocommands -nobackslashes {
+            (?:
+             (?:${h16}:){6}${ls32}
+             |
+             ::(?:${h16}:){5}${ls32}
+             |
+             (?:${h16})?::(?:${h16}:){4}${ls32}
+             |
+             (?:(?:${h16}:)?${h16})?::(?:${h16}:){3}${ls32}
+             |
+             (?:(?:${h16}:){0,2}${h16})?::(?:${h16}:){2}${ls32}
+             |
+             (?:(?:${h16}:){0,3}${h16})?::${h16}:${ls32}
+             |
+             (?:(?:${h16}:){0,4}${h16})?::${ls32}
+             |
+             (?:(?:${h16}:){0,5}${h16})?::${h16}
+             |
+             (?:(?:${h16}:){0,6}${h16})?::
+             )
+        }]
+
+        set ipvfuture [subst -nocommands -nobackslashes {
+            (?:v[0-9a-fA-F]+\.(?:${unreserved}|${sub_delims}|:)+)
+        }]
+        
+        set ip_literal [subst -nocommands -nobackslashes {
+            (?:\[(?:${ipv6_address}|${ipvfuture})\])
+        }]
+        
+        set host [subst -nocommands -nobackslashes {
+            (?:${ip_literal}|${ipv4_address}|(?:${unreserved}|${pct_encoded}|${sub_delims})*)
+        }]
+
+        set user_info [subst -nocommands -nobackslashes {
+            (?:(?:${unreserved}|${pct_encoded}|${sub_delims}|:)*)
+        }]
+
+        set port [subst -nocommands -nobackslashes {
+            (?:[0-9]*)
+        }]
+
+        set authority [subst -nocommands -nobackslashes {
+            (?:${user_info}@)?${host}(?::${port})?
+        }]           
+
+        set path_abempty [subst -nocommands -nobackslashes {
+            (?:(?:/${segment})*)
+        }]
+        
+        set path_absolute [subst -nocommands -nobackslashes {
+            (?:/(?:${segment_nz}(?:/${segment})*)?)
+        }]
+        
+        set path_noscheme [subst -nocommands -nobackslashes {
+            (?:${segment_nz_nc}(?:/${segment})*)
+        }]
+
+        set path_rootless [subst -nocommands -nobackslashes {
+            (?:${segment_nz}(?:/${segment})*)
+        }]
+
+        set path_empty [subst -nocommands -nobackslashes {
+            (?:${pchar}{0})
+        }]
+
+        set fragment_char [subst -nobackslashes {
+            (?:${pchar}|/|\?)
+        }]
+
+        set query_char [subst -nobackslashes {
+            (?:${pchar}|/|\?)
+        }]   
+        
+        set relative_uri [subst -nocommands -nobackslashes {
+            (?:
+             (?://${authority}${path_abempty}|${path_absolute}|${path_noscheme}|${path_empty})
+             (?:\?${query_char}+)?
+             (\#${fragment_char}+)?
+             )
+        }]
+
+        set absolute_uri [subst -nocommands -nobackslashes {
+            (?:
+             ${scheme}:
+             (?:(?://${authority}${path_abempty})|${path_absolute}|${path_rootless}|${path_empty})
+             (?:\?${query_char}+)?
+             (?:\#${fragment_char}+)?
+             )
+        }]
+
+        set re [subst -nocommands -nobackslashes {
+            ^
+            (?:
+             ${absolute_uri}
+             |
+             ${relative_uri}
+             )
+            $
+        }]
+        
+        return [regexp -expanded $re $uri]
     }
 }
 


### PR DESCRIPTION
* qc::cast decimal now accounts for precision and scale arguments to closer match PSQL data type.
* Various qc::is_x qc::cast_x and qc::is_x_castable moved to appropriate ensembles and originals marked as deprecated.
* Documentation for qc::is procs.