### PR TITLE
Revert "Allow qc::url to pick up local vars"

### DIFF
--- a/tcl/url.tcl
+++ b/tcl/url.tcl
@@ -26,20 +26,15 @@ proc qc::url { url args } {
             # check if caller has provided a substitution for the segment
             if { [dict exists $dict $segment] } {
                 set value [dict get $dict $segment]
-
-            } elseif { [uplevel info exists $segment] } {
-                set value [uplevel set $segment]
-
+                if { [string index $value 0] eq ":" } {
+                    return -code error "The substitute value \"$value\" for colon variable \"$segment\" begins with a colon."
+                }
+                lappend substituted_segments $value
+                # remove the dict entry so that it isn't reused
+                set dict [dict remove $dict $segment]
             } else {
-                return -code error "Key \"$segment\" not found in args or local vars."
+                return -code error "Key \"$segment\" not found in args."
             }
-            if { [string index $value 0] eq ":" } {
-                return -code error "The substitute value \"$value\" for colon variable \"$segment\" begins with a colon."
-            }
-            lappend substituted_segments $value
-            # remove the dict entry so that it isn't reused
-            set dict [dict remove $dict $segment]
-
         } else {
             lappend substituted_segments $segment
         }
@@ -51,19 +46,15 @@ proc qc::url { url args } {
         set temp [string range $hash 1 end]
         if { [dict exists $dict $temp] } {
             set value [dict get $dict $temp]
-
-        } elseif { [uplevel info exists $temp] } {
-            set value [uplevel set $temp]
-
+            if { [string index $value 0] eq ":" } {
+                return -code error "The substitute value \"$value\" for colon variable \"$temp\" begins with a colon."
+            }
+            set hash $value
+            # remove the dict entry so that it isn't reused
+            set dict [dict remove $dict $temp]
         } else {
-            return -code error "Key \"$temp\" not found in args or local vars."
+            return -code error "Key \"$temp\" not found in args."
         }
-        if { [string index $value 0] eq ":" } {
-            return -code error "The substitute value \"$value\" for colon variable \"$temp\" begins with a colon."
-        }
-        set hash $value
-        # remove the dict entry so that it isn't reused
-        set dict [dict remove $dict $temp]
     }
 
     # rest of args are form vars

--- a/test/url.test
+++ b/test/url.test
@@ -150,11 +150,11 @@ namespace eval ::qcode::test {
 
     test url-1.12 {url colon segment no var} -body {
         url /:path foo 123 bar 456
-    } -cleanup {} -returnCodes {error} -result {Key "path" not found in args or local vars.}
+    } -cleanup {} -returnCodes {error} -result {Key "path" not found in args.}
 
     test url-1.13 {url colon fragment no var} -body {
         url "https://www.qcode.co.uk/path#:hash" foo 123 bar 456
-    } -cleanup {} -returnCodes {error} -result {Key "hash" not found in args or local vars.}
+    } -cleanup {} -returnCodes {error} -result {Key "hash" not found in args.}
 
     test url-1.14 {url colon var segment begins with colon} -body {
         url /:path path :123
@@ -163,26 +163,6 @@ namespace eval ::qcode::test {
     test url-1.15 {url colon var fragment begins with colon} -body {
         url /path#:hash hash :abc
     } -cleanup {} -returnCodes {error} -result {The substitute value ":abc" for colon variable "hash" begins with a colon.}
-
-    test url-1.16 {url colon var from local} -body {
-        set id 123
-        url /product/:id
-    } -cleanup {} -result {/product/123}
-
-    test url-1.17 {url colon var with local} -body {
-        set id 123
-        url /product/:id id 456
-    } -cleanup {} -result {/product/456}
-
-    test url-1.18 {url colon hash var from local} -body {
-        set id 123
-        url /product#:id
-    } -cleanup {} -result {/product#123}
-
-    test url-1.19 {url colon hash var with local} -body {
-        set id 123
-        url /product#:id id 456
-    } -cleanup {} -result {/product#456}
     
     # url_match
     test url_match-1.0 {url_match identical urls} -body {


### PR DESCRIPTION
Reverts qcode-software/qcode-tcl#297

Introduces an url injection attack.