### PR TITLE
Filter authenticate update

### DIFF
--- a/tcl/auth.tcl
+++ b/tcl/auth.tcl
@@ -15,8 +15,9 @@ proc qc::auth {} {
     if { [qc::cookie_exists session_id] } {
         set session_id [cookie_get session_id]
         if { [qc::session_exists $session_id] } {
+            set current_user_id [qc::auth_session $session_id]
             qc::session_update $session_id
-            return [set current_user_id [qc::auth_session $session_id]]
+            return $current_user_id
         }
     }
     
@@ -72,7 +73,7 @@ proc qc::auth_hba_check {} {
     } 
 }
 
-proc qc::auth_session { session_id } {
+proc qc::auth_session { session_id} {
     #| Try to authenticate user based on the session_id given
     #| Return the user_id if successful
     #| On failure throw AUTH error

--- a/tcl/auth.tcl
+++ b/tcl/auth.tcl
@@ -14,7 +14,7 @@ proc qc::auth {} {
     # Try session based auth
     if { [qc::cookie_exists session_id] } {
         set session_id [cookie_get session_id]
-        if { [qc::session_valid $session_id] } {
+        if { [qc::session_exists $session_id] } {
             qc::session_update $session_id
             return [set current_user_id [qc::auth_session $session_id]]
         }
@@ -34,7 +34,7 @@ proc qc::auth_check {} {
     # session based auth
     if { [qc::cookie_exists session_id]} {
 	set session_id [cookie_get session_id]
-	if { [qc::session_valid $session_id] } {
+	if { [qc::session_exists $session_id] } {
 	    return true
 	}
     }
@@ -76,7 +76,7 @@ proc qc::auth_session { session_id } {
     #| Try to authenticate user based on the session_id given
     #| Return the user_id if successful
     #| On failure throw AUTH error
-    if { [session_exists $session_id] } {
+    if { [session_valid $session_id] } {
         return [session_user_id $session_id]
     } else {
 	error "Session authentication failed to identify you." {} AUTH

--- a/tcl/auth.tcl
+++ b/tcl/auth.tcl
@@ -14,7 +14,7 @@ proc qc::auth {} {
     # Try session based auth
     if { [qc::cookie_exists session_id] } {
         set session_id [cookie_get session_id]
-        if { [qc::session_exists $session_id] } {
+        if { [qc::session_valid $session_id] } {
             qc::session_update $session_id
             return [set current_user_id [qc::auth_session $session_id]]
         }
@@ -34,7 +34,7 @@ proc qc::auth_check {} {
     # session based auth
     if { [qc::cookie_exists session_id]} {
 	set session_id [cookie_get session_id]
-	if { [qc::session_exists $session_id] } {
+	if { [qc::session_valid $session_id] } {
 	    return true
 	}
     }

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -50,13 +50,10 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
         # Check if this request is registered.
         if { [qc::registered $method $url_path] } {
             if {[qc::cookie_exists session_id] && [qc::session_valid [qc::session_id]]} {
-                global session_id current_user_id
-                qc::session_update $session_id
-                set current_user_id [qc::session_user_id $session_id]
+                qc::session_update [qc::session_id]
             } elseif {$method ni [list "GET" "HEAD"] && [qc::cookie_exists session_id] && ! [qc::session_valid [qc::session_id]]} {
-                global session_id
                 # User is trying to POST with an invalid session
-                if {[qc::session_exists $session_id] && [qc::session_user_id $session_id] != -1} {
+                if {[qc::session_exists [qc::session_id]] && [qc::session_user_id [qc::session_id]] != [qc::anonymous_user_id]} {
                     # Normal user - redirect to login page.
                     qc::response action redirect "/user/login"
                     qc::return_response
@@ -66,8 +63,7 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
                 }
             } else {
                 # Implicitly log in as anonymous user.
-                global current_user_id session_id
-                set current_user_id [qc::anonymous_user_id]
+                global session_id
                 set session_id [qc::anonymous_session_id]
                 qc::cookie_set session_id $session_id
             }

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -50,10 +50,13 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
         # Check if this request is registered.
         if { [qc::registered $method $url_path] } {
             if {[qc::cookie_exists session_id] && [qc::session_valid [qc::session_id]]} {
-                qc::session_update [qc::session_id]
+                global session_id current_user_id
+                qc::session_update $session_id
+                set current_user_id [qc::session_user_id $session_id]
             } elseif {$method ni [list "GET" "HEAD"] && [qc::cookie_exists session_id] && ! [qc::session_valid [qc::session_id]]} {
+                global session_id
                 # User is trying to POST with an invalid session
-                if {[qc::session_exists [qc::session_id]] && [qc::session_user_id [qc::session_id]] != -1} {
+                if {[qc::session_exists $session_id] && [qc::session_user_id $session_id] != -1} {
                     # Normal user - redirect to login page.
                     qc::response action redirect "/user/login"
                     qc::return_response
@@ -84,7 +87,7 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
             
             # Roll the anonymous session after 1 hour.
             if {[qc::auth] == [qc::anonymous_user_id]} {
-                qc::cookie_set session_id [qc::anonymous_session_id]
+                qc::cookie_set session_id $session_id
             }
         }
     } on error [list error_message options] {

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -87,6 +87,8 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
             
             # Roll the anonymous session after 1 hour.
             if {[qc::auth] == [qc::anonymous_user_id]} {
+                global session_id
+                set session_id [qc::anonymous_session_id]
                 qc::cookie_set session_id $session_id
             }
         }

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -82,7 +82,7 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
             }
             
             # Roll the anonymous session after 1 hour.
-            if {[qc::auth] == [qc::anonymous_user_id]} {
+            if {[qc::session_user_id [qc::session_id]] == [qc::anonymous_user_id]} {
                 global session_id
                 set session_id [qc::anonymous_session_id]
                 qc::cookie_set session_id $session_id

--- a/tcl/session.tcl
+++ b/tcl/session.tcl
@@ -68,7 +68,20 @@ proc qc::session_exists {session_id} {
 
 proc qc::session_valid {args} {
     #| Check session exists and has not expired.
-    qc::args $args -age_limit "12 hours" -idle_timeout "1 hour" -- session_id
+    qc::args $args -age_limit ? -idle_timeout "1 hour" -- session_id
+    
+    # Check config parameters for session age limit and idle timeout.
+    if { [qc::param_exists session_age_limit] } {
+        default age_limit [qc::param_get session_age_limit]
+    } else {
+        default age_limit "12 hours"
+    }
+    if { [qc::param_exists session_idle_timeout] } {
+        default idle_timeout [qc::param_get session_idle_timeout]
+    } else {
+        default idle_timeout "1 hour"
+    }
+    
     set qry {
 	select
 	user_id


### PR DESCRIPTION
The current user ID was not being set up if the session was recognised as valid. Changed to set the current user ID.

`qc::auth_session` changed to check validity of session rather than existence.

#### Checklist
----
- [x] Are variable names well chosen ?
- [x] List what testing has been done.
  - Tested change on blog project. All working as expected.
