### PR TITLE
Single colon for port

### DIFF
--- a/tcl/url.tcl
+++ b/tcl/url.tcl
@@ -279,7 +279,7 @@ proc qc::url_make {dict} {
     #     params {tags tcl tags psql author peter}
     #     hash comments
     # }
-    # => https://qcode.co.uk::80/posts/123/hello+world?tags=tcl&tags=psql&author=peter#comments
+    # => https://qcode.co.uk:80/posts/123/hello+world?tags=tcl&tags=psql&author=peter#comments
     # all keys are optional, but if protocol, domain, and/or port are specified,
     #   protocol and domain must be specified)
     # "segments" is a list
@@ -287,7 +287,7 @@ proc qc::url_make {dict} {
     # If segments is specified (even as an empty list), the url path will be absolute
     dict2vars $dict protocol domain port segments params hash
 
-    # Construct url root (eg. http://qcode.co.uk::80).
+    # Construct url root (eg. http://qcode.co.uk:80).
     if {
         ([info exists protocol] && $protocol ne "")
         || ([info exists domain] && $domain ne "")
@@ -309,7 +309,7 @@ proc qc::url_make {dict} {
             if { ! [regexp {[0-9]+} $port] } {
                 error "Invalid url port $port"
             }
-            set root "${protocol}://${domain}::${port}"
+            set root "${protocol}://${domain}:${port}"
         } else {
             set root "${protocol}://${domain}"
         }
@@ -361,15 +361,15 @@ proc qc::url_make {dict} {
 
 proc qc::url_maker {args} {
     #| Construct or modifiy an url
-    # Usage url_maker [$base] [:: $port] [/ [segment ...]] [? [param_name param_value ...]] [# [hash]]
+    # Usage url_maker [$base] [: $port] [/ [segment ...]] [? [param_name param_value ...]] [# [hash]]
     qc::args $args -multimap_form_vars -- args
     default multimap_form_vars false
-    set usage_error {Usage: url_maker [$base [:: $port]] [/ [segment ...]] [? [param_name param_value ...]] [# [hash]] }
+    set usage_error {Usage: url_maker [$base [: $port]] [/ [segment ...]] [? [param_name param_value ...]] [# [hash]] }
     set url_dict [dict create]
     set section "base"
     set sections [list "base" "port" "segments" "params" "hash"]
     set delimiters {
-        "::" "port"
+        ":" "port"
         "/" "segments"
         "?" "params"
         "#" "hash"

--- a/test/url.test
+++ b/test/url.test
@@ -303,7 +303,7 @@ namespace eval ::qcode::test {
             }
             hash "comments"
         }
-    } -result "https://qcode.co.uk::80/post/123?tags=tcl&tags=psql&author=peter#comments"
+    } -result "https://qcode.co.uk:80/post/123?tags=tcl&tags=psql&author=peter#comments"
 
     test url_make-1.1 {url_make hash only} -body {
         url_make {
@@ -336,7 +336,7 @@ namespace eval ::qcode::test {
             domain "qcode.co.uk"
             port 80
         }
-    } -result "https://qcode.co.uk::80"
+    } -result "https://qcode.co.uk:80"
 
     # url_maker
     test url_maker-1.0 {url_maker base only} -body {
@@ -344,8 +344,8 @@ namespace eval ::qcode::test {
     } -result "https://qcode.co.uk/"
 
     test url_maker-1.1 {url_maker base and port} -body {
-        url_maker "https://qcode.co.uk" :: "80"
-    } -result "https://qcode.co.uk::80/"
+        url_maker "https://qcode.co.uk" : "80"
+    } -result "https://qcode.co.uk:80/"
 
     test url_maker-1.2 {url_maker slash only} -body {
         url_maker /


### PR DESCRIPTION
@PeterChaplin Looks like you were using double colon for the port delimiter when it should be just a single colon. Think I've caught them all but could you have a look over to make sure?