### PR TITLE
no-auth flag added

### DIFF
--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -47,8 +47,8 @@ proc qc::filter_authenticate {event args} {
     set method [string toupper [qc::conn_method]]
     ::try {
       
-        # Check if this request is registered.
-        if { [qc::registered $method $url_path] } {
+        # Check if this request is registered for authentication
+        if { [qc::registered authenticate $method $url_path] } {
             if { ![qc::cookie_exists session_id] || ![qc::session_exists [qc::session_id]] } {
                 # No session cookie or session doesn't exist - implicitly log in as anonymous user.
                 global session_id current_user_id


### PR DESCRIPTION
# Checklist
- [x] Are there comments throughout the code ?
- [x] Are variable names well chosen ?
- [x] List what testing has been done.
  - Ensure that registering works as before and also registers for authentication.
  - Test `qc::registered` update too.
    ```tcl
    > qc::register GET /foo
    
    > qc::registered GET /foo
    true
    
    > qc::registered authenticate GET /foo
    true
    ```
  - Register method path without authentication
    ```
    > qc::register -no-auth GET /foo
    
    > qc::registered GET /foo
    true
    
    > qc::registered authenticate GET /foo
    false
    ```
  - Register a couple of paths. Update one to exempt it from authentication. Check that others are unaffected. 

    ```
    > qc::register GET /foo
    
    > qc::registered GET /foo
    true

    > qc::registered authenticate GET /foo
    true
    
    > qc::register GET /bar
    
    > qc::registered GET /bar
    true

    > qc::registered authenticate GET /bar
    true
    
    # Update GET /bar to be exempt from authentication
    > qc::register -no-auth GET /bar
    
    > qc::registered GET /bar
    true

    > qc::registered authenticate GET /bar
    false
    
    # Check others remain unaffected
    > qc::registered authenticate GET /foo
    true
    ```
  - Tested on MLA DEV with WWW admin login authenticating against ERP. 

    ```
    # On ERP
    register -no-auth POST /www_login.json {user_code password} {
        #| Login authenticator for website admin
        ...
    }
    ```