### PR TITLE
Anonymous session migrate

### DIFF
--- a/doc/procs/anonymous_session_id.md
+++ b/doc/procs/anonymous_session_id.md
@@ -1,0 +1,26 @@
+qc::anonymous_session_id
+===========
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`anonymous_session_id`
+
+Description
+-----------
+Return the anonymous session ID.
+
+Examples
+--------
+```tcl
+
+% anonymous_session_id
+961b068fc13c428e64908dd7e507d1f9c1a332e4
+
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/doc/procs/anonymous_user_id.md
+++ b/doc/procs/anonymous_user_id.md
@@ -1,0 +1,26 @@
+qc::anonymous_user_id
+===========
+
+part of [Docs](../index.md)
+
+Usage
+-----
+`anonymous_user_id`
+
+Description
+-----------
+Return the anonymous user ID.
+
+Examples
+--------
+```tcl
+
+% anonymous_user_id
+-1
+
+```
+
+----------------------------------
+*[Qcode Software Limited] [qcode]*
+
+[qcode]: http://www.qcode.co.uk "Qcode Software"

--- a/tcl/session.tcl
+++ b/tcl/session.tcl
@@ -116,3 +116,29 @@ proc qc::session_id {} {
     return -code error "No known session_id"
 }
 
+proc qc::anonymous_session_id {} {
+    #| Return the anonymous session ID.
+    set user_id [qc::anonymous_user_id]
+    qc::db_0or1row {
+        SELECT session_id,(current_timestamp-time_created)>'1 hour'::interval as old 
+        FROM session
+        WHERE user_id=:user_id
+        order by time_created DESC LIMIT 1
+    } {
+        # No session found
+        return [qc::session_new $user_id] 
+    } {
+        # Session found
+        if { $old } {
+            return [qc::session_new $user_id] 
+        } else {
+            return $session_id
+        }
+    }
+}
+
+proc qc::anonymous_user_id {} {
+    #| Return the anonymous session ID.
+    return -1
+}
+

--- a/tcl/session.tcl
+++ b/tcl/session.tcl
@@ -1,5 +1,5 @@
 namespace eval qc {
-    namespace export session_*
+    namespace export session_* anonymous_session_id anonymous_user_id
 }
 
 package require uuid
@@ -138,7 +138,7 @@ proc qc::anonymous_session_id {} {
 }
 
 proc qc::anonymous_user_id {} {
-    #| Return the anonymous session ID.
+    #| Return the anonymous user ID.
     return -1
 }
 


### PR DESCRIPTION
While reviewing documentation and what was left to cover I discovered that `anonymous_session_id` and `anonymous_user_id` hadn't been migrated yet.

Migrated the procs and added documentation.

Checklist
----
- [x] Does each proc have a #| comment to describe what it does ?
- [x] Are there comments throughout the code ?
- [x] Is each proc unit testable ?
- [x] Are the proc names well chosen ?
- [x] Are variable names well chosen ?
- [x] List what testing has been done.
  - Tested on dev blog to make sure everything still worked