### PR TITLE
Make "qc::handlers validation data" consistent with "qc::handlers data"

### DIFF
--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -176,6 +176,7 @@ namespace eval qc::handlers {
             #| Returns a dictionary of args for the handler identified by $method $pattern.
             set method [string toupper $method]
             set args [args $method $pattern]
+            set unambiguous [qc::args_unambiguous {*}$args]
             set result {}
             foreach arg $args {
                 # Check if a form variable exists for $arg

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -178,17 +178,27 @@ namespace eval qc::handlers {
             set args [args $method $pattern]
             set result {}
             foreach arg $args {
+                # Check if a form variable exists for $arg
                 if { [dict exists $form $arg] } {
                     lappend result $arg [dict get $form $arg]
-                } elseif { [regexp {^[^.]+\.([^.]+)$} $arg -> column] && [dict exists $form $column] } {
-                    # e.g. use form variable "firstname" for arg "users.firstname"
-                    lappend result $arg [dict get $form $column]
-                } elseif { [default_exists $method $pattern $arg] } {
-                    lappend result $arg [default $method $pattern $arg]
-                } else {
-                    # arg wasn't optional and didn't appear in form
-                    return -code error "No matching arg value for \"$arg\" in form." 
+                    continue
                 }
+
+                # Check if shortname of $arg is unambiguous and exists as a form variable
+                set shortname [qc::arg_shortname $arg]
+                if { [llength [lsearch -all $unambiguous $arg]] && [dict exists $form $shortname] } {
+                    lappend result $arg [dict get $form $shortname]
+                    continue
+                }
+
+                # Check if default value exists for $arg
+                if { [default_exists $method $pattern $arg] } {
+                    lappend result $arg [default $method $pattern $arg]
+                    continue
+                }
+                
+                # arg wasn't optional and didn't appear in form
+                return -code error "No matching arg value for \"$arg\" in form." 
             }
             return $result
         }

--- a/tcl/response.tcl
+++ b/tcl/response.tcl
@@ -42,7 +42,7 @@ namespace eval qc::response {
         namespace export invalid valid remove all_valid
         namespace ensemble create
 
-        proc valid {name value message} {
+        proc valid {name value {message ""}} {
             #| Adds the given field to the record as valid. If the field already exists then updates it.
             global data
             dict set data record $name valid true

--- a/tcl/validate.tcl
+++ b/tcl/validate.tcl
@@ -20,7 +20,7 @@ proc qc::validate2model {dict} {
             set all_valid false
             continue
         } elseif {$nullable && $value eq ""} {
-            qc::response record valid $column $value ""
+            qc::response record valid $column $value
             continue
         }
         # Check value against data type
@@ -36,7 +36,7 @@ proc qc::validate2model {dict} {
             qc::response record invalid $column $value $message
             set all_valid false
         } elseif {$type_check} {
-            qc::response record valid $column [qc::cast $data_type $value] ""
+            qc::response record valid $column [qc::cast $data_type $value]
         }
     }
 


### PR DESCRIPTION
* Makes `qc::handlers validation data` consistent with `qc::handlers data` through use of new proc `qc::args_unambiguous`.
* Makes `message` arg for `qc::response record valid` optional.

Tested with new/update sales order in MLA ERP .