### PR TITLE
Filter to Set Up HTTP Headers

### DIFF
--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -356,6 +356,12 @@ proc qc::filter_set_expires {filter_when seconds {cache_response_directive ""}} 
     return "filter_ok"
 }
 
+proc qc::filter_set_content_disposition {filter_when value} {
+    #| Filter to set the content-disposition header.
+    ns_set update [ns_conn outputheaders] content-disposition $value
+    return "filter_ok"
+}
+
 proc qc::filter_form_variables_validate {event args} {
     #| Check form variable names to prevent Tcl namespaced variables from being
     #| set or overwritten.

--- a/tcl/filter.tcl
+++ b/tcl/filter.tcl
@@ -356,9 +356,11 @@ proc qc::filter_set_expires {filter_when seconds {cache_response_directive ""}} 
     return "filter_ok"
 }
 
-proc qc::filter_set_content_disposition {filter_when value} {
-    #| Filter to set the content-disposition header.
-    ns_set update [ns_conn outputheaders] content-disposition $value
+proc qc::filter_set_headers {filter_when args} {
+    #| Filter to set header values.
+    foreach {name value} $args {
+        ns_set update [ns_conn outputheaders] $name $value
+    }
     return "filter_ok"
 }
 


### PR DESCRIPTION
Filter to set up HTTP headers before the request handler is called. This is particularly useful for any files served by fastpath.

Testing
---
Tested on a project:

```tcl
ns_register_filter postauth $http_method /file-download/* qc::filter_set_headers content-disposition "attachment"
```

* Accessed a file in `/file-download/` path and inspected the response headers to ensure that the `content-disposition` header was set to `attachment`.