### PR TITLE
Log invalid form variable names

### DIFF
--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -161,7 +161,7 @@ proc qc::filter_authenticate {event args} {
 }
 
 proc qc::filter_http_request_validate {event {error_handler "qc::error_handler"}} {
-    #| Check that request string and connection url are both valid.
+    #| Check that request string, connection url, and form variable names are valid.
     qc::setif error_handler "" "qc::error_handler"
     ::try {
         set request [ns_conn request]
@@ -174,6 +174,14 @@ proc qc::filter_http_request_validate {event {error_handler "qc::error_handler"}
             return [ns_returnbadrequest "\"$url\" is not a valid URL."]
             return filter_return
         }
+
+        set names [qc::form_var_names]
+        foreach name $names {
+            if { [regexp {::} $name] } {
+                log "Invalid form variable name: $name"
+            }
+        }
+        
         return filter_ok
     } on error {error_message options} {
         $error_handler $error_message [dict get $options -errorinfo] [dict get $options -errorcode]

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -175,10 +175,13 @@ proc qc::filter_http_request_validate {event {error_handler "qc::error_handler"}
             return filter_return
         }
 
+        # Check form variable names to prevent Tcl namespaced variables from
+        # being set or overwritten.
         set names [qc::form_var_names]
         foreach name $names {
             if { [regexp {::} $name] } {
                 log "Invalid form variable name: $name"
+                log "Request: $request"
             }
         }
         


### PR DESCRIPTION
**Tested on mla-erp**

Input:
```
https://qcode.dev.mlaccessories.co.uk/home.html?::testing=123
```

Log:
```
[03/May/2016:09:58:09][4005.7f2bd0507700][-conn:mla_erp:3-] App:Notice: Invalid form variable name: ::testing
```

Input:
```
https://qcode.dev.mlaccessories.co.uk/home.html?::testing=123&foo::bar=baz
```

Log:
```
[03/May/2016:10:00:57][4005.7f2bd0507700][-conn:mla_erp:3-] App:Notice: Invalid form variable name: ::testing
[03/May/2016:10:00:57][4005.7f2bd0507700][-conn:mla_erp:3-] App:Notice: Invalid form variable name: foo::bar
```