### PR TITLE
Set status to invalid when record invalid called.

### DIFF
--- a/tcl/response.tcl
+++ b/tcl/response.tcl
@@ -52,10 +52,12 @@ namespace eval qc::response {
 
         proc invalid {name value message} {
             #| Adds the given field to the record as invalid. If the field already exists then updates it.
+            #| Also sets the status of the response to invalid.
             global data
             dict set data record $name valid false
             dict set data record $name value $value
             dict set data record $name message $message
+            qc::response status invalid
         }
 
         proc remove {name} {


### PR DESCRIPTION
Checklist
----
- [x] Does each proc have a #| comment to describe what it does ?
- [x] List what testing has been done.
  - Setting record item invalid and checking the global variable `data` for `status` being present and set to `invalid`:
```tcl
> set data
set data
can't read "data": no such variable

> qc::response record invalid test "Foo" "Foo is invalid."
qc::response record invalid test "Foo" "Foo is invalid."
record {test {valid false value Foo message {Foo was invalid.}}} status invalid

> qc::data2json
qc::data2json
{
"status": "invalid",
"record": {
"test": {
"valid": false,
"value": "Foo",
"message": "Foo is invalid."
}
},
"message": {

},
"action": {

}
}
```