### PR TITLE
Use column instead of name for returned record response.

### DIFF
--- a/tcl/validate.tcl
+++ b/tcl/validate.tcl
@@ -16,11 +16,11 @@ proc qc::validate2model {dict} {
         
         # Check if nullable
         if {! $nullable && $value eq ""} {
-            qc::response record invalid $name $value $message
+            qc::response record invalid $column $value $message
             set all_valid false
             continue
         } elseif {$nullable && $value eq ""} {
-            qc::response record valid $name $value ""
+            qc::response record valid $column $value ""
             continue
         }
         # Check value against data type
@@ -33,10 +33,10 @@ proc qc::validate2model {dict} {
         # Check constraints
         set constraint_results [qc::db_eval_column_constraints $table $column $dict]
         if {! $type_check || ([llength $constraint_results] > 0 && ! [expr [join [dict values $constraint_results] " && "]]) } {
-            qc::response record invalid $name $value $message
+            qc::response record invalid $column $value $message
             set all_valid false
         } elseif {$type_check} {
-            qc::response record valid $name [qc::cast $data_type $value] ""
+            qc::response record valid $column [qc::cast $data_type $value] ""
         }
     }
 


### PR DESCRIPTION
`$name` is the name of the argument for the handler that may or may not be fully qualified i.e. `table.column` or `column`. The record was returned with the potentially fully qualified name of the argument which does not match up with the form elements and therefore was causing troubles with the validation plugin because it cannot select the input elements with a fully qualified name. The response should just return the column portion of a fully qualified name and this change fixes that.

The alternative is to have the validation plugin check if the name is fully qualified and split name by the separator `.`.