### PR TITLE
Silence http exists

### DIFF
--- a/tcl/http.tcl
+++ b/tcl/http.tcl
@@ -458,7 +458,7 @@ proc qc::http_head {args} {
 	lappend httpheaders [qc::http_header $name $value]
     }
 
-    dict2vars [qc::http_curl -nobody 1 -header 1 -headervar headers -url $url -sslverifypeer 0 -sslverifyhost 0 -timeout $timeout -followlocation 1 -httpheader $httpheaders] headers responsecode curlErrorNumber
+    dict2vars [qc::http_curl -nobody 1 -headervar headers -url $url -sslverifypeer 0 -sslverifyhost 0 -timeout $timeout -followlocation 1 -httpheader $httpheaders] headers responsecode curlErrorNumber
 
     switch $curlErrorNumber {
 	0 {

--- a/test/http.test
+++ b/test/http.test
@@ -148,6 +148,23 @@ namespace eval ::qcode::test {
         return [qc::http_header_sort_values_by_weight $accept_header]
     } -result {{token application/json params {indent 4}} {token text/html params {level 1 q 0.9}} {token text/xml params {q 0.7}} {token */* params {q 0.01}}}
 
+    test http_exists-1.0 {http_exists true} -body {
+        http_exists -timeout 30 -- http://httpbin.org/
+    } -result {true}
+
+    test http_exists-1.1 {http_exists false} -body {
+        http_exists -timeout 30 -- http://httpbin.org/idontexist
+    } -result {false}
+
+    test http_head-1.0 {http_head} -body {
+        set response [qc::http_head -timeout 30 http://httpbin.org/response-headers?test=hello]
+        if { [dict exists $response test] } {
+            return [dict get $response test]
+        } else {
+            return ""
+        }
+    } -result {hello}
+
     cleanupTests
 }
 namespace delete ::qcode::test


### PR DESCRIPTION
http_exists and http_head output the response headers to stdout currently.
This can fill big chunks of log file with fairly useless information where a lot of URLs are being checked.
eg.
```
HTTP/1.1 200 OK
Server: NaviServer/4.99.12
Date: Wed, 04 Jan 2017 17:42:04 GMT
X-Frame-Options: SAMEORIGIN
P3P: CP="DSP CAO TELi CUR ADMi DEVi TAIi PSAi PSDi IVDi IVAi CONi HISi SAMi STP PHY DEM UNI ONL NAV COM STA INT"
Strict-Transport-Security: max-age=15768000
Last-Modified: Wed, 21 Dec 2016 13:09:32 GMT
Content-Type: text/html
Accept-Ranges: bytes
Content-Length: 28852
Connection: keep-alive

HTTP/1.1 200 OK
Server: NaviServer/4.99.12
Date: Wed, 04 Jan 2017 17:42:04 GMT
X-Frame-Options: SAMEORIGIN
P3P: CP="DSP CAO TELi CUR ADMi DEVi TAIi PSAi PSDi IVDi IVAi CONi HISi SAMi STP PHY DEM UNI ONL NAV COM STA INT"
Strict-Transport-Security: max-age=15768000
Last-Modified: Wed, 21 Dec 2016 13:09:32 GMT
Content-Type: text/html
Accept-Ranges: bytes
Content-Length: 28852
Connection: keep-alive

HTTP/1.1 200 OK
Server: NaviServer/4.99.12
Date: Wed, 04 Jan 2017 17:42:04 GMT
X-Frame-Options: SAMEORIGIN
P3P: CP="DSP CAO TELi CUR ADMi DEVi TAIi PSAi PSDi IVDi IVAi CONi HISi SAMi STP PHY DEM UNI ONL NAV COM STA INT"
Strict-Transport-Security: max-age=15768000
Last-Modified: Wed, 21 Dec 2016 13:09:32 GMT
Content-Type: text/html
Accept-Ranges: bytes
Content-Length: 28852
Connection: keep-alive

........
```
I don't think there's any need for this... but others may disagree..?