### PR TITLE
Treat Varchar With No Length As Text

### DIFF
--- a/tcl/db_introspection.tcl
+++ b/tcl/db_introspection.tcl
@@ -344,7 +344,7 @@ proc qc::db_canonical_type {udt_name {character_maximum_length ""} {numeric_prec
     #| Returns the canonical type name for the given type name.
     switch -glob -- $udt_name {
         varchar {
-            return [expr {$character_maximum_length ne "" ? "varchar($character_maximum_length)": "varchar"}]
+            return [expr {$character_maximum_length ne "" ? "varchar($character_maximum_length)": "text"}]
         }
         numeric {
             return [expr {$numeric_precision ne "" ? "decimal($numeric_precision,$numeric_scale)": "decimal"}]


### PR DESCRIPTION
## Testing
Tested on MLA ERP. `customer.nmbs_number` is a varchar with no length specified:

```
> qc::db_column_type customer nmbs_number
text
```
