### PR TITLE
Widget Namespace Fix

### DIFF
--- a/tcl/widget.tcl
+++ b/tcl/widget.tcl
@@ -5,12 +5,16 @@ namespace eval qc {
 proc qc::widget {args} {
     #| Look for a proc "widget_$type" to make the widget
     set type [dict get $args type]
+    # Check the qc namespace for a widget proc to create the widget type.
     if { [eq [info procs "::qc::widget_$type"] "::qc::widget_$type"] } {
 	return ["::qc::widget_$type" {*}$args]
-    } 
-    if { [eq [info procs "widget_$type"] "widget_$type"] } {
-	return ["widget_$type" {*}$args]
-    } 
+    }
+
+    # No widget proc found in the qc namespace for the type.
+    # Check the global namespace for a proc to create the widget type.
+    if { [eq [info procs "::widget_$type"] "::widget_$type"] } {
+	return ["::widget_$type" {*}$args]
+    }
     error "No widget proc defined for $type"
 }
 


### PR DESCRIPTION
It looks to me like the intention of `qc::widget` was to prioritise widget procs in the qcode-tcl library for creation and fall back to procs defined in the global namespace if no proc exists in the qcode-tcl library.

@bvw Do you recall if this was the intention?

If it was then it's currently bugged because the global namespace will never be checked. This is due to `info procs` checking for the given pattern in the _current_ namespace when no namespace is specified. Within `qc::widget` the current namespace is `::qc` therefore calling:

`info procs "widget_$type"` 

is exactly the same as calling:

`info procs "::qc::widget_$type"`

### Testing
1. Locally installed a new version with the fix.
2. Created my own widget type in the global namespace that is not in the qcode-tcl library.
    * `proc widget_select_group {args} { ... }`
3. Ran `qc::form_layout_table` using a configuration that specifies my custom widget type:
      ```tcl
      set conf [list \
          [dict create \
              label "Custom" \
              name custom \
              type select_group \
              options [custom_options] \
              null_option yes] \
      ]
      ```
