### PR TITLE
strip leading zeros

### DIFF
--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -301,6 +301,9 @@ namespace eval qc::cast {
         #| Try to cast given string into a decimal value with the given precision and/or scale if present.
         qc::args $args -precision ? -scale ? -- string
         set original $string
+        # Strip leading zeros if followed by digit
+        # This copes with 0 and 00
+        regsub {^(-?)0+([0-9].*)$} $string {\1\2} string
         set string [string map {, {} % {}} $string]
         if { [string is double -strict $string] } {
             if { ! [info exists scale] && ! [info exists precision] } {


### PR DESCRIPTION
This is to make the following calls have the same result:

```
$ cast decimal 001
001.123
$ cast decimal -precision 10 001
1
```

After this change leading zeros will be stripped out and both will return ```1```