### PR TITLE
always initialise valid flag for each field in a record

### DIFF
--- a/tcl/validate.tcl
+++ b/tcl/validate.tcl
@@ -20,13 +20,14 @@ proc qc::validate2model {dict} {
             # Mark field as being sensitive in the global data structure
             qc::response record sensitive $column
         }
+        # Initialise valid flag
+        qc::response record valid $column $value
         # Check if nullable
         if {! $nullable && $value eq ""} {
             qc::response record invalid $column $value $message
             set all_valid false
             continue
         } elseif {$nullable && $value eq ""} {
-            qc::response record valid $column $value
             dict set cast_dict $name ""
             continue
         }
@@ -37,7 +38,6 @@ proc qc::validate2model {dict} {
             continue
         } 
 
-        qc::response record valid $column $value $message
         dict set cast_dict $name [qc::cast $data_type $value]
     }
 

--- a/tcl/validate.tcl
+++ b/tcl/validate.tcl
@@ -36,7 +36,7 @@ proc qc::validate2model {dict} {
             qc::response record invalid $column $value $message
             set all_valid false
             continue
-        }
+        } 
         dict set cast_dict $name [qc::cast $data_type $value]
     }
 

--- a/tcl/validate.tcl
+++ b/tcl/validate.tcl
@@ -36,8 +36,7 @@ proc qc::validate2model {dict} {
             qc::response record invalid $column $value $message
             set all_valid false
             continue
-        } 
-
+        }
         dict set cast_dict $name [qc::cast $data_type $value]
     }
 

--- a/tcl/validate.tcl
+++ b/tcl/validate.tcl
@@ -36,6 +36,8 @@ proc qc::validate2model {dict} {
             set all_valid false
             continue
         } 
+
+        qc::response record valid $column $value $message
         dict set cast_dict $name [qc::cast $data_type $value]
     }
 
@@ -63,9 +65,6 @@ proc qc::validate2model {dict} {
                 set all_valid false
                 continue
             }         
-        
-            # Record passed all data model validation
-            qc::response record valid $column $value
         }
     }
 


### PR DESCRIPTION
Issue discovered when one field failed data validation, another field's valid flag was not being set because of this check: https://github.com/qcode-software/qcode-tcl/compare/validate2model-bug-fix2?expand=1#diff-5bbae3529ffd2733b2b7100ca589dd50L42

Valid flag is required for all fields