### PR TITLE
qc::cast safe_html no longer casts to xml

### DIFF
--- a/doc/procs/cast-safe_html.md
+++ b/doc/procs/cast-safe_html.md
@@ -17,16 +17,12 @@ Examples
 --------
 ```tcl
 
-% qc::cast safe_html "Hello World"
-<root>Hello World</root>
+% qc::cast safe_html {<a href="http://www.qcode.co.uk">Hello World</a>}
+<a href="http://www.qcode.co.uk">Hello World</a>
 
 % qc::cast safe_html {<div id="foo">Bar</div>}
-<root>
-    <div>Bar</div>
-</root>
+Can't cast "<div id="foo">Bar</div>...": not safe html.
 
-% qc::cast safe_html {Foo <script>alert('Hello World');</script>}
-<root>Foo </root>
 ```
 
 ----------------------------------

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -418,15 +418,11 @@ namespace eval qc::cast {
 
     proc safe_html {text} {
         #| Cast text to safe html.
-        set safe_html [qc::html_sanitize $text]
-        if {! [regexp {^<root>(.+)</root>$} $text]} {
-            # Wrap the text with a root node so that it can be stored in the database as XML.
-            set safe_html [qc::h root $safe_html]
+        if { [qc::is safe_html $text] } {
+            return $text
+        } else {
+            return -code error -errorcode CAST "Can't cast \"[qc::trunc $text 100]...\": not safe html."
         }
-        set doc [dom parse -html $safe_html]
-        set xml [$doc asXML -escapeNonASCII]
-        $doc delete
-        return $xml
     }
 
     proc safe_markdown {text} {


### PR DESCRIPTION
This change is to fix a bug that makes safe HTML unsafe due to casting to XML. One particular instance was that casting to XML causes tags with no content between them to be void elements i.e. self-closing when they aren't supposed to be. This can cause problems of HTML breaking out of its container when used in particular cases.

For example:

```
% set html {<a href="test"></a>}
<a href="test"></a>
% qc::cast safe_html $html
<a href="test" />
```
The `a` tag is not a void element so shouldn't self-close as per w3 documentation: http://www.w3.org/TR/html-markup/syntax.html#syntax-elements

Checklist
------------

### Tcl
- [x] List what testing has been done.
  - Testing done as changed in documentation plus a few other invalid and valid HTML snippets. All passed OK.