### PR TITLE
Fix for ID and Class Matching

### DIFF
--- a/tcl/db_init.tcl
+++ b/tcl/db_init.tcl
@@ -1,3 +1,7 @@
+namespace eval qc {
+    namespace export db_init
+}
+
 proc qc::db_init {} {
     #| Initialises the database objects required by qcode-tcl
 

--- a/tcl/html.tcl
+++ b/tcl/html.tcl
@@ -211,58 +211,65 @@ proc qc::html_info_tables {args} {
     return [qc::html_table class "columns-container" tbody [list $row]]
 }
 
-proc qc::html_styles2inline {html} {
+proc qc::html_styles2inline {args} {
     #| Applies defined styles in html head as inline styles for relevant elements in body
+    qc::args $args -version 2 -- html
     set styles [regexp -all -inline {<style[^>]*>[^<]*</style>} $html]
     #regsub -all {<style[^>]*>([^<]*)</style>} $html {} html
     foreach style $styles {
 	regexp {<style[^>]*>([^<]*)</style>} $style -> style
-	set html [qc::html_style2inline $html $style]
+	set html [qc::html_style2inline -version $version $html $style]
     }
     return $html
 }
 
-proc qc::html_style2inline {html style} {
+proc qc::html_style2inline {args} {
     #| Helper proc for qc::html_styles2inline
+    qc::args $args -version 2 -- html style
     set data [qc::css_parse $style]
     package require tdom
     dom parse -html $html doc
     foreach {selector styles} $data {
       	set nodes {}
-	set xpath ""
-	foreach part $selector {
-	    if { [regexp {^[a-zA-Z][a-zA-Z0-9]*$} $part] } {
-		# HTML element
-		append xpath //$part
-	    }  elseif { [regexp {^\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> classes] } {
-		# .class.other-class selector
-		append xpath //*
-                foreach class [split $classes "."] {
-                    append xpath \[contains(@class,\"$class\")\]
+        if { $version == 1 } {
+            # Version 1 deprecated because of XPath "contains" function partially matching IDs and classes
+            set xpath ""
+            foreach part $selector {
+                if { [regexp {^[a-zA-Z][a-zA-Z0-9]*$} $part] } {
+                    # HTML element
+                    append xpath //$part
+                }  elseif { [regexp {^\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> classes] } {
+                    # .class.other-class selector
+                    append xpath //*
+                    foreach class [split $classes "."] {
+                        append xpath \[contains(@class,\"$class\")\]
+                    }
+                }  elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*)\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> tag classes] } {
+                    # tag.class.other-class selector
+                    append xpath //$tag
+                    foreach class [split $classes "."] {
+                        append xpath \[contains(@class,\"$class\")\]
+                    }
+                } elseif { [regexp {^#([a-zA-Z][a-zA-Z0-9\-\_]*)$} $part -> id] } {
+                    # #id selector
+                    append xpath //*\[contains(@id,\"$id\")\]
+                } elseif { [regexp {^#([a-zA-Z][a-zA-Z0-9\-\_]*)\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> id classes] } {
+                    # #id.class.otherclass selector
+                    append xpath //*\[contains(@id,\"$id\")\]
+                    foreach class [split $classes "."] {
+                        append xpath \[contains(@class,\"$class\")\]
+                    }
+                } elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*)#([a-zA-Z][a-zA-Z0-9\-\_]*)$} $part -> tag id] } {
+                    # tag#id selector
+                    append xpath //$tag\[contains(@id,\"$id\")\]
+                } elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*):nth-child\(([0-9]+)\)$} $part -> tag nth_child] } {
+                    # tag:nth-child() selector
+                    append xpath //$tag\[position()=$nth_child\]
                 }
-	    }  elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*)\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> tag classes] } {
-		# tag.class.other-class selector
-		append xpath //$tag
-                foreach class [split $classes "."] {
-                    append xpath \[contains(@class,\"$class\")\]
-                }
-	    } elseif { [regexp {^#([a-zA-Z][a-zA-Z0-9\-\_]*)$} $part -> id] } {
-		# #id selector
-                append xpath //*\[contains(@id,\"$id\")\]
-	    } elseif { [regexp {^#([a-zA-Z][a-zA-Z0-9\-\_]*)\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> id classes] } {
-		# #id.class.otherclass selector
-                append xpath //*\[contains(@id,\"$id\")\]
-                foreach class [split $classes "."] {
-                    append xpath \[contains(@class,\"$class\")\]
-                }
-	    } elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*)#([a-zA-Z][a-zA-Z0-9\-\_]*)$} $part -> tag id] } {
-		# tag#id selector
-		append xpath //$tag\[contains(@id,\"$id\")\]
-	    } elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*):nth-child\(([0-9]+)\)$} $part -> tag nth_child] } {
-		# tag:nth-child() selector
-		append xpath //$tag\[position()=$nth_child\]
-	    }
-	}
+            }
+        } else {
+            set xpath [qc::css_selector2xpath $selector]
+        }
         set nodes [$doc selectNodes $xpath]
 
 	foreach node $nodes {

--- a/tcl/html.tcl
+++ b/tcl/html.tcl
@@ -211,65 +211,24 @@ proc qc::html_info_tables {args} {
     return [qc::html_table class "columns-container" tbody [list $row]]
 }
 
-proc qc::html_styles2inline {args} {
+proc qc::html_styles2inline {html} {
     #| Applies defined styles in html head as inline styles for relevant elements in body
-    qc::args $args -version 2 -- html
     set styles [regexp -all -inline {<style[^>]*>[^<]*</style>} $html]
     #regsub -all {<style[^>]*>([^<]*)</style>} $html {} html
     foreach style $styles {
 	regexp {<style[^>]*>([^<]*)</style>} $style -> style
-	set html [qc::html_style2inline -version $version $html $style]
+	set html [qc::html_style2inline $html $style]
     }
     return $html
 }
 
-proc qc::html_style2inline {args} {
+proc qc::html_style2inline {html style} {
     #| Helper proc for qc::html_styles2inline
-    qc::args $args -version 2 -- html style
     set data [qc::css_parse $style]
     package require tdom
     dom parse -html $html doc
     foreach {selector styles} $data {
-      	set nodes {}
-        if { $version == 1 } {
-            # Version 1 deprecated because of XPath "contains" function partially matching IDs and classes
-            set xpath ""
-            foreach part $selector {
-                if { [regexp {^[a-zA-Z][a-zA-Z0-9]*$} $part] } {
-                    # HTML element
-                    append xpath //$part
-                }  elseif { [regexp {^\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> classes] } {
-                    # .class.other-class selector
-                    append xpath //*
-                    foreach class [split $classes "."] {
-                        append xpath \[contains(@class,\"$class\")\]
-                    }
-                }  elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*)\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> tag classes] } {
-                    # tag.class.other-class selector
-                    append xpath //$tag
-                    foreach class [split $classes "."] {
-                        append xpath \[contains(@class,\"$class\")\]
-                    }
-                } elseif { [regexp {^#([a-zA-Z][a-zA-Z0-9\-\_]*)$} $part -> id] } {
-                    # #id selector
-                    append xpath //*\[contains(@id,\"$id\")\]
-                } elseif { [regexp {^#([a-zA-Z][a-zA-Z0-9\-\_]*)\.([a-zA-Z][a-zA-Z0-9\-]*(?:\.[a-zA-Z][a-zA-Z0-9\-]*)*)$} $part -> id classes] } {
-                    # #id.class.otherclass selector
-                    append xpath //*\[contains(@id,\"$id\")\]
-                    foreach class [split $classes "."] {
-                        append xpath \[contains(@class,\"$class\")\]
-                    }
-                } elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*)#([a-zA-Z][a-zA-Z0-9\-\_]*)$} $part -> tag id] } {
-                    # tag#id selector
-                    append xpath //$tag\[contains(@id,\"$id\")\]
-                } elseif { [regexp {^([a-zA-Z][a-zA-Z0-9]*):nth-child\(([0-9]+)\)$} $part -> tag nth_child] } {
-                    # tag:nth-child() selector
-                    append xpath //$tag\[position()=$nth_child\]
-                }
-            }
-        } else {
-            set xpath [qc::css_selector2xpath $selector]
-        }
+      	set xpath [qc::css_selector2xpath $selector]
         set nodes [$doc selectNodes $xpath]
 
 	foreach node $nodes {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -229,7 +229,7 @@ proc qc::is_uri_valid {uri} {
 
 namespace eval qc::is {
     
-    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri
+    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path
     namespace ensemble create -unknown {
         data_type_parser
     }

--- a/test/html.test
+++ b/test/html.test
@@ -171,6 +171,70 @@ namespace eval ::qcode::test {
 </body>
 </html>}
 
+    test html_styles2inline-1.2 {html_styles2inline ID Selector} -body {
+        html_styles2inline {
+            <html>
+                <head>
+                    <style type="text/css">
+                        #table_1 > * > tr > td:nth-child(1) {
+                            text-align:left;
+                        }
+                    </style>
+                </head>
+                <body>
+                    <table id="table_1">
+                        <tbody>
+                            <tr>
+                                <td>Table entry</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <table id="table_10">
+                        <tbody>
+                            <tr>
+                                <td>Table entry</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </body>
+            </html>
+        }
+    }  -result {<html>
+<head><style type="text/css">
+                        #table_1 > * > tr > td:nth-child(1) {
+                            text-align:left;
+                        }
+                    </style></head><body>
+<table id="table_1"><tbody><tr><td style="text-align:left">Table entry</td></tr></tbody></table><table id="table_10"><tbody><tr><td>Table entry</td></tr></tbody></table>
+</body>
+</html>}
+
+    test html_styles2inline-1.3 {html_styles2inline Class Selector} -body {
+        html_styles2inline {
+            <html>
+                <head>
+                    <style type="text/css">
+                        .flex {
+                            color:red;
+                        }
+                    </style>
+                </head>
+                <body>
+                    <p class="flex">Foo</p>
+                    <p class="flexi">Bar</p>
+                    <p class="flexible">Baz</p>
+                </body>
+            </html>
+        }
+    }  -result {<html>
+<head><style type="text/css">
+                        .flex {
+                            color:red;
+                        }
+                    </style></head><body>
+<p class="flex" style="color:red">Foo</p><p class="flexi">Bar</p><p class="flexible">Baz</p>
+</body>
+</html>}
 
     test html_col_styles_apply2td-1.0 {html_col_styles_apply2td } -body {
         html_col_styles_apply2td {


### PR DESCRIPTION
The xpath selectors for classes and IDs was using the `contains` function which will match anything that contains the given text. This is problematic in a lot of cases because CSS selectors do not work in this manner. The change made to use `css_selector2xpath` means that exact matching will be done on classes and IDs.

Tcl
----
- [x] Are there comments throughout the code ?
- [x] Is each proc unit testable ?
- [x] Are variable names well chosen ?
- [x] List what testing has been done.
  - Checked `css_selector2xpath` to ensure it would generate correct xpath for the required CSS selectors:
    - Elements
    - Classes `.class1.class2`
    - IDs `#ID`
    - Pseduo selectors `:nth-child(*)`
    - Combinations:
      - `element.class1.class2`
      - `#ID.class1.class2`
      - `element#ID`
      - `#ID > * > tr > td:nth-child(1)`
  - HTML tests
    - [x] ID exact match
    - [x] Class exact match
  - Ran `make test VERSION=6.46.1`

### ID Test

**Test HTML**
```tcl
set html {
  <html>
    <head>
      <style type="text/css">
        #table_1 > * > tr > td:nth-child(1) {
          text-align:left;
        }
      </style>
    </head>
    <body>
      <table id="table_1" >
        <thead>
          <th>Test</th>
        </thead>
        <tbody>
          <tr>
            <td>test</td>
          </tr>
        </tbody>
      </table>
      <table id="table_10" >
        <thead>
          <th>Test</th>
        </thead>
        <tbody>
          <tr>
            <td>test</td>
          </tr>
        </tbody>
      </table>
      <table id="table_100" >
        <thead>
          <th>Test</th>
        </thead>
        <tbody>
          <tr>
            <td>test</td>
          </tr>
        </tbody>
      </table>
    </body>
  </html>
}
```

**Old Output**
```
> qc::html_styles2inline -version 1 $html
<html>
  <head>
    <style type="text/css">
    #table_1 > * > tr > td:nth-child(1) {
      text-align:left;
    }
    </style>
  </head>
  <body>
    <table id="table_1">
      <thead>
        <th>Test</th>
      </thead>
      <tbody>
        <tr>
          <td style="text-align:left">test</td>
        </tr>
      </tbody>
    </table>
    <table id="table_10">
      <thead>
        <th>Test</th>
      </thead>
      <tbody>
        <tr>
          <td style="text-align:left">test</td>
        </tr>
      </tbody>
    </table>
    <table id="table_100">
      <thead>
        <th>Test</th>
      </thead>
      <tbody>
        <tr>
          <td style="text-align:left">test</td>
        </tr>
      </tbody>
    </table>
  </body>
</html>
```

**New Output**
```
> qc::html_styles2inline $html
<html>
  <head>
    <style type="text/css">
      #table_1 > * > tr > td:nth-child(1) {
        text-align:left;
      }
    </style>
  </head>
  <body>
    <table id="table_1">
      <thead>
        <th>Test</th>
      </thead>
      <tbody>
       <tr>
         <td style="text-align:left">test</td>
       </tr>
      </tbody>
    </table>
    <table id="table_10">
     <thead>
       <th>Test</th>
     </thead>
     <tbody>
      <tr>
        <td>test</td>
      </tr>
     </tbody>
    </table>
    <table id="table_100">
      <thead>
        <th>Test</th>
      </thead>
      <tbody>
        <tr>
          <td>test</td>
        </tr>
      </tbody>
    </table>
  </body>
</html>
```

### Class Test

**Test HTML**
```tcl
set html {
<html>
  <head>
    <style type="text/css">
      .flex {
        color:red;
      }
    </style>
  </head>
  <body>
    <p class="flex">Foo</p>
    <p class="flexible">Bar</p>
    <p class="flexi">Baz</p>
  </body>
</html>
}
```

**Old Output**
```
> qc::html_styles2inline -version 1 $html
<html>
  <head>
    <style type="text/css">
    .flex {
      color:red;
    }
    </style>
  </head>
  <body>
    <p class="flex" style="color:red">Foo</p>
    <p class="flexible" style="color:red">Bar</p>
    <p class="flexi" style="color:red">Baz</p>
  </body>
</html>
```

**New Output**
```
> qc::html_styles2inline $html
<html>
  <head>
    <style type="text/css">
      .flex {
        color:red;
      }
    </style>
  </head>
  <body>
    <p class="flex" style="color:red">Foo</p>
    <p class="flexible">Bar</p>
    <p class="flexi">Baz</p>
  </body>
</html>
```