### PR TITLE
filter_authenticate bugfix

### DIFF
--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -63,7 +63,8 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
                 }
             } else {
                 # Implicitly log in as anonymous user.
-                global session_id
+                global session_id current_user_id
+                set current_user_id [qc::anonymous_user_id]
                 set session_id [qc::anonymous_session_id]
                 qc::cookie_set session_id $session_id
             }
@@ -82,7 +83,7 @@ proc qc::filter_authenticate {event {error_handler qc::error_handler}} {
             }
             
             # Roll the anonymous session after 1 hour.
-            if {[qc::session_user_id [qc::session_id]] == [qc::anonymous_user_id]} {
+            if {[qc::auth] == [qc::anonymous_user_id]} {
                 global session_id
                 set session_id [qc::anonymous_session_id]
                 qc::cookie_set session_id $session_id


### PR DESCRIPTION
Noticed a bug under certain circumstances whereby `qc::auth` would fail if the user session was invalid. The anonymous session ID is set if the session was invalid however `qc::auth` grabs the session ID from the cookie which is the old invalid one because the user agent hasn't yet been told to update the cookie.

Setting the current user ID on anonymous login fixes this. An alternative would be to have `qc::auth` check the global session ID first.