### PR TITLE
Register paths fix

### DIFF
--- a/tcl/conn.tcl
+++ b/tcl/conn.tcl
@@ -179,8 +179,8 @@ proc qc::handler_restful {} {
     set url_path [qc::conn_path]
     set method [qc::conn_method]
     
-    if {[qc::handlers exists $url_path $method]} {
-        set result [qc::handlers call $url_path $method]
+    if {[qc::handlers exists $method $url_path]} {
+        set result [qc::handlers call $method $url_path]
         # If conn is still open
         if {[qc::conn_open]} {
             # If a non-GET method then return the global data structure otherwise return the result as text/html.

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -11,7 +11,7 @@ proc qc::filter_validate {event {error_handler qc::error_handler}} {
     ::try {
         set url_path [qc::conn_path]
         set method [string toupper [qc::conn_method]]
-        # Check if this request is registered for this filter and a handler exists to validate against.
+        # Check if this request is registered and a handler exists to validate against.
         if { [qc::registered $method $url_path] && [qc::handlers exists $method $url_path] } {
             # Validate to data model
             qc::handlers validate2model $method $url_path
@@ -47,7 +47,7 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
     set url_path [qc::conn_path]
     set method [string toupper [qc::conn_method]]
     ::try {
-        # Check if this request is registered for this filter
+        # Check if this request is registered.
         if { [qc::registered $method $url_path] } {
             if {[qc::cookie_exists session_id] && [qc::session_valid [qc::session_id]]} {
                 qc::session_update [qc::session_id]

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -21,7 +21,7 @@ proc qc::filter_validate {event {error_handler qc::error_handler}} {
             }
             
             # Let the client know if there's a problem
-            if {[qc::conn_open] && $method ne "GET" && $method ne "HEAD" && ! [qc::record all_valid]} {
+            if {[qc::conn_open] && $method ni [list GET HEAD] && ! [qc::record all_valid]} {
                 qc::return_result
                 return "filter_return"
             } elseif { [qc::conn_open] && ! [qc::record all_valid] } {

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -21,7 +21,7 @@ proc qc::filter_validate {event {error_handler qc::error_handler}} {
             }
             
             # Let the client know if there's a problem
-            if {[qc::conn_open] && $method ne "GET" && ! [qc::record all_valid]} {
+            if {[qc::conn_open] && $method ne "GET" && $method ne "HEAD" && ! [qc::record all_valid]} {
                 qc::return_result
                 return "filter_return"
             } elseif { [qc::conn_open] && ! [qc::record all_valid] } {

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -10,7 +10,7 @@ namespace eval qc::handlers {
         set patterns [get $method]
         set form_dict [qc::form2dict]
         set proc_dict {}
-        set pattern_dict {}
+        set command_dict {}
         
         foreach pattern $patterns {
             set parts [split $pattern /]
@@ -57,29 +57,29 @@ namespace eval qc::handlers {
                 set command [list $pattern {*}$args]
                 if {$colon_variable_count > 0} {
                     # The proc contains colon variables
-                    if { [info exists pattern_dict] && [dict exists $pattern_dict variable]} {
+                    if { [info exists command_dict] && [dict exists $command_dict variable]} {
                         # There is currently a colon variable command in the dictionary...
-                        if { $colon_variable_count < [dict get $pattern_dict variable colon_variable_count] } {
+                        if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
                             # Prefer the command with the lower number of colon variables
-                            dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
+                            dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
                         }
                     } else {
                         # No colon variable command currently stored.
-                        dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
+                        dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
                     }                    
                 } else {
                     # The pattern was an exact match
-                    dict set pattern_dict exact [list command $command]
+                    dict set command_dict exact [list command $command]
                     break
                 }
             }
         }
         
         # Call the proc and return the result. Prefer the exact match.
-        if {[dict exists $pattern_dict exact]} {
-            set command [dict get $pattern_dict exact command]
-        } elseif [dict exists $pattern_dict variable] {
-            set command [dict get $pattern_dict variable command]
+        if {[dict exists $command_dict exact]} {
+            set command [dict get $command_dict exact command]
+        } elseif [dict exists $command_dict variable] {
+            set command [dict get $command_dict variable command]
         }
         set pattern [lindex $command 0]
         set args_dict [qc::dict_zipper [args $pattern $method] [lrange $command 1 end]]
@@ -138,7 +138,7 @@ namespace eval qc::handlers {
         set patterns [get $method]
         set form_dict [qc::form2dict]
         set proc_dict {}
-        set pattern_dict {}
+        set command_dict {}
         
         foreach pattern $patterns {
             set parts [split $pattern /]
@@ -185,29 +185,29 @@ namespace eval qc::handlers {
                 set command [list $pattern {*}$args]
                 if {$colon_variable_count > 0} {
                     # The proc contains colon variables
-                    if { [info exists pattern_dict] && [dict exists $pattern_dict variable]} {
+                    if { [info exists command_dict] && [dict exists $command_dict variable]} {
                         # There is currently a colon variable command in the dictionary...
-                        if { $colon_variable_count < [dict get $pattern_dict variable colon_variable_count] } {
+                        if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
                             # Prefer the command with the lower number of colon variables.
-                            dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
+                            dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
                         }
                     } else {
                         # No colon variable command currently stored.
-                        dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
+                        dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
                     }
                 } else {
                     # The pattern was an exact match
-                    dict set pattern_dict exact [list command $command]
+                    dict set command_dict exact [list command $command]
                     break
                 }
             }
         }
 
         # Return the arg dict. Prefer the exact match.
-        if {[dict exists $pattern_dict exact]} {
-            set command [dict get $pattern_dict exact command]
-        } elseif [dict exists $pattern_dict variable] {
-            set command [dict get $pattern_dict variable command]
+        if {[dict exists $command_dict exact]} {
+            set command [dict get $command_dict exact command]
+        } elseif [dict exists $command_dict variable] {
+            set command [dict get $command_dict variable command]
         }
         
         return [qc::validate2model [qc::dict_zipper [args [lindex $command 0] $method] [lrange $command 1 end]]]
@@ -299,7 +299,7 @@ namespace eval qc::handlers {
             set patterns [get $method]
             set form_dict [qc::form2dict]
             set proc_dict {}
-            set pattern_dict {}
+            set command_dict {}
             
             foreach pattern $patterns {
                 set parts [split $pattern /]
@@ -346,29 +346,29 @@ namespace eval qc::handlers {
                     set command [list [proc_name $pattern $method] {*}$args]
                     if {$colon_variable_count > 0} {
                         # The proc contains colon variables
-                        if { [info exists pattern_dict] && [dict exists $pattern_dict variable]} {
+                        if { [info exists command_dict] && [dict exists $command_dict variable]} {
                             # There is currently a colon variable command in the dictionary...
-                            if { $colon_variable_count < [dict get $pattern_dict variable colon_variable_count] } {
+                            if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
                                 # Prefer the command with the lower number of colon variables.
-                                dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
+                                dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
                             }
                         } else {
                             # No colon variable command currently stored.
-                            dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
+                            dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
                         }
                     } else {
                         # The pattern was an exact match
-                        dict set pattern_dict exact [list command $command]
+                        dict set command_dict exact [list command $command]
                         break
                     }
                 }
             }
 
             # Call the handler. Prefer the exact match.
-            if {[dict exists $pattern_dict exact]} {
-                return [{*}[dict get $pattern_dict exact command]]
-            } elseif [dict exists $pattern_dict variable] {
-                return [{*}[dict get $pattern_dict variable command]]
+            if {[dict exists $command_dict exact]} {
+                return [{*}[dict get $command_dict exact command]]
+            } elseif [dict exists $command_dict variable] {
+                return [{*}[dict get $command_dict variable command]]
             }
         }
 

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -63,15 +63,15 @@ namespace eval qc::handlers {
                         # There is currently a colon variable command in the dictionary...
                         if { $colon_count < [dict get $pattern_dict variable colon_count] } {
                             # Prefer the command with the lower number of colon variables
-                            dict set pattern_dict variable command $command colon_count $colon_count
+                            dict set pattern_dict variable [list command $command colon_count $colon_count]
                         }
                     } else {
                         # No colon variable command currently stored.
-                        dict set pattern_dict variable command $command colon_count $colon_count
+                        dict set pattern_dict variable [list command $command colon_count $colon_count]
                     }                    
                 } else {
                     # The pattern was an exact match
-                    dict set pattern_dict exact command $command
+                    dict set pattern_dict exact [list command $command]
                     break
                 }
             }
@@ -166,6 +166,7 @@ namespace eval qc::handlers {
             set args {}
             set url_pattern_parts {}
             set colon_vars false
+            set colon_count 0
             # check that each part of the pattern  matches the corresponding url_path part 
             foreach part $parts url_part $url_parts {
                 if {[qc::url_decode $url_part] eq $part} {
@@ -176,6 +177,7 @@ namespace eval qc::handlers {
                     lappend args [string range $part 1 end] [qc::url_decode $url_part]
                     lappend url_pattern_parts $part
                     set colon_vars true
+                    incr colon_count
                 }
             }
 
@@ -191,15 +193,15 @@ namespace eval qc::handlers {
                         # There is currently a colon variable command in the dictionary...
                         if { $colon_count < [dict get $pattern_dict variable colon_count] } {
                             # Prefer the command with the lower number of colon variables.
-                            dict set pattern_dict variable command $command colon_count $colon_count
+                            dict set pattern_dict variable [list command $command colon_count $colon_count]
                         }
                     } else {
                         # No colon variable command currently stored.
-                        dict set pattern_dict variable command $command colon_count $colon_count
+                        dict set pattern_dict variable [list command $command colon_count $colon_count]
                     }
                 } else {
                     # The pattern was an exact match
-                    dict set pattern_dict exact command $command
+                    dict set pattern_dict exact [list command $command]
                     break
                 }
             }
@@ -327,6 +329,7 @@ namespace eval qc::handlers {
                 set args {}
                 set url_pattern_parts {}
                 set colon_vars false
+                set colon_count 0
                 # check that each part of the handler matches the corresponding url_path part 
                 foreach part $parts url_part $url_parts {
                     if {[qc::url_decode $url_part] eq $part} {
@@ -337,6 +340,7 @@ namespace eval qc::handlers {
                         lappend args [string range $part 1 end] [qc::url_decode $url_part]
                         lappend url_pattern_parts $part
                         set colon_vars true
+                        incr colon_count
                     }
                 }
 
@@ -352,15 +356,15 @@ namespace eval qc::handlers {
                             # There is currently a colon variable command in the dictionary...
                             if { $colon_count < [dict get $pattern_dict variable colon_count] } {
                                 # Prefer the command with the lower number of colon variables.
-                                dict set pattern_dict variable command $command colon_count $colon_count
+                                dict set pattern_dict variable [list command $command colon_count $colon_count]
                             }
                         } else {
                             # No colon variable command currently stored.
-                            dict set pattern_dict variable command $command colon_count $colon_count
+                            dict set pattern_dict variable [list command $command colon_count $colon_count]
                         }
                     } else {
                         # The pattern was an exact match
-                        dict set pattern_dict exact command $command
+                        dict set pattern_dict exact [list command $command]
                         break
                     }
                 }

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -57,7 +57,7 @@ namespace eval qc::handlers {
                 set command [list $pattern {*}$args]
                 if {$colon_variable_count > 0} {
                     # The proc contains colon variables
-                    if { [info exists command_dict] && [dict exists $command_dict variable]} {
+                    if {[dict exists $command_dict variable]} {
                         # There is currently a colon variable command in the dictionary...
                         if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
                             # Prefer the command with the lower number of colon variables
@@ -69,7 +69,7 @@ namespace eval qc::handlers {
                     }                    
                 } else {
                     # The pattern was an exact match
-                    dict set command_dict exact [list command $command]
+                    dict set command_dict exact command $command
                     break
                 }
             }
@@ -185,7 +185,7 @@ namespace eval qc::handlers {
                 set command [list $pattern {*}$args]
                 if {$colon_variable_count > 0} {
                     # The proc contains colon variables
-                    if { [info exists command_dict] && [dict exists $command_dict variable]} {
+                    if {[dict exists $command_dict variable]} {
                         # There is currently a colon variable command in the dictionary...
                         if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
                             # Prefer the command with the lower number of colon variables.
@@ -197,7 +197,7 @@ namespace eval qc::handlers {
                     }
                 } else {
                     # The pattern was an exact match
-                    dict set command_dict exact [list command $command]
+                    dict set command_dict exact command $command
                     break
                 }
             }
@@ -346,7 +346,7 @@ namespace eval qc::handlers {
                     set command [list [proc_name $pattern $method] {*}$args]
                     if {$colon_variable_count > 0} {
                         # The proc contains colon variables
-                        if { [info exists command_dict] && [dict exists $command_dict variable]} {
+                        if {[dict exists $command_dict variable]} {
                             # There is currently a colon variable command in the dictionary...
                             if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
                                 # Prefer the command with the lower number of colon variables.
@@ -358,7 +358,7 @@ namespace eval qc::handlers {
                         }
                     } else {
                         # The pattern was an exact match
-                        dict set command_dict exact [list command $command]
+                        dict set command_dict exact command $command
                         break
                     }
                 }

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -35,8 +35,7 @@ namespace eval qc::handlers {
 
             set args {}
             set url_pattern_parts {}
-            set colon_vars false
-            set colon_count 0
+            set colon_variable_count 0
             # check that each part of the pattern matches the corresponding url_path part 
             foreach part $parts url_part $url_parts {
                 if {[qc::url_decode $url_part] eq $part} {
@@ -46,8 +45,7 @@ namespace eval qc::handlers {
                     # so update the args with the url_part
                     lappend args [string range $part 1 end] [qc::url_decode $url_part]
                     lappend url_pattern_parts $part
-                    set colon_vars true
-                    incr colon_count
+                    incr colon_variable_count
                 }
             }
 
@@ -57,17 +55,17 @@ namespace eval qc::handlers {
                 set form_dict [dict merge $form_dict $args]
                 set args [args_from_dict $form_dict $pattern $method]
                 set command [list $pattern {*}$args]
-                if {$colon_vars} {
+                if {$colon_variable_count > 0} {
                     # The proc contains colon variables
                     if { [info exists pattern_dict] && [dict exists $pattern_dict variable]} {
                         # There is currently a colon variable command in the dictionary...
-                        if { $colon_count < [dict get $pattern_dict variable colon_count] } {
+                        if { $colon_variable_count < [dict get $pattern_dict variable colon_variable_count] } {
                             # Prefer the command with the lower number of colon variables
-                            dict set pattern_dict variable [list command $command colon_count $colon_count]
+                            dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
                         }
                     } else {
                         # No colon variable command currently stored.
-                        dict set pattern_dict variable [list command $command colon_count $colon_count]
+                        dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
                     }                    
                 } else {
                     # The pattern was an exact match
@@ -165,8 +163,7 @@ namespace eval qc::handlers {
 
             set args {}
             set url_pattern_parts {}
-            set colon_vars false
-            set colon_count 0
+            set colon_variable_count 0
             # check that each part of the pattern  matches the corresponding url_path part 
             foreach part $parts url_part $url_parts {
                 if {[qc::url_decode $url_part] eq $part} {
@@ -176,8 +173,7 @@ namespace eval qc::handlers {
                     # so update the args with the url_part
                     lappend args [string range $part 1 end] [qc::url_decode $url_part]
                     lappend url_pattern_parts $part
-                    set colon_vars true
-                    incr colon_count
+                    incr colon_variable_count
                 }
             }
 
@@ -187,17 +183,17 @@ namespace eval qc::handlers {
                 set form_dict [dict merge $form_dict $args]
                 set args [args_from_dict $form_dict $pattern $method]
                 set command [list $pattern {*}$args]
-                if {$colon_vars} {
+                if {$colon_variable_count > 0} {
                     # The proc contains colon variables
                     if { [info exists pattern_dict] && [dict exists $pattern_dict variable]} {
                         # There is currently a colon variable command in the dictionary...
-                        if { $colon_count < [dict get $pattern_dict variable colon_count] } {
+                        if { $colon_variable_count < [dict get $pattern_dict variable colon_variable_count] } {
                             # Prefer the command with the lower number of colon variables.
-                            dict set pattern_dict variable [list command $command colon_count $colon_count]
+                            dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
                         }
                     } else {
                         # No colon variable command currently stored.
-                        dict set pattern_dict variable [list command $command colon_count $colon_count]
+                        dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
                     }
                 } else {
                     # The pattern was an exact match
@@ -328,8 +324,7 @@ namespace eval qc::handlers {
 
                 set args {}
                 set url_pattern_parts {}
-                set colon_vars false
-                set colon_count 0
+                set colon_variable_count 0
                 # check that each part of the handler matches the corresponding url_path part 
                 foreach part $parts url_part $url_parts {
                     if {[qc::url_decode $url_part] eq $part} {
@@ -339,8 +334,7 @@ namespace eval qc::handlers {
                         # so update the args with the url_part
                         lappend args [string range $part 1 end] [qc::url_decode $url_part]
                         lappend url_pattern_parts $part
-                        set colon_vars true
-                        incr colon_count
+                        incr colon_variable_count
                     }
                 }
 
@@ -350,17 +344,17 @@ namespace eval qc::handlers {
                     set form_dict [dict merge $form_dict $args]
                     set args [args_from_dict $form_dict $pattern $method]
                     set command [list [proc_name $pattern $method] {*}$args]
-                    if {$colon_vars} {
+                    if {$colon_variable_count > 0} {
                         # The proc contains colon variables
                         if { [info exists pattern_dict] && [dict exists $pattern_dict variable]} {
                             # There is currently a colon variable command in the dictionary...
-                            if { $colon_count < [dict get $pattern_dict variable colon_count] } {
+                            if { $colon_variable_count < [dict get $pattern_dict variable colon_variable_count] } {
                                 # Prefer the command with the lower number of colon variables.
-                                dict set pattern_dict variable [list command $command colon_count $colon_count]
+                                dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
                             }
                         } else {
                             # No colon variable command currently stored.
-                            dict set pattern_dict variable [list command $command colon_count $colon_count]
+                            dict set pattern_dict variable [list command $command colon_variable_count $colon_variable_count]
                         }
                     } else {
                         # The pattern was an exact match

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -5,212 +5,29 @@ namespace eval qc::handlers {
 
     proc call {method path} {
         #| Call the registered handler that matches the given path and method.
-        set url_parts [split $path /]
         set method [string toupper $method]
-        set patterns [get $method]
-        set form_dict [qc::form2dict]
-        set proc_dict {}
-        set command_dict {}
-        
-        foreach pattern $patterns {
-            set parts [split $pattern /]
-            set arg_names [args $pattern $method]
-            # make sure that all colon variables appear in the handler args
-            set move_on false
-            foreach part $parts {
-                if {[string first : $part] == 0 && [lsearch -exact $arg_names [string range $part 1 end]] == -1} {
-                    set move_on true
-                    break
-                }
-            }
-            if {$move_on} { continue }
-            
-            # count the number of colon variables in the pattern
-            set no_vars [regexp -all {[^:]:[^:]+(?=/|$)} $pattern]
-            # Check length of parts matches and that the number of arguments for the handler is
-            # not less than the number of colon variables in the pattern.
-            if { [llength $parts] != [llength $url_parts] || [llength $arg_names] < $no_vars } {
-                continue
-            }
-
-            set args {}
-            set url_pattern_parts {}
-            set colon_variable_count 0
-            # check that each part of the pattern matches the corresponding url_path part 
-            foreach part $parts url_part $url_parts {
-                if {[qc::url_decode $url_part] eq $part} {
-                    lappend url_pattern_parts $part
-                } elseif {[string first : $part] == 0 } {
-                    # the first character of the pattern part was ':'
-                    # so update the args with the url_part
-                    lappend args [string range $part 1 end] [qc::url_decode $url_part]
-                    lappend url_pattern_parts $part
-                    incr colon_variable_count
-                }
-            }
-
-            # check if the built url_pattern_parts is the same as the pattern
-            if {[join $url_pattern_parts /] eq $pattern} {
-                # Get the relevant args for the handler from the form variables.
-                set form_dict [dict merge $form_dict $args]
-                set args [args_from_dict $form_dict $pattern $method]
-                set command [list $pattern {*}$args]
-                if {$colon_variable_count > 0} {
-                    # The proc contains colon variables
-                    if {[dict exists $command_dict variable]} {
-                        # There is currently a colon variable command in the dictionary...
-                        if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
-                            # Prefer the command with the lower number of colon variables
-                            dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
-                        }
-                    } else {
-                        # No colon variable command currently stored.
-                        dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
-                    }                    
-                } else {
-                    # The pattern was an exact match
-                    dict set command_dict exact command $command
-                    break
-                }
-            }
-        }
-        
-        # Call the proc and return the result. Prefer the exact match.
-        if {[dict exists $command_dict exact]} {
-            set command [dict get $command_dict exact command]
-        } elseif [dict exists $command_dict variable] {
-            set command [dict get $command_dict variable command]
-        }
-        set pattern [lindex $command 0]
-        set args_dict [qc::dict_zipper [args $pattern $method] [lrange $command 1 end]]
-        return [[proc_name $pattern $method] {*}[dict values [qc::cast_values2model {*}$args_dict]]]
+        set pattern [qc::path_best_match $path [get $method]]
+        # Add in path variables to form data.
+        set form [dict merge [qc::form2dict] [qc::path_variables $path $pattern]]
+        # Cast to model
+        set dict [qc::cast_values2model {*}[data $form $method $pattern]]
+        # Call handler
+        return [qc::call_with [proc_name $method $pattern] {*}$dict]
     }
 
     proc exists {method path} {
         #| Check if a handler exists for the given path and method.
-        set url_parts [split $path /]
-        set method [string toupper $method]
-        set patterns [get $method]
-        foreach pattern $patterns {
-            set parts [split $pattern /]
-            set arg_names [args $pattern $method]
-            # make sure that all colon variables appear in the handler args
-            set move_on false
-            foreach part $parts {
-                if {[string first : $part] == 0 && [lsearch -exact $arg_names [string range $part 1 end]] == -1} {
-                    set move_on true
-                    break
-                }
-            }
-            if {$move_on} { continue }
-            
-            # count the number of colon variables in the pattern
-            set no_vars [regexp -all {[^:]:[^:]+(?=/|$)} $pattern]
-            # Check length of parts matches and that the number of arguments for the handler is
-            # not less than the number of colon variables in the pattern.
-            if { [llength $parts] != [llength $url_parts] || [llength $arg_names] < $no_vars } {
-                continue
-            }
-
-            set url_pattern_parts {}
-            # check that each part of the pattern matches the corresponding path part 
-            foreach part $parts url_part $url_parts {
-                if {[qc::url_decode $url_part] eq $part} {
-                    lappend url_pattern_parts $part
-                } elseif {[string first : $part] == 0 } {
-                    # the first character of the pattern part was ':'
-                    lappend url_pattern_parts $part
-                }
-            }
-
-            # check if the built url_pattern_parts is the same as the handler
-            if {[join $url_pattern_parts /] eq $pattern} {
-                return true
-            }        
-        }
-        return false
+        return [qc::path_matches $path [get [string toupper $method]]]
     }
 
     proc validate2model {method path} {
         #| Validates the args of the handler registered for the given path and method.
-        set url_parts [split $path /]
         set method [string toupper $method]
-        set patterns [get $method]
-        set form_dict [qc::form2dict]
-        set proc_dict {}
-        set command_dict {}
-        
-        foreach pattern $patterns {
-            set parts [split $pattern /]
-            set arg_names [args $pattern $method]
-            # make sure that all colon variables appear in the handler args
-            set move_on false
-            foreach part $parts {
-                if {[string first : $part] == 0 && [lsearch -exact $arg_names [string range $part 1 end]] == -1} {
-                    set move_on true
-                    break
-                }
-            }
-            if {$move_on} { continue }
-            
-            # count the number of colon variables in the pattern
-            set no_vars [regexp -all {[^:]:[^:]+(?=/|$)} $pattern]
-            # Check length of parts matches and that the number of arguments for the handler is
-            # not less than the number of colon variables in the pattern.
-            if { [llength $parts] != [llength $url_parts] || [llength $arg_names] < $no_vars } {
-                continue
-            }
-
-            set args {}
-            set url_pattern_parts {}
-            set colon_variable_count 0
-            # check that each part of the pattern  matches the corresponding url_path part 
-            foreach part $parts url_part $url_parts {
-                if {[qc::url_decode $url_part] eq $part} {
-                    lappend url_pattern_parts $part
-                } elseif {[string first : $part] == 0 } {
-                    # the first character of the handler part was ':'
-                    # so update the args with the url_part
-                    lappend args [string range $part 1 end] [qc::url_decode $url_part]
-                    lappend url_pattern_parts $part
-                    incr colon_variable_count
-                }
-            }
-
-            # check if the built url_pattern_parts is the same as the pattern
-            if {[join $url_pattern_parts /] eq $pattern} {
-                # Get the relevant args for the handler from the form variables.
-                set form_dict [dict merge $form_dict $args]
-                set args [args_from_dict $form_dict $pattern $method]
-                set command [list $pattern {*}$args]
-                if {$colon_variable_count > 0} {
-                    # The proc contains colon variables
-                    if {[dict exists $command_dict variable]} {
-                        # There is currently a colon variable command in the dictionary...
-                        if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
-                            # Prefer the command with the lower number of colon variables.
-                            dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
-                        }
-                    } else {
-                        # No colon variable command currently stored.
-                        dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
-                    }
-                } else {
-                    # The pattern was an exact match
-                    dict set command_dict exact command $command
-                    break
-                }
-            }
-        }
-
-        # Return the arg dict. Prefer the exact match.
-        if {[dict exists $command_dict exact]} {
-            set command [dict get $command_dict exact command]
-        } elseif [dict exists $command_dict variable] {
-            set command [dict get $command_dict variable command]
-        }
-        
-        return [qc::validate2model [qc::dict_zipper [args [lindex $command 0] $method] [lrange $command 1 end]]]
+        set pattern [qc::path_best_match $path [get $method]]
+        # Add in path variables to form data.
+        set form [dict merge [qc::form2dict] [qc::path_variables $path $pattern]]
+        # Validate the data.
+        return [qc::validate2model [data $form $method $pattern]]
     }
 
     ##################################################
@@ -233,51 +50,45 @@ namespace eval qc::handlers {
         return $temp
     }
     
-    proc proc_name {pattern method} {
-        #| Get the proc name for the handler named "$method $pattern".
+    proc proc_name {method pattern} {
+        #| Get the proc name for the handler identified by $method $pattern.
         return [qc::nsv_dict get handlers $method $pattern proc_name]
     }
 
-    proc args {pattern method} {
-        #| Get all arguments for the given handler named "$method $pattern".
+    proc args {method pattern} {
+        #| Get all arguments for the given handler identified by $method $pattern.
         return [qc::nsv_dict get handlers $method $pattern args]
     }
 
-    proc default {pattern method arg} {
-        #| Get the default value of the given arg for the handler named "$method $pattern".
+    proc default {method pattern arg} {
+        #| Get the default value of the given arg for the handler identified by $method $pattern.
         return [qc::nsv_dict get handlers $method $pattern defaults $arg]
     }
 
-    proc default_exists {pattern method arg} {
-        #| Check if a default argument exists for the given argument for handler named "$method $pattern".
+    proc default_exists {method pattern arg} {
+        #| Check if a default argument exists for the given argument for handler identified by $method $pattern.
         return [qc::nsv_dict exists handlers $method $pattern defaults $arg]
     }
 
-    proc args_from_dict {dict pattern method} {
-        #| Returns a list of args for the handler named "$method $pattern" that correspond to any form variables in the given dictionary.
+    proc data {form method pattern} {
+        #| Returns a dictionary of data for the handler identified by $method $pattern.
         set method [string toupper $method]
-        set args [args $pattern $method]
-        set handler_args {}
+        set args [args $method $pattern]
+        set result {}
         foreach arg $args {
-            if {[default_exists $pattern $method $arg]} {
-                # the argument was an optional one 
-                if {[dict exists $dict $arg]} {
-                    lappend handler_args [dict get $dict $arg]
-                } elseif { [regexp {^[^.]+\.([^.]+)$} $arg -> column] && [dict exists $dict $column] } {
-                    # Return the first form value matching a fully qualified handler arg
-                    # eg. Use form var firstname for arg users.firstname
-                    lappend handler_args [dict get $dict $column]
-                } else {
-                    lappend handler_args [default $pattern $method $arg]
-                }
-            } elseif {[dict exists $dict $arg]} {
-                lappend handler_args [dict get $dict $arg]
+            if { [dict exists $form $arg] } {
+                lappend result $arg [dict get $form $arg]
+            } elseif { [regexp {^[^.]+\.([^.]+)$} $arg -> column] && [dict exists $form $column] } {
+                # e.g. use form variable "firstname" for arg "users.firstname"
+                lappend result $arg [dict get $form $column]
+            } elseif { [default_exists $method $pattern $arg] } {
+                lappend result $arg [default $method $pattern $arg]
             } else {
-                # arg wasn't optional and didn't appear in form_dict 
-                return -code error "No matching arg value for \"$arg\" in handler \"$method $pattern\"" 
+                # arg wasn't optional and didn't appear in form
+                return -code error "No matching arg value for \"$arg\" in form."
             }
         }
-        return $handler_args
+        return $result
     }
 
 
@@ -294,127 +105,19 @@ namespace eval qc::handlers {
 
         proc call {method path} {
             #| Calls the registered handler that matches the given method and path.
-            set url_parts [split $path /]
             set method [string toupper $method]
-            set patterns [get $method]
-            set form_dict [qc::form2dict]
-            set proc_dict {}
-            set command_dict {}
-            
-            foreach pattern $patterns {
-                set parts [split $pattern /]
-                set arg_names [args $pattern $method]
-                # make sure that all colon variables appear in the handler args
-                set move_on false
-                foreach part $parts {
-                    if {[string first : $part] == 0 && [lsearch -exact $arg_names [string range $part 1 end]] == -1} {
-                        set move_on true
-                        break
-                    }
-                }
-                if {$move_on} { continue }
-                
-                # count the number of colon variables in the pattern
-                set no_vars [regexp -all {[^:]:[^:]+(?=/|$)} $pattern]
-                # Check length of parts matches and that the number of arguments for the handler is
-                # not less than the number of colon variables in the pattern.
-                if { [llength $parts] != [llength $url_parts] || [llength $arg_names] < $no_vars } {
-                    continue
-                }
-
-                set args {}
-                set url_pattern_parts {}
-                set colon_variable_count 0
-                # check that each part of the handler matches the corresponding url_path part 
-                foreach part $parts url_part $url_parts {
-                    if {[qc::url_decode $url_part] eq $part} {
-                        lappend url_pattern_parts $part
-                    } elseif {[string first : $part] == 0 } {
-                        # the first character of the handler part was ':'
-                        # so update the args with the url_part
-                        lappend args [string range $part 1 end] [qc::url_decode $url_part]
-                        lappend url_pattern_parts $part
-                        incr colon_variable_count
-                    }
-                }
-
-                # check if the built url_pattern_parts is the same as the pattern
-                if {[join $url_pattern_parts /] eq $pattern} {
-                    # Get the relevant args for the handler from the form variables.
-                    set form_dict [dict merge $form_dict $args]
-                    set args [args_from_dict $form_dict $pattern $method]
-                    set command [list [proc_name $pattern $method] {*}$args]
-                    if {$colon_variable_count > 0} {
-                        # The proc contains colon variables
-                        if {[dict exists $command_dict variable]} {
-                            # There is currently a colon variable command in the dictionary...
-                            if { $colon_variable_count < [dict get $command_dict variable colon_variable_count] } {
-                                # Prefer the command with the lower number of colon variables.
-                                dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
-                            }
-                        } else {
-                            # No colon variable command currently stored.
-                            dict set command_dict variable [list command $command colon_variable_count $colon_variable_count]
-                        }
-                    } else {
-                        # The pattern was an exact match
-                        dict set command_dict exact command $command
-                        break
-                    }
-                }
-            }
-
-            # Call the handler. Prefer the exact match.
-            if {[dict exists $command_dict exact]} {
-                return [{*}[dict get $command_dict exact command]]
-            } elseif [dict exists $command_dict variable] {
-                return [{*}[dict get $command_dict variable command]]
-            }
+            set pattern [qc::path_best_match $path [get $method]]
+            # Add in path variables to form data.
+            set form [dict merge [qc::form2dict] [qc::path_variables $path $pattern]]
+            # Grab relevant arg data from form.
+            set dict [data $form $method $pattern]
+            # Call the validation handler.
+            return [qc::call_with [proc_name $method $pattern] {*}$dict]
         }
 
         proc exists {method path} {
             #| Checks if a validation handler exists for the given path and method.
-            set url_parts [split $path /]
-            set method [string toupper $method]
-            set handlers [get $method]
-            foreach handler $handlers {
-                set parts [split $handler /]
-                set arg_names [args $handler $method]
-                # make sure that all colon variables appear in the handler args
-                set move_on false
-                foreach part $parts {
-                    if {[string first : $part] == 0 && [lsearch -exact $arg_names [string range $part 1 end]] == -1} {
-                        set move_on true
-                        break
-                    }
-                }
-                if {$move_on} { continue }
-                
-                # count the number of colon variables in the pattern
-                set no_vars [regexp -all {[^:]:[^:]+(?=/|$)} $handler]
-                # Check length of parts matches and that the number of arguments for the handler is
-                # not less than the number of colon variables in the pattern.
-                if { [llength $parts] != [llength $url_parts] || [llength $arg_names] < $no_vars } {
-                    continue
-                }
-
-                set url_pattern_parts {}
-                # check that each part of the pattern matches the corresponding path part 
-                foreach part $parts url_part $url_parts {
-                    if {[qc::url_decode $url_part] eq $part} {
-                        lappend url_pattern_parts $part
-                    } elseif {[string first : $part] == 0 } {
-                        # the first character of the pattern part was ':'
-                        lappend url_pattern_parts $part
-                    }
-                }
-
-                # check if the built url_pattern_parts is the same as the handler
-                if {[join $url_pattern_parts /] eq $handler} {
-                    return true
-                }        
-            }
-            return false
+            return [qc::path_matches $path [get [string toupper $method]]]
         }
 
         ##################################################
@@ -438,51 +141,45 @@ namespace eval qc::handlers {
             return $temp
         }
         
-        proc proc_name {pattern method} {
-            #| Get the validation proc_name for the handler named "$method $pattern".
+        proc proc_name {method pattern} {
+            #| Get the validation proc_name for the handler identified by $method $pattern.
             return [qc::nsv_dict get handlers VALIDATE $method $pattern proc_name]
         }
 
-        proc args {pattern method} {
-            #| Get all arguments for the handler named "$method $pattern".
+        proc args {method pattern} {
+            #| Get all arguments for the handler identified by $method $pattern.
             return [qc::nsv_dict get handlers VALIDATE $method $pattern args]
         }
 
-        proc default {pattern method arg} {
-            #| Get the default value of the given arg for the handler named "$method $pattern".
+        proc default {method pattern arg} {
+            #| Get the default value of the given arg for the handler identified by $method $pattern.
             return [qc::nsv_dict get handlers VALIDATE $method $pattern defaults $arg]
         }
 
-        proc default_exists {pattern method arg} {
-            #| Check if a default argument exists for the given argument for handler named "$method $pattern".
+        proc default_exists {method pattern arg} {
+            #| Check if a default argument exists for the given argument for handler identified by $method $pattern.
             return [qc::nsv_dict exists handlers VALIDATE $method $pattern defaults $arg]
         }
 
-        proc args_from_dict {dict pattern method} {
-            #| Returns a list of args for the handler named "$method $pattern" that correspond to any form variables in the given dictionary
+        proc data {form method pattern} {
+            #| Returns a dictionary of args for the handler identified by $method $pattern.
             set method [string toupper $method]
-            set args [args $pattern $method]
-            set handler_args {}
+            set args [args $method $pattern]
+            set result {}
             foreach arg $args {
-                if {[default_exists $pattern $method $arg]} {
-                    # the argument was an optional one 
-                    if {[dict exists $dict $arg]} {
-                        lappend handler_args [dict get $dict $arg]
-                    } elseif { [regexp {^[^.]+\.([^.]+)$} $arg -> column] && [dict exists $dict $column] } {
-                        # Return the first form value matching a fully qualified handler arg
-                        # eg. Use form var firstname for arg users.firstname
-                        lappend handler_args [dict get $dict $column]
-                    } else {
-                        lappend handler_args [default $pattern $method $arg]
-                    }
-                } elseif {[dict exists $dict $arg]} {
-                    lappend handler_args [dict get $dict $arg]
+                if { [dict exists $form $arg] } {
+                    lappend result $arg [dict get $form $arg]
+                } elseif { [regexp {^[^.]+\.([^.]+)$} $arg -> column] && [dict exists $form $column] } {
+                    # e.g. use form variable "firstname" for arg "users.firstname"
+                    lappend result $arg [dict get $form $column]
+                } elseif { [default_exists $method $pattern $arg] } {
+                    lappend result $arg [default $method $pattern $arg]
                 } else {
-                    # arg wasn't optional and didn't appear in form_dict 
-                    return -code error "No matching arg value for \"$arg\" in handler \"$method $pattern\"" 
+                    # arg wasn't optional and didn't appear in form
+                    return -code error "No matching arg value for \"$arg\" in form." 
                 }
             }
-            return $handler_args
+            return $result
         }
     }
 }

--- a/tcl/nsv_dict.tcl
+++ b/tcl/nsv_dict.tcl
@@ -3,7 +3,7 @@ namespace eval qc {
 }
 
 namespace eval qc::nsv_dict {
-    namespace export exists set unset get
+    namespace export exists set unset get lappend
     namespace ensemble create
 
     proc exists {variable key args} {
@@ -81,5 +81,10 @@ namespace eval qc::nsv_dict {
             ::set temp [nsv_get $variable [lindex $keys 0]]
             return [dict get $temp {*}[lrange $keys 1 end]]
         }        
+    }
+
+    proc lappend {variable key values} {
+        #| Append the values to the key in an nsv_array
+        nsv_lappend $variable $key {*}$values
     }
 }

--- a/tcl/nsv_dict.tcl
+++ b/tcl/nsv_dict.tcl
@@ -84,7 +84,7 @@ namespace eval qc::nsv_dict {
     }
 
     proc lappend {variable key values} {
-        #| Append the values to the key in an nsv_array
+        #| Append values to the list corresponding to the dictionary key stored in a nsv_array
         nsv_lappend $variable $key {*}$values
     }
 }

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -78,13 +78,9 @@ proc qc::validate {method path proc_args proc_body} {
 
 proc qc::registered {method url_path} {
     #| Checks if the given method url_path is registered for the given filter.
-    if { $method ni [list GET HEAD POST] } {
-        set http_method POST
-    } else {
-        set http_method $method
-    }
-    if { [qc::nsv_dict exists registered $http_method] } {
-        return [qc::pattern_matches $url_path [qc::nsv_dict get registered $http_method]]
+    set method [string toupper $method]
+    if { [qc::nsv_dict exists registered $method] } {
+        return [qc::pattern_matches $url_path [qc::nsv_dict get registered $method]]
     } else {
         return false
     }

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -11,14 +11,8 @@ proc qc::register {args} {
     set method [string toupper [lindex $args 0]]
     set path [lindex $args 1]
     # Add to registered nsv array
-    if { [qc::nsv_dict exists registered $method] } {
-        set patterns [qc::nsv_dict get registered $method]
-        if { [lsearch -exact $patterns $path] < 0 } {
-            # path hasn't been registered already
-            qc::nsv_dict lappend registered $method $path
-        }
-    } else {
-        qc::nsv_dict set registered $method $path
+    if { ! [qc::registered $method $path] } {
+        qc::nsv_dict lappend registered $method $path
     }
 
     if { [llength $args] >= 3 } {

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -2,45 +2,42 @@ namespace eval qc {
     namespace export register validate
 }
 
-proc qc::register {method path proc_args proc_body} {
+proc qc::register {args} {
     #| Register a URL handler.
-    set method [string toupper $method]
-    namespace eval ::${method} {}
-    set proc_name "::${method}::$path"
-    {*}[list proc $proc_name $proc_args $proc_body]
+    if { [llength $args] < 2 || [llength $args] > 4 } {
+        return -code error "Usage: qc::register method path ?args? ?body?"
+    }
 
-    # Separate arg names and default values
-    set args {}
-    set defaults {}
-    foreach arg $proc_args {
-        if {[llength $arg] == 2} {
-            lappend args [lindex $arg 0]
-            dict set defaults [lindex $arg 0] [lindex $arg 1]
-        } else {
-            lappend args $arg
+    set method [string toupper [lindex $args 0]]
+    set path [lindex $args 1]
+    qc::nsv_dict set registered $method $path
+
+    if { [llength $args] >= 3 } {
+        set $proc_args [lindex $args 2]
+        # Separate arg names and default values
+        set args {}
+        set defaults {}
+        foreach arg $proc_args {
+            if {[llength $arg] == 2} {
+                lappend args [lindex $arg 0]
+                dict set defaults [lindex $arg 0] [lindex $arg 1]
+            } else {
+                lappend args $arg
+            }
         }
     }
 
-    # Update the handlers nsv array.
-    qc::nsv_dict set handlers $method $path proc_name $proc_name
-    qc::nsv_dict set handlers $method $path args $args
-    qc::nsv_dict set handlers $method $path body $proc_body
-    qc::nsv_dict set handlers $method $path defaults $defaults    
+    if { [llength $args] == 4 } {
+        set $proc_body [lindex $args 3]
+        namespace eval ::${method} {}
+        set proc_name "::${method}::$path"
+        {*}[list proc $proc_name $proc_args $proc_body]
 
-    if {$method eq "GET"} {
-        set http_methods [list HEAD GET]
-    } else {
-        set http_methods [list "POST"]
-    }
-
-    # Add path to the filters database if not present.
-    foreach http_method $http_methods {
-        if { ! [qc::nsv_dict exists filters filter_validate $http_method $path] } {
-            qc::nsv_dict set filters filter_validate $http_method $path 1
-        }
-        if { ! [qc::nsv_dict exists filters filter_authenticate $http_method $path] } {
-            qc::nsv_dict set filters filter_authenticate $http_method $path 1
-        }
+        # Update the handlers nsv array.
+        qc::nsv_dict set handlers $method $path proc_name $proc_name
+        qc::nsv_dict set handlers $method $path args $args
+        qc::nsv_dict set handlers $method $path body $proc_body
+        qc::nsv_dict set handlers $method $path defaults $defaults  
     }
 }
 
@@ -68,4 +65,45 @@ proc qc::validate {method path proc_args proc_body} {
     qc::nsv_dict set handlers VALIDATE $method $path args $args 
     qc::nsv_dict set handlers VALIDATE $method $path body $proc_body 
     qc::nsv_dict set handlers VALIDATE $method $path defaults $defaults
+}
+
+proc qc::registered {method url_path} {
+    #| Checks if the given method url_path is registered for the given filter.
+    if { $method ni [list GET HEAD POST] } {
+        set http_method POST
+    } else {
+        set http_method $method
+    }
+    if { [qc::nsv_dict exists registered $http_method] } {
+        dict for {item_path handler} [qc::nsv_dict get registered $http_method] {
+            
+        }
+    }
+    return false
+}
+
+proc qc::pattern_matches {url_path patterns} {
+    #| Checks if the given url_path matches any of the given patterns.
+    foreach pattern $patterns {
+        set path_parts [split $url_path /]
+        set pattern_parts [split $pattern /]
+        # check number of parts in each path are equal
+        if { [llength $path_parts] == [llength $pattern_parts] } {
+            # check that each part matches
+            set parts_equal true
+            foreach path_part $path_parts pattern_part $pattern_parts {
+                # if the item part is a colon variable
+                if {[string index $pattern_part 0] eq ":"} {
+                    continue
+                } elseif {$path_part ne $pattern_part} {
+                    set parts_equal false
+                    break
+                }
+            }
+            if {$parts_equal} {
+                return true
+            }
+        }
+    }
+    return false
 }

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -28,6 +28,14 @@ proc qc::register {args} {
                 lappend arg_names $arg
             }
         }
+
+        # Check that colon variables in the path appear in the args
+        set path_parts [split $path /]
+        foreach path_part $path_parts {
+            if { [string first : $path_part] == 0 && [lsearch -exact $arg_names [string range $path_part 1 end]] == -1} {
+                return -code error "Colon variable \"$path_part\" missing from args."
+            }
+        }
     }
 
     if { [llength $args] == 4 } {
@@ -81,10 +89,10 @@ proc qc::registered {method url_path} {
     }
 }
 
-proc qc::path_matches {url_path patterns} {
-    #| Checks if the given url_path matches any of the given patterns.
+proc qc::path_matches {path patterns} {
+    #| Checks if the given path matches any of the given patterns.
     foreach pattern $patterns {
-        set path_parts [split $url_path /]
+        set path_parts [split $path /]
         set pattern_parts [split $pattern /]
         # check number of parts in each path are equal
         if { [llength $path_parts] == [llength $pattern_parts] } {
@@ -105,4 +113,61 @@ proc qc::path_matches {url_path patterns} {
         }
     }
     return false
+}
+
+proc qc::path_best_match {path patterns} {
+    #| Finds the best match to path from the given patterns.
+    set path_parts [split $path /]
+    set matches {}
+    foreach pattern $patterns {
+        set pattern_parts [split $pattern /]
+        # Check if path and pattern have the same number of parts
+        if { [llength $path_parts] != [llength $pattern_parts] } {
+            continue
+        }
+        set parts_equal true
+        foreach path_part $path_parts pattern_part $pattern_parts {
+            if { $path_part ne $pattern_part && [string first : $pattern_part] != 0 } {
+                # Parts are not the same and the pattern part is not a colon variable
+                set parts_equal false
+            }
+        }
+
+        if { ! $parts_equal } {
+            continue
+        }
+
+        # count the number of colon variables in the pattern
+        set colon_variable_count [regexp -all {[^:]:[^:]+(?=/|$)} $pattern]
+        # Add it to the matches dict
+        dict lappend matches $colon_variable_count $pattern
+    }
+    
+    # Get the lowest count of colon variables in a matched pattern.
+    foreach count [dict keys $matches] {
+        if { ! [info exists best_match_count] || $count < $best_match_count} {
+            set best_match_count $count
+        }
+    }
+    
+    # If there were matches found then return one with the least amount of colon variables.
+    if { [dict size $matches] > 0 } {
+        return [lindex [dict get $matches $best_match_count] 0]
+    } else {
+        return -code error "No pattern matched path: \"$path\""
+    }
+}
+
+proc qc::path_variables {path pattern} {
+    #| Gets variables from the path that corresponds to colon variables in the pattern.
+    set path_parts [split $path /]
+    set pattern_parts [split $pattern /]
+    set variables {}
+    foreach path_part $path_parts pattern_part $pattern_parts {
+        if { [string first : $pattern_part ] == 0 } {
+            # The pattern part is a colon variable - store the path_part
+            dict set variables [string range $pattern_part 1 end] $path_part
+        }
+    }
+    return $variables
 }

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -52,7 +52,7 @@ proc qc::register {args} {
 }
 
 proc qc::validate {method path proc_args proc_body} {
-    #| Register a URL handler for extra validation.
+    #| Register a URL handler for custom validation.
     set method [string toupper $method]
     set proc_name "::${method}::VALIDATE::$path"
     namespace eval ::${method}::VALIDATE {}
@@ -78,7 +78,7 @@ proc qc::validate {method path proc_args proc_body} {
 }
 
 proc qc::registered {method url_path} {
-    #| Checks if the given method url_path is registered for the given filter.
+    #| Checks if the given method url_path is registered.
     set method [string toupper $method]
     if { [qc::nsv_dict exists registered $method] } {
         return [qc::path_matches $url_path [qc::nsv_dict get registered $method]]

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -13,7 +13,7 @@ proc qc::register {args} {
     qc::nsv_dict set registered $method $path
 
     if { [llength $args] >= 3 } {
-        set $proc_args [lindex $args 2]
+        set proc_args [lindex $args 2]
         # Separate arg names and default values
         set args {}
         set defaults {}

--- a/tcl/register.tcl
+++ b/tcl/register.tcl
@@ -28,7 +28,7 @@ proc qc::register {args} {
     }
 
     if { [llength $args] == 4 } {
-        set $proc_body [lindex $args 3]
+        set proc_body [lindex $args 3]
         namespace eval ::${method} {}
         set proc_name "::${method}::$path"
         {*}[list proc $proc_name $proc_args $proc_body]

--- a/tcl/util.tcl
+++ b/tcl/util.tcl
@@ -150,8 +150,7 @@ proc qc::call { proc_name args } {
 }
 
 proc qc::call_with {proc_name args} {
-    #| Calls the given proc with the arguments specified.
-    #| Returns the result of the execution of the proc.
+    #| Calls proc_name by mapping name value pairs to named args.
     if { [llength $args]%2 != 0 } {
         return -code error "usage qc::call_with proc_name ?name value?"
     }


### PR DESCRIPTION
* `register` now allows for registering of paths i.e. `register GET /page`
* `qc::handlers` updated to choose a match with the least amount of colon variables
* `lappend` added to `qc::nsv_dict`