### PR TITLE
Relax criteria for external domain redirect

### DIFF
--- a/tcl/response.tcl
+++ b/tcl/response.tcl
@@ -144,7 +144,7 @@ namespace eval qc::response {
     ##################################################
     namespace eval action {
         
-        namespace export redirect resubmit login
+        namespace export redirect external_redirect resubmit login
         namespace ensemble create
 
         proc redirect {url} {
@@ -183,7 +183,12 @@ namespace eval qc::response {
                     }
                 }
 
-            } else {                
+            } else {
+                # Absolute url
+                # check that redirection is to the same domain
+                if { ![regexp "^https?://${host}(:\[0-9\]+)?(/|\$)" $url] } {
+                    error "Will not redirect to a different domain. Host $host. Redirect to \"[html_escape $url]\""
+                }
                 # check for malicious mal-formed url
                 if { ![qc::is url $url] } {
                     error "\"[html_escape $url]\" is not a valid url."
@@ -191,6 +196,19 @@ namespace eval qc::response {
             }
             
             dict set data action redirect value [url $url]
+        }
+
+        proc external_redirect {url} {
+            #| Sets the redirect property with the given external URL.
+            global data
+            reset
+                        
+            # check for malicious mal-formed url
+            if { ![qc::is url $url] } {
+                error "\"[html_escape $url]\" is not a valid url."
+            }
+
+            dict set data action redirect value $url
         }
 
         proc resubmit {} {

--- a/tcl/response.tcl
+++ b/tcl/response.tcl
@@ -183,12 +183,7 @@ namespace eval qc::response {
                     }
                 }
 
-            } else {
-                # Absolute url
-                # check that redirection is to the same domain
-                if { ![regexp "^https?://${host}(:\[0-9\]+)?(/|\$)" $url] } {
-                    error "Will not redirect to a different domain. Host $host. Redirect to \"[html_escape $url]\""
-                }
+            } else {                
                 # check for malicious mal-formed url
                 if { ![qc::is url $url] } {
                     error "\"[html_escape $url]\" is not a valid url."


### PR DESCRIPTION
The security issue with redirects is for open redirects based on user-supplied urls.

This change relaxes the constraint on redirect destinations but relies on the caller to sanitise the url destination.

https://portswigger.net/KnowledgeBase/issues/Details/00500100_Openredirection