### PR TITLE
File Changes

### DIFF
--- a/tcl/file.tcl
+++ b/tcl/file.tcl
@@ -99,18 +99,11 @@ proc qc::file2url {file} {
     }
 }
 
-proc qc::file_handler {cache_dir {error_handler "qc::error_handler"}} {
+proc qc::file_handler {file_id cache_dir canonical_url {error_handler "qc::error_handler"}} {
     #| URL handler to serve files that can not be served by fastpath.
-    # If canonical url was requested return file to client and register URL to be servered by fastpath for future requests.
+    # If canonical url was requested return file to client and register URL to be served by fastpath for future requests.
     setif error_handler "" "qc::error_handler"
-    ::try {
-        set request_path [qc::conn_path]
-        
-        if { ! [regexp {^/file/([0-9]+)(?:/.*|$)} $request_path -> file_id] } {
-            # Invalid file url
-            return [ns_returnnotfound]
-        }
-        
+    ::try {        
         if { [qc::file_cache_exists $cache_dir $file_id] } {
             # Cache already exists for canonical url
             dict2vars [qc::file_cache_data $cache_dir $file_id] url

--- a/tcl/file.tcl
+++ b/tcl/file.tcl
@@ -99,98 +99,57 @@ proc qc::file2url {file} {
     }
 }
 
-proc qc::file_handler {file_id cache_dir canonical_url {error_handler "qc::error_handler"}} {
-    #| URL handler to serve files that can not be served by fastpath.
-    # If canonical url was requested return file to client and register URL to be served by fastpath for future requests.
-    setif error_handler "" "qc::error_handler"
-    ::try {        
-        if { [qc::file_cache_exists $cache_dir $file_id] } {
-            # Cache already exists for canonical url
-            dict2vars [qc::file_cache_data $cache_dir $file_id] url
-            set canonical_url $url
-            set canonical_file [ns_pagepath]$canonical_url
-        } else {
-            # Create cache for canonical url
-
-            # Check file exists
-            db_0or1row {
-                select 
-                file_id
-                from file
-                where file_id=:file_id
-            } {
-                return [ns_returnnotfound]
-            } 
-
-            set canonical_file [qc::file_cache_create $cache_dir $file_id]
-            set canonical_url [qc::file2url $canonical_file]
-        } 
-        if { $request_path eq $canonical_url } {
-            # Canonical URL was requested - return file
-            ns_register_fastpath GET $canonical_url
-            ns_register_fastpath HEAD $canonical_url
-            return [ns_returnfile 200 [mime_type_guess $canonical_file] $canonical_file]
-        } 
-        
-        # Catch All - redirect to Canonical URL
-        return [ns_returnredirect $canonical_url]      
-    } on error {error_message options} {
-        # Error handler
-        return [$error_handler $error_message [dict get $options -errorinfo] [dict get $options -errorcode]]
-    }
-}
-
-proc qc::file_cache_create {cache_dir file_id} {
+proc qc::file_cache_create {file_id file_path} {
     #| Create a file in the disk cache
     set file [qc::db_file_export $file_id]
 
     # Place files in cache
-    db_1row {select mime_type from file where file_id=:file_id}
-    set cache_file ${cache_dir}/${file_id}/${file_id}[qc::mime_file_extension $mime_type]
-    if { ! [file exists [file dirname $cache_file]] } {
-        file mkdir [file dirname $cache_file]
+    if { ! [file exists [file dirname $file_path]] } {
+        file mkdir [file dirname $file_path]
     }
-    file rename -force $file $cache_file
 
-    return $cache_file
+    file rename -force $file $file_path
+
+    return $file_path
 }
 
-proc qc::file_cache_data {cache_dir file_id} {
+proc qc::file_cache_data {file_id file_path} {
     #| Return dict containing canonical url of cached file.
-    #| Return {} if cached file does not exist.
+    #| Return an empty dict if cached file does not exist.
 
-    # Check nsv
-    set nsv_key "$file_id"
-    if { [nsv_exists file_cache_data $nsv_key] } {
-        return [nsv_get file_cache_data $nsv_key]
-    }
-    
-    # Check disk cache for canonical URL (/file/${file_id}/${file_id}${extension})
-    set data {}
-    set options [list -nocomplain -types f -directory $cache_dir]
-    set files [glob {*}$options "${file_id}/${file_id}.*"]
-    if { [llength $files] > 0 } {
-        set url [qc::file2url [lindex $files 0]]
+    if { [nsv_exists file_cache_data $file_id] } {
+        # File has been recorded in NSV file_cache_data.
+
+        return [nsv_get file_cache_data $file_id]
+    } elseif { [file exists $file_path]
+               && [file isfile $file_path] } {
+        # File exists on disk but hasn't been recorded in NSV file_cache_data.
+
+        set url [qc::file2url $file_path]
         set data [dict_from url]
-        nsv_set image_cache_data $nsv_key $data
+        nsv_set file_cache_data $file_id $data
+
         return $data
     } else {
-        return {}
+        # File doesn't exist and hasn't been recorded in NSV file_cache_data.
+
+        return [dict create]
     }
 }
 
-proc qc::file_data {cache_dir file_id} {
+proc qc::file_data {file_id file_path} {
     #| Return dict containing url of file.
     #| Generates file cache if it doesn't already exist.
-    if { ! [qc::file_cache_exists $cache_dir $file_id] } {
-        qc::file_cache_create $cache_dir $file_id
+    if { ! [qc::file_cache_exists $file_id $file_path] } {
+        qc::file_cache_create $file_id $file_path
     }
-    return [qc::file_cache_data $cache_dir $file_id]
+
+    return [qc::file_cache_data $file_id $file_path]
 }
 
-proc qc::file_cache_exists {cache_dir file_id} {
+proc qc::file_cache_exists {file_id file_path} {
     #| Return true if this file has been cached on disk.
-    if { [llength [qc::file_cache_data $cache_dir $file_id]] > 0 } {
+    if { [llength [qc::file_cache_data $file_id $file_path]] > 0 } {
         return true
     } else {
         return false


### PR DESCRIPTION
**Note: This is a breaking change due to the changing of arguments and removal of `qc::file_handler`**

The file structure to identify and create file caches is hard-coded which makes it impossible to use if the file structure is not the same as the hard-coded structure.

I've updated the file caching procs to accept a filepath as an argument. When refactoring this it became apparent that the request handler `qc::file_handler` was too trivial and therefore no longer necessary.

Testing
---
```tcl
set file_id 9227
set filepath "/home/nick/file/9227/9227.pdf"

qc::file_cache_exists $file_id $filepath
false

qc::file_cache_create $file_id $filepath
/home/nick/file/9227/9227.pdf

qc::file_cache_exists $file_id $filepath
true

qc::file_cache_data $file_id $filepath
url /home/nick/file/9227/9227.pdf

qc::file_data $file_id $filepath
url /home/nick/file/9227/9227.pdf

```
