### PR TITLE
Match 1 and only 1 proc

### DIFF
--- a/tcl/conn.tcl
+++ b/tcl/conn.tcl
@@ -31,7 +31,7 @@ proc qc::conn_marshal { {error_handler qc::error_handler} {namespace ""} } {
     set url_path [qc::conn_path]
     set file [ns_url2file $url_path]
     
-    if { [llength [info procs "${namespace}::${url_path}"]] } {
+    if { [info procs "${namespace}::${url_path}"] eq "${namespace}::${url_path}" } {
 	qc::try {
 	    set result [form_proc "${namespace}::${url_path}"]
 	    if { ![expr 0x1 & [ns_conn flags]] } {


### PR DESCRIPTION
For discussion.

If a wildcard character is passed in as part of the URL (and returned by ```qc::conn_path```), ```info procs``` behaves like ```string match``` and will return any matching proc.

So, ```info procs ::namespace::/*``` will return all procs defined in ```::namespace``` then will proceed to reference the wildcard as if ```::namespace::/*``` is the name of a proc.

I think it should only proceed if ```info procs``` returns exactly the name of the proc supplied, no more, no less.