### PR TITLE
bugfix

### DIFF
--- a/tcl/email.tcl
+++ b/tcl/email.tcl
@@ -34,7 +34,7 @@ proc qc::email_send {args} {
     # From
     lappend headers From $from
     # To
-    set rcpt [list]
+    set rcpts [list]
     foreach address [qc::email_addresses $to] {
 	lappend rcpts $address
     }


### PR DESCRIPTION
From the support account:

```
hostname:polaris.mlaccessories.co.uk
time:2015‑11‑17 12:37:47
errorMessage: can't read "rcpts": no such variable 
errorInfo:

can't read "rcpts": no such variable
    while executing
"qc::sendmail $mail_from $rcpts $mime_body {*}$headers"
    (procedure "qc::email_send" line 128)
    invoked from within
"qc::email_send from [qc::param_get email_accounts] to $email_address subject "MLA - Invoice $sales_invoice_no" html $email_html attachments $attachmen..."
    (procedure "mla_sales_invoice_report_email_send" line 34)
    invoked from within
"mla_sales_invoice_report_email_send $invoice_email $sales_invoice_id"
    ("::try" body line 4)

errorCode: NONE
```

Before this fix `rcpts` only fails to exist if there are no recipients. Should we check if that's the case in this proc or rely upon the caller passing in sensible data?