### PR TITLE
Added support for grouped CSS selectors in html_style2inline

### DIFF
--- a/tcl/html.tcl
+++ b/tcl/html.tcl
@@ -246,16 +246,18 @@ proc qc::html_style2inline {html style} {
     package require tdom
     dom parse -html $html doc
     foreach {selector styles} $data {
-      	set xpath [qc::css_selector2xpath $selector]
-        set nodes [$doc selectNodes $xpath]
+        foreach item [split $selector ","] {
+            set xpath [qc::css_selector2xpath [string trim $item]]
+            set nodes [$doc selectNodes $xpath]
 
-	foreach node $nodes {
-	    if { [$node hasAttribute style] } {
-		$node setAttribute style [style_set [$node getAttribute style] {*}$styles]
-	    } else {
-		$node setAttribute style [style_set "" {*}$styles]
-	    }
-	}
+            foreach node $nodes {
+                if { [$node hasAttribute style] } {
+                    $node setAttribute style [style_set [$node getAttribute style] {*}$styles]
+                } else {
+                    $node setAttribute style [style_set "" {*}$styles]
+                }
+            }
+        }
     }
     set html [$doc asHTML  -escapeNonASCII -htmlEntities]
     $doc delete


### PR DESCRIPTION
Testing
---
Ran with HTML and single and grouped CSS selectors.

HTML for testing:
```html
<table id="table_1">
  <thead>
    <tr>
      <th>Column 1</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Test</td>
    </tr>
  </tbody>
</table>
``` 
CSS for testing:
```css
#table_1 > * > tr > td:nth-child(1) {
    background-color: #ece9d8;
}
#table_1 > thead > tr > th:nth-child(1), #table_1 > * > tr > td:nth-child(1) {
   padding-left: 3px; padding-right: 3px;
}
```

Output:
```
qc::html_style2inline $html $css

<table id="table_1">
  <thead>
    <tr>
      <th style="padding-left:3px;padding-right:3px">Column 1</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td style="background-color:#ece9d8;padding-left:3px;padding-right:3px">Test</td>
    </tr>
  </tbody>
</table>
```