### PR TITLE
Allow setting of session token where temporary credentials are being …

### DIFF
--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -8,10 +8,13 @@ namespace eval qc {
     namespace export s3 s3_* aws_*
 }
 
-proc qc::aws_credentials_set { access_key secret_key } {
+proc qc::aws_credentials_set { access_key secret_key {token ""}} {
     #| Set globals containing AWS credentials
     set ::env(AWS_ACCESS_KEY_ID) $access_key
     set ::env(AWS_SECRET_ACCESS_KEY) $secret_key
+    if { $token ne "" } {
+        set ::env(AWS_SESSION_TOKEN) $token
+    }
     return true
 }
 


### PR DESCRIPTION
…used

Using role-based temporary credentials requires a session token to be set. This change allows that via qcode-tcl