### PR TITLE
revert changes to tcl tests for qcode-tcl-5

### DIFF
--- a/test/cast.test
+++ b/test/cast.test
@@ -13,10 +13,10 @@ namespace eval ::qcode::test {
     test cast_integer-1.2 {cast_integer percentages} {qc::cast_integer "10%"} 10
     test cast_integer-1.3 {cast_integer e notation} {qc::cast_integer "43e2"} 4300
     test cast_integer-1.4 {cast_integer upper limit} {qc::cast_integer "2147483647"} 2147483647
-    test cast_integer-1.5 {cast_integer outside integer range} -body {qc::cast_integer "2147483648"} -result "Could not cast 2147483648 to integer." -returnCodes error 
-    test cast_integer-1.6 {cast_integer outside integer range} -body {qc::cast_integer "2e100"} -result "Could not cast 2e100 to integer." -returnCodes error 
+    test cast_integer-1.5 {cast_integer outside integer range} -body {qc::cast_integer "2147483648"} -result "Could not cast 2147483648 to integer" -returnCodes error 
+    test cast_integer-1.6 {cast_integer outside integer range} -body {qc::cast_integer "2e100"} -result "Could not cast 2e100 to integer" -returnCodes error 
     test cast_integer-1.7 {cast_integer lower limit} {qc::cast_integer "-2147483648"} -2147483648
-    test cast_integer-1.8 {cast_integer outside integer range} -body {qc::cast_integer "-2147483649"} -result "Could not cast -2147483649 to integer." -returnCodes error 
+    test cast_integer-1.8 {cast_integer outside integer range} -body {qc::cast_integer "-2147483649"} -result "Could not cast -2147483649 to integer" -returnCodes error 
     test cast_integer-1.9 {cast_integer leading zeros} {qc::cast_integer "-08"} -8
     test cast_integer-1.10 {cast_integer leading zeros} {qc::cast_integer "-1.008"} -1
     test cast_integer-1.10 {cast_integer leading zeros} {qc::cast_integer "0008"} 8
@@ -85,15 +85,15 @@ namespace eval ::qcode::test {
     test cast_period-1.9 {qc::cast_period "1st February 2014"} {qc::cast_period "1st February 2014"} [list 2014-02-01 2014-02-01]
 
 
-    test is_period-1.0 {qc::is_period ""} {qc::is_period ""} "0"
-    test is_period-1.1 {qc::is_period "Jan"} {qc::is_period "Jan"} "1"
-    test is_period-1.2 {qc::is_period "January"} {qc::is_period "January"} "1"
-    test is_period-1.3 {qc::is_period "2014"} {qc::is_period "2014"} "1"
-    test is_period-1.4 {qc::is_period "Jan 2014"} {qc::is_period "Jan 2013"} "1"
-    test is_period-1.5 {qc::is_period "January 2014"} {qc::is_period "January 2014"} "1"
-    test is_period-1.6 {qc::is_period "Jan 2014 to March 2014"} {qc::is_period "Jan 2014 to March 2014"} "1"
-    test is_period-1.7 {qc::is_period "Febuary 2014"} {qc::is_period "Febuary 2014"} "0"
-    test is_period-1.8 {qc::is_period "1st February 2014 to 14th February 2014"} {qc::is_period "1st February 2014 to 14th February 2014"} "1"
+    test is_period-1.0 {qc::is_period ""} {qc::is_period ""} "false"
+    test is_period-1.1 {qc::is_period "Jan"} {qc::is_period "Jan"} "true"
+    test is_period-1.2 {qc::is_period "January"} {qc::is_period "January"} "true"
+    test is_period-1.3 {qc::is_period "2014"} {qc::is_period "2014"} "true"
+    test is_period-1.4 {qc::is_period "Jan 2014"} {qc::is_period "Jan 2013"} "true"
+    test is_period-1.5 {qc::is_period "January 2014"} {qc::is_period "January 2014"} "true"
+    test is_period-1.6 {qc::is_period "Jan 2014 to March 2014"} {qc::is_period "Jan 2014 to March 2014"} "true"
+    test is_period-1.7 {qc::is_period "Febuary 2014"} {qc::is_period "Febuary 2014"} "false"
+    test is_period-1.8 {qc::is_period "1st February 2014 to 14th February 2014"} {qc::is_period "1st February 2014 to 14th February 2014"} "true"
 
     cleanupTests
 }

--- a/test/is.test
+++ b/test/is.test
@@ -2642,27 +2642,27 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
     test is_mobile_number-1.0 {is_mobile_number valid} -setup {
     } -body {
         is_mobile_number 07768777777
-    } -result 1
+    } -result true
 
     test is_mobile_number-1.1 {is_mobile_number exta chars} -setup {
     } -body {
         is_mobile_number "07768 - 777-777 "
-    } -result 1
+    } -result true
 
     test is_mobile_number-1.2 {is_mobile_number invalid} -setup {
     } -body {
         is_mobile_number 09768777777
-    } -result 0
+    } -result false
 
     test is_mobile_number-1.3 {is_mobile_number too short} -setup {
     } -body {
         is_mobile_number 0751111111
-    } -result 0
+    } -result false
 
     test is_mobile_number-1.4 {is_mobile_number empty} -setup {
     } -body {
-        string is true [is_mobile_number {}]
-    } -result 0
+       is_mobile_number {}
+    } -result false
 
     test contains_creditcard-1.0 {contains_creditcard cc no only} -setup {
     } -body {
@@ -2780,32 +2780,32 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
     test is_ipv4-1.0 {is_ipv4 ip6} -setup {
     } -body {
         is_ipv4 2001:0db8:85a3:0042:0000:8a2e:0370:7334
-    } -result 0
+    } -result false
 
     test is_ipv4-1.1 {is_ipv4 partial} -setup {
     } -body {
         is_ipv4 192.168.1
-    } -result 0
+    } -result false
 
     test is_ipv4-1.2 {is_ipv4 invalid but still true} -setup {
     } -body {
         is_ipv4 192.168.1.354
-    } -result 1
+    } -result true
 
     test is_ipv4-1.3 {is_ipv4 valid} -setup {
     } -body {
         is_ipv4 192.168.1.1
-    } -result 1
+    } -result true
 
     test is_cidrnetv4-1.0 {is_cidrnetv4 ip only} -setup {
     } -body {
         is_cidrnetv4  192.168.1.20
-    } -result 0
+    } -result false
 
     test is_cidrnetv4-1.1 {is_cidrnetv4 valid cidr} -setup {
     } -body {
         is_cidrnetv4  192.168.1.0/24
-    } -result 1
+    } -result true
 
     test is_uri-1.0 {is_uri absolute} -setup {} -body {
         qc::is_uri_valid http://test.com

--- a/test/sql.test
+++ b/test/sql.test
@@ -41,17 +41,17 @@ namespace eval ::qcode::test {
     test sql_sort-1.0 {sql_sort} -setup {
     } -body {
         sql_sort name email user_code 
-    } -cleanup {} -result {"name","email","user_code"}
+    } -cleanup {} -result {name,email,user_code}
 
     test sql_sort-1.1 {sql_sort with order} -setup {
     } -body {
         sql_sort name DESC email user_code 
-    } -cleanup {} -result {"name" DESC NULLS LAST,"email","user_code"}
+    } -cleanup {} -result {name DESC NULLS LAST,email,user_code}
 
     test sql_sort-1.2 {sql_sort with paging} -setup {
     } -body {
         sql_sort -paging name email user_code 
-    } -cleanup {} -result {"name","email","user_code" limit '100' offset '0'}
+    } -cleanup {} -result {name,email,user_code limit 100 offset 0}
 
     test sql_in-1.0 {sql_in} -setup {
     } -body {

--- a/test/url.test
+++ b/test/url.test
@@ -95,23 +95,23 @@ namespace eval ::qcode::test {
     # url 
     test url-1.0 {url some safe characters} -body {
         url someplace.html session_id 23.121 title Mr first_name Test last_name Test age ~25 dob 1988-03-13
-    } -cleanup {} -result {/someplace.html?session_id=23.121&title=Mr&first_name=Test&last_name=Test&age=~25&dob=1988-03-13}
+    } -cleanup {} -result {someplace.html?last_name=Test&first_name=Test&session_id=23.121&dob=1988-03-13&age=~25&title=Mr}
     
     test url-1.1 {url some unsafe characters} -body {
         url someplace.html next_url someplace_else.html?name=Mr+Test+Test&email=test@test.com
-    } -cleanup {} -result {/someplace.html?next_url=someplace_else.html%3fname%3dMr%2bTest%2bTest%26email%3dtest%40test.com}
+    } -cleanup {} -result {someplace.html?next_url=someplace_else.html%3fname%3dMr%2bTest%2bTest%26email%3dtest%40test.com}
 
     test url-1.2 {url some safe characters} -body {
         url someplace.html#someanchor session_id 23.121 title Mr first_name Test last_name Test age ~25 dob 1988-03-13
-    } -cleanup {} -result {/someplace.html?session_id=23.121&title=Mr&first_name=Test&last_name=Test&age=~25&dob=1988-03-13#someanchor}
+    } -cleanup {} -result {someplace.html?last_name=Test&first_name=Test&session_id=23.121&dob=1988-03-13&age=~25&title=Mr#someanchor}
     
     test url-1.3 {url some safe characters} -body {
         url someplace.html?a=1#someanchor session_id 23.121 title Mr first_name Test last_name Test age ~25 dob 1988-03-13
-    } -cleanup {} -result {/someplace.html?a=1&session_id=23.121&title=Mr&first_name=Test&last_name=Test&age=~25&dob=1988-03-13#someanchor}
+    } -cleanup {} -result {someplace.html?last_name=Test&first_name=Test&session_id=23.121&dob=1988-03-13&age=~25&a=1&title=Mr#someanchor}
     
     test url-1.4 {url some unsafe characters} -body {
         url someplace.html#someanchor next_url someplace_else.html?name=Mr+Test+Test&email=test@test.com
-    } -cleanup {} -result {/someplace.html?next_url=someplace_else.html%3fname%3dMr%2bTest%2bTest%26email%3dtest%40test.com#someanchor}
+    } -cleanup {} -result {someplace.html?next_url=someplace_else.html%3fname%3dMr%2bTest%2bTest%26email%3dtest%40test.com#someanchor}
     
     # url_match
     test url_match-1.0 {url_match identical urls} -body {
@@ -185,47 +185,47 @@ namespace eval ::qcode::test {
     # url_parts
     test url_parts-1.0 {url parts with everything} -body {
         url_parts "https://www.qcode.test.co.uk:80/homepage?width=12&age=2#flowers"
-    } -result {base https://www.qcode.test.co.uk:80/homepage params {width 12 age 2} hash flowers protocol https domain www.qcode.test.co.uk port 80 path /homepage segments homepage}
+    } -result {base https://www.qcode.test.co.uk:80/homepage params {width 12 age 2} hash flowers protocol https domain www.qcode.test.co.uk port 80 path /homepage}
 
     test url_parts-1.1 {url parts with no port} -body {
         url_parts "https://www.qcode.test.co.uk/homepage?width=12&age=2#flowers"
-    } -result {base https://www.qcode.test.co.uk/homepage params {width 12 age 2} hash flowers protocol https domain www.qcode.test.co.uk port {} path /homepage segments homepage}
+    } -result {base https://www.qcode.test.co.uk/homepage params {width 12 age 2} hash flowers protocol https domain www.qcode.test.co.uk port {} path /homepage}
 
     test url_parts-1.3 {url parts with no domain} -body {
         url_parts "/homepage?width=12&age=2#flowers"
-    } -result {base /homepage params {width 12 age 2} hash flowers protocol {} domain {} port {} path /homepage segments homepage}
+    } -result {base /homepage params {width 12 age 2} hash flowers protocol {} domain {} port {} path /homepage}
 
     test url_parts-1.4 {url parts with no params} -body {
         url_parts "https://www.qcode.test.co.uk:80/homepage#flowers"
-    } -result {base https://www.qcode.test.co.uk:80/homepage params {} hash flowers protocol https domain www.qcode.test.co.uk port 80 path /homepage segments homepage}
+    } -result {base https://www.qcode.test.co.uk:80/homepage params {} hash flowers protocol https domain www.qcode.test.co.uk port 80 path /homepage}
 
     test url_parts-1.5 {url parts with no hash} -body {
         url_parts "https://www.qcode.test.co.uk:80/homepage?width=12&age=2"
-    } -result {base https://www.qcode.test.co.uk:80/homepage params {width 12 age 2} hash {} protocol https domain www.qcode.test.co.uk port 80 path /homepage segments homepage}
+    } -result {base https://www.qcode.test.co.uk:80/homepage params {width 12 age 2} hash {} protocol https domain www.qcode.test.co.uk port 80 path /homepage}
 
     test url_parts-1.6 {url parts with path only} -body {
         url_parts "homepage"
-    } -result {base homepage params {} hash {} protocol {} domain {} port {} path homepage segments homepage}
+    } -result {base homepage params {} hash {} protocol {} domain {} port {} path homepage}
 
     test url_parts-1.7 {url parts with no path} -body {
         url_parts "https://www.qcode.test.co.uk:80"
-    } -result {base https://www.qcode.test.co.uk:80 params {} hash {} protocol https domain www.qcode.test.co.uk port 80 path {} segments {}}
+    } -result {base https://www.qcode.test.co.uk:80 params {} hash {} protocol https domain www.qcode.test.co.uk port 80 path {}}
 
     test url_parts-1.8 {url parts with all safe chars } -body {
         url_parts {https://www.qcode.test.com/test/this,(123)+is-strange!@for%2F$url*'x'.html}
-    } -result {base {https://www.qcode.test.com/test/this,(123)+is-strange!@for%2F$url*'x'.html} params {} hash {} protocol https domain www.qcode.test.com port {} path {/test/this,(123)+is-strange!@for%2F$url*'x'.html} segments {test {this,(123)+is-strange!@for%2F$url*'x'.html}}}
+    } -result {base {https://www.qcode.test.com/test/this,(123)+is-strange!@for%2F$url*'x'.html} params {} hash {} protocol https domain www.qcode.test.com port {} path {/test/this,(123)+is-strange!@for%2F$url*'x'.html}}
 
     test url_parts-1.9 {url parts with all safe chars no domain } -body {
         url_parts {/test/this,(123)+is-strange!@for%2F$url*'x'.html}
-    } -result {base {/test/this,(123)+is-strange!@for%2F$url*'x'.html} params {} hash {} protocol {} domain {} port {} path {/test/this,(123)+is-strange!@for%2F$url*'x'.html} segments {test {this,(123)+is-strange!@for%2F$url*'x'.html}}}
+    } -result {base {/test/this,(123)+is-strange!@for%2F$url*'x'.html} params {} hash {} protocol {} domain {} port {} path {/test/this,(123)+is-strange!@for%2F$url*'x'.html}}
     
     test url_parts-1.10 {url parts with all safe chars no domain and query} -body {
         url_parts {/test/this,(123)+is-strange!for%2F$url*'x'.html?width(a)=123&width(b)=321}
-    } -result {base {/test/this,(123)+is-strange!for%2F$url*'x'.html} params {width(a) 123 width(b) 321} hash {} protocol {} domain {} port {} path {/test/this,(123)+is-strange!for%2F$url*'x'.html} segments {test {this,(123)+is-strange!for%2F$url*'x'.html}}}
+    } -result {base {/test/this,(123)+is-strange!for%2F$url*'x'.html} params {width(a) 123 width(b) 321} hash {} protocol {} domain {} port {} path {/test/this,(123)+is-strange!for%2F$url*'x'.html}}
 
     test url_parts-1.11 {url parts with all safe chars no domain and hash} -body {
         url_parts {/test/this,(123)+is-strange!for%2F$url*'x'.html#placeholder(a)}
-    } -result {base {/test/this,(123)+is-strange!for%2F$url*'x'.html} params {} hash placeholder(a) protocol {} domain {} port {} path {/test/this,(123)+is-strange!for%2F$url*'x'.html} segments {test {this,(123)+is-strange!for%2F$url*'x'.html}}}
+    } -result {base {/test/this,(123)+is-strange!for%2F$url*'x'.html} params {} hash placeholder(a) protocol {} domain {} port {} path {/test/this,(123)+is-strange!for%2F$url*'x'.html}}
 
     # url_request_path
     test url_request_path-1.0 {url_request_path basic usage} -body {


### PR DESCRIPTION
revert changes introduced in https://github.com/qcode-software/qcode-tcl/pull/445.

SideNote: don't think the makefile testing works as expected when newer versions of qcode-tcl are installed. Think there is an existing GitHub issue relating to this.

I had to `make install VERSION=5.34.0` then `rm -rf /usr/lib/tcltck/qcode6*` then `make test VERSION=5.34.0` so that the version i was testing was actually the one I wanted to test.