### PR TITLE
Remove Ending Square Brackets From Form Var Names

### DIFF
--- a/tcl/form.tcl
+++ b/tcl/form.tcl
@@ -75,9 +75,7 @@ proc qc::form2dict {args}  {
     }
     # set vars
     foreach name $args {
-        # if the name is an array then remove the square brackets
-        regexp {^(.+)\[\]$} $name -> name
-	if { [form_var_exists $name] } {
+        if { [form_var_exists $name] } {
 	    dict set dict $name [form_var_get $name]
 	}
     }

--- a/tcl/form.tcl
+++ b/tcl/form.tcl
@@ -75,8 +75,10 @@ proc qc::form2dict {args}  {
     }
     # set vars
     foreach name $args {
+        # if the name is an array then remove the square brackets
+        regexp {^(.+)\[\]$} $name -> name
 	if { [form_var_exists $name] } {
-	    lappend dict $name [form_var_get $name]
+	    dict set dict $name [form_var_get $name]
 	}
     }
     return $dict

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -8,7 +8,13 @@ namespace eval qc::handlers {
         set method [string toupper $method]
         set pattern [qc::path_best_match $path [get $method]]
         # Add in path variables to form data.
-        set form [dict merge [qc::form2dict] [qc::path_variables $path $pattern]]
+        set args [args $method $pattern]
+        set list [list]
+        foreach arg $args {
+            regexp {^[^\.]+\.([^\.]+)$} $arg -> arg
+            lappend list $arg
+        }
+        set form [dict merge [qc::form2dict $list] [qc::path_variables $path $pattern]]
         # Cast to model
         set dict [qc::cast_values2model {*}[data $form $method $pattern]]
         # Call handler
@@ -25,7 +31,13 @@ namespace eval qc::handlers {
         set method [string toupper $method]
         set pattern [qc::path_best_match $path [get $method]]
         # Add in path variables to form data.
-        set form [dict merge [qc::form2dict] [qc::path_variables $path $pattern]]
+        set args [args $method $pattern]
+        set list [list]
+        foreach arg $args {
+            regexp {^[^\.]+\.([^\.]+)$} $arg -> arg
+            lappend list $arg
+        }
+        set form [dict merge [qc::form2dict $list] [qc::path_variables $path $pattern]]
         # Validate the data.
         return [qc::validate2model [data $form $method $pattern]]
     }
@@ -119,7 +131,13 @@ namespace eval qc::handlers {
             set method [string toupper $method]
             set pattern [qc::path_best_match $path [get $method]]
             # Add in path variables to form data.
-            set form [dict merge [qc::form2dict] [qc::path_variables $path $pattern]]
+            set args [args $method $pattern]
+            set list [list]
+            foreach arg $args {
+                regexp {^[^\.]+\.([^\.]+)$} $arg -> arg
+                lappend list $arg
+            }
+            set form [dict merge [qc::form2dict $list] [qc::path_variables $path $pattern]]
             # Grab relevant arg data from form.
             set dict [qc::cast_values2model {*}[data $form $method $pattern]]
             # Call the validation handler.

--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -7,14 +7,16 @@ namespace eval qc::handlers {
         #| Call the registered handler that matches the given path and method.
         set method [string toupper $method]
         set pattern [qc::path_best_match $path [get $method]]
-        # Add in path variables to form data.
+        # Gather a list of form variables we might be interested in and add in
+        # path variables to the form data.
         set args [args $method $pattern]
-        set list [list]
         foreach arg $args {
-            regexp {^[^\.]+\.([^\.]+)$} $arg -> arg
-            lappend list $arg
+            set shortname [qc::arg_shortname $arg]
+            if { $shortname ne $arg } {
+                lappend args $shortname
+            }
         }
-        set form [dict merge [qc::form2dict $list] [qc::path_variables $path $pattern]]
+        set form [dict merge [qc::form2dict {*}$args] [qc::path_variables $path $pattern]]
         # Cast to model
         set dict [qc::cast_values2model {*}[data $form $method $pattern]]
         # Call handler
@@ -30,14 +32,16 @@ namespace eval qc::handlers {
         #| Validates the args of the handler registered for the given path and method.
         set method [string toupper $method]
         set pattern [qc::path_best_match $path [get $method]]
-        # Add in path variables to form data.
+        # Gather a list of form variables we might be interested in and add in
+        # path variables to the form data.
         set args [args $method $pattern]
-        set list [list]
         foreach arg $args {
-            regexp {^[^\.]+\.([^\.]+)$} $arg -> arg
-            lappend list $arg
+            set shortname [qc::arg_shortname $arg]
+            if { $shortname ne $arg } {
+                lappend args $shortname
+            }
         }
-        set form [dict merge [qc::form2dict $list] [qc::path_variables $path $pattern]]
+        set form [dict merge [qc::form2dict {*}$args] [qc::path_variables $path $pattern]]
         # Validate the data.
         return [qc::validate2model [data $form $method $pattern]]
     }
@@ -130,14 +134,16 @@ namespace eval qc::handlers {
             #| Calls the registered handler that matches the given method and path.
             set method [string toupper $method]
             set pattern [qc::path_best_match $path [get $method]]
-            # Add in path variables to form data.
+            # Gather a list of form variables we might be interested in and add in
+            # path variables to the form data.
             set args [args $method $pattern]
-            set list [list]
             foreach arg $args {
-                regexp {^[^\.]+\.([^\.]+)$} $arg -> arg
-                lappend list $arg
+                set shortname [qc::arg_shortname $arg]
+                if { $shortname ne $arg } {
+                    lappend args $shortname
+                }
             }
-            set form [dict merge [qc::form2dict $list] [qc::path_variables $path $pattern]]
+            set form [dict merge [qc::form2dict {*}$args] [qc::path_variables $path $pattern]]
             # Grab relevant arg data from form.
             set dict [qc::cast_values2model {*}[data $form $method $pattern]]
             # Call the validation handler.


### PR DESCRIPTION
See #383 

Tcl
----
- [x] Are there comments throughout the code ?

All
---
- [x] List what testing has been done.
  - [x] Tested on MLA ERP with GRN creation by logging the purchase orders in the validation handler.
    
    **Form data**
    ```
    account_name: testing
    exchange_rate:1.61
    duty_cost:0.00
    freight_cost:0.00
    stock_account_id:12
    narration:
    purchase_orders[]:12345
    purchase_orders[]:67890
    ```
    
    ```
    validate POST  /grn_new.tcl {
        grn.stock_account_id
        required.account_name
        grn.exchange_rate
        grn.narration
        grn.duty_cost
        grn.freight_cost
        {form.purchase_orders {}}
    } {
        log $purchase_orders
        ...
    }
    ```

    **Log**
    ```
    12345 67890
    ```