### PR TITLE
Qcode 5 backporting

### DIFF
--- a/tcl/args.tcl
+++ b/tcl/args.tcl
@@ -20,7 +20,15 @@ proc qc::args2dict {callers_args} {
 	}
 	return $dict
     } else {
-	return $callers_args
+        if { [llength $callers_args] % 2 != 0 } {
+            error "Missing name or value in args for qc::args2dict"
+        }
+        
+        set dict [dict create {*}$callers_args]
+        if { [llength $callers_args] ne [llength $dict] } {
+            error "Duplicate key for qc::args2dict"
+        }
+	return $dict
     }
 }
 
@@ -28,7 +36,7 @@ proc qc::args2vars {callers_args args} {
     #| Parse callers args. Interpret as regular dict unless first item is ~ 
     #| in which case interpret as a list of variable names to pass-by-name.
     #| Dict - set all variables or just those specified that exists in the dict
-    #| Pass-by-Value - set all variables or just those specified that exists in caller's namespce.
+    #| Pass-by-Value - set all variables or just those specified that exists in caller's namespace.
 
     if { [llength $callers_args]==1 } {set callers_args [lindex $callers_args 0]}
     set varNames {}
@@ -43,7 +51,7 @@ proc qc::args2vars {callers_args args} {
 	}
     } else {
 	foreach {varName varValue} $callers_args {
-	    if { [llength $args]==0 || [in $args $varName] } {
+            if { [llength $args]==0 || [in $args $varName] } {
 		upset 1 $varName $varValue
 		lappend varNames $varName
 	    }

--- a/tcl/bs_capsule.tcl
+++ b/tcl/bs_capsule.tcl
@@ -1,0 +1,108 @@
+namespace eval qc {
+    namespace export bs_capsule_*
+}
+
+proc qc::bs_capsule_text {args} {
+    #| Returns bootstrap floating label form group for text input
+    args_check_required $args name value label
+    array set this $args
+    set this(type) text
+    default this(id) $this(name)
+
+    set group [list]
+    lappend group [h label for $this(id) $this(label)]
+    lappend group [h input type $this(type) class "form-control" placeholder \
+		       $this(label) value $this(value) name $this(name) \
+		       id $this(id)]
+    if {[info exist this(unit)]} {
+	lappend group [h span \
+			   class "help-block help-block-inline help-block-background" \
+			   $this(unit)]
+    }
+    return [h div class "form-group" [join $group \n]]
+
+}
+
+proc qc::bs_capsule_password {args} {
+    #| Returns bootstrap floating label form group for password input
+    args_check_required $args name value label
+    array set this $args
+    set this(type) password
+    default this(id) $this(name)
+
+    set group [list]
+    lappend group [h label for $this(id) $this(label)]
+    lappend group [h input type $this(type) class "form-control" \
+		       placeholder $this(label) value $this(value) \
+		       name $this(name) id $this(id)]
+    return [h div class "form-group" [join $group \n]]
+
+}
+
+
+proc qc::bs_capsule_select {args} {
+    #| Returns bootstrap floating label form group for dropdown
+    args_check_required $args name value options label
+    array set this $args
+    default this(id) $this(name)
+    default this(null_option) no
+
+    set group [list]
+    lappend group [h label for $this(id) $this(label)]
+    set dropdown [qc::widget_select name $this(name) id $this(id) \
+		      value $this(value) options $this(options) \
+		      class "form-control" null_option $this(null_option)]
+    lappend group [h div class "select-wrapper" $dropdown]
+
+    return [h div class "form-group form-group-select" [join $group \n]]
+}
+
+proc qc::bs_capsule_textarea {args} {
+    #| Returns bootstrap floating label form group for textarea
+    args_check_required $args name value label
+    array set this $args
+    default this(id) $this(name)
+    default this(rows) 25
+
+    set group [list]
+    lappend group [h label for $this(id) $this(label)]
+    lappend group [h textarea class "form-control" rows $this(rows) \
+		       placeholder $this(label)  name $this(name) id $this(id) \
+		       $this(value)]
+    return [h div class "form-group form-group-textarea" [join $group \n]]
+}
+
+proc qc::bs_capsule_button {args} {
+    #| Returns bootstrap flavoured button 
+    array set this $args
+    default this(type) submit
+    default this(label) Submit
+    
+    return [h button type $this(type) class "btn btn-default" $this(label)]    
+}
+
+proc qc::bs_capsule_markdown {args} {
+    #| Returns bootstrap floating label form group for markdown textarea
+    args_check_required $args name value label
+    array set this $args
+    default this(id) $this(name)
+
+    set group [list]
+    lappend group [h label for $this(id) $this(label)]
+    lappend group [h textarea class "form-control" placeholder $this(label) \
+		       name $this(name) id $this(id) $this(value)]
+
+    return [h div class "form-group form-group-markdown" [join $group \n]]
+}
+
+proc qc::bs_capsule_checkbox {args} {
+    #| Returns bootstrap flavoured checkbox
+    args_check_required $args name value label
+    array set this $args
+    default this(id) $this(name)
+    set this(type) checkbox
+    set this(checked) [true $this(value)]
+
+    set checkbox [h input {*}[qc::dict_exclude [array get this] label]]
+    return [h div class checkbox [h label ${checkbox}$this(label)]]
+}

--- a/tcl/bs_form_layout.tcl
+++ b/tcl/bs_form_layout.tcl
@@ -1,0 +1,35 @@
+namespace eval qc {
+    namespace export bs_form_layout_*
+}
+
+proc qc::bs_form_layout_capsule {args} {
+    #| Constructs a bootstrap floating label form layout with labels 
+    # and form elements
+    args $args -- conf
+    
+    set level 1
+    set body [list]
+    
+    foreach dict $conf {
+	array set this $dict	
+	default this(type) text
+
+	if { ![info exists this(value)] } {
+	    qc::upcopy $level $this(name) value
+	    if {[info exists value]} {
+		set this(value) $value
+	    } else {
+		set this(value) ""
+	    }
+	}
+	if {[info procs "::qc::bs_capsule_$this(type)"] ne "::qc::bs_capsule_$this(type)"} {
+	    error "No widget proc defined for $this(type)"
+	}
+
+	lappend body ["qc::bs_capsule_$this(type)" {*}[array get this]]
+	
+	unset this
+	
+    }
+    return [join $body "\n"]
+}

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -1,31 +1,16 @@
 namespace eval qc {
-    namespace export cast_*
+    namespace export cast_* data_type_error_check
 }
 
 proc qc::cast_integer {string} {
+    #| Deprecated - see qc::cast integer
     #| Try to cast given string into an integer
-    set original $string
-    # Convert e notation
-    if { [string first e $string]!=-1 || [string first E $string]!=-1 } {
-	set string [exp2string $string]
-    }
-    set string [string map {, {} % {}} $string]
-    # Strip leading zeros if followed by digit
-    # This copes with 0 and 00
-    regsub {^(-?)0+([0-9]+)$} $string {\1\2} string
-    # Convert decimals
-    if { [string first . $string]!=-1 } {
-	set string [qc::round $string 0]
-    }
-    if { [qc::is_integer $string] } {
-	return $string
-    } else {
-	error "Could not cast $original to integer" {} CAST
-    }
+    return [qc::cast integer $string]
 }
 
 proc qc::cast_int {string} {
-    return [qc::cast_integer $string]
+    #| Deprecated - see qc::cast integer
+    return [qc::cast integer $string]
 }
 
 proc qc::cast_decimal {string {precision ""}} {
@@ -43,339 +28,311 @@ proc qc::cast_decimal {string {precision ""}} {
 }
 
 proc qc::cast_date {string} {
+    #| Deprecated - see qc::cast date
     #| Try to convert the given string into an ISO date.
-    return [clock format [cast_epoch $string] -format "%Y-%m-%d"]
+    return [qc::cast date $string]
 }
 
 proc qc::cast_timestamp {string} {
+    #| Deprecated - see qc::cast timestamp
     #| Try to convert the given string into an ISO datetime.
-    return [clock format [cast_epoch $string] -format "%Y-%m-%d %H:%M:%S"]
+    return [qc::cast timestamp $string]
 }
 
 proc qc::cast_timestamptz {string} {
+    #| Deprecated - see qc::cast timestamptz
     #| Try to convert the given string into an ISO datetime with timezone.
-    return [clock format [cast_epoch $string] -format "%Y-%m-%d %H:%M:%S %z"]
+    return [qc::cast timestamptz $string]
 }
 
 proc qc::cast_epoch { string } {
+    #| Deprecated - see qc::cast epoch
     #| Try to convert the given string into an epoch
-    #
-    set string [string map [list "&#8209;" -] $string]
-    #### EXACT MATCHES ####
-    if { [string equal $string ""] } {
-	error "Can't cast an empty string to epoch"
-    }
-    # Looks like a number but really an iso date without delimitor.
-    if { [regexp {^(19\d\d|20\d\d)(\d\d)(\d\d)$} $string -> year month day] } {
-	return [clock scan "$year-$month-$day"]
-    }
-    # Already an epoch
-    if { [string is wideinteger -strict $string] } {
-        if { $string > [clock scan "5000-01-01"] } {
-            # Interpret as milliseconds past epoch
-            return [expr {${string}/1000}]
-        } elseif { $string>31 } {
-            return $string
-        }
-    }
-    # Exact ISO date
-    if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})$} $string -> year month day] } {
-	 return [clock scan "$year-$month-$day"]
-    }
-    # Exact ISO datetime
-    if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})( |T)(\d{1,2}:\d{1,2}(:\d{1,2})?)$} $string -> year month day . time] } {
-	return [clock scan "$year-$month-$day $time"]
-    }
-    # Exact ISO datetime with offset timezone e.g. "2012-08-13 10:21:23.7777 -06:00"
-    # Accepts offsets in formats -hh, -hhmm, or -hh:mm
-    if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})(?: |T)(\d{1,2}:\d{1,2})(?::(\d{1,2})(?:\.\d+)?)?\s?(Z|[-+]\d\d(:?\d\d)?)$} $string -> year month day time sec timezone] } {
-        if { $timezone eq "Z" } {
-            set timezone "+00"
-        }
-        if { $sec ne "" } {
-            set time "$time:$sec"
-        }
-	return [clock scan "$year-$month-$day $time" -timezone "$timezone"]
-    }
-    # rfc-822 style dates used in emails.
-    # "Fri, 17 Aug 2012 12:51:36 +0100"
-    if { [regexp {(\d{1,2}) +(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December) +(\d{4}) +(\d{1,2}:\d{1,2})(?::(\d{1,2})(?:\.\d+)?)?\s?(Z|[-+]\d\d(:?\d\d)?)} $string -> day mon year time sec timezone] } {
-        if { $timezone eq "Z" } {
-            set timezone "+00"
-        }
-        if { $sec ne "" } {
-            set time "$time:$sec"
-        }
-        set month [expr {[lsearch {January February March April May June July August September October November December} "${mon}*"]+1}]
-	return [clock scan "$year-$month-$day $time" -timezone "$timezone"]
-    }
-    # ISO datetime Don't match the end of line for e.g. "2009-04-06 12:25:18.343"
-    if { [regexp {^(19\d\d|20\d\d)(\d\d)(\d\d)( |T)(\d{1,2}:\d{1,2}(:\d{1,2})?)} $string -> year month day . time] } {
-	return [clock scan "$year-$month-$day $time"]
-    }
-    # dd/mm/yyYY
-    if { [regexp {^(\d{1,2})[/\.](\d{1,2})[/\.](\d{4}|\d{2}|\d)$} $string -> day month year] } {
-	# Assume UK locale dd/mm/yy or dd.mm.yy
-	return [clock scan "$year-$month-$day"]
-    }
-    #### RELATIVE ####
-    if { [regexp -nocase -- {(\+-)? ?(this|last|next|[0-9]+) ?(year|month|week|day|hour|minute)s?( ago)?} $string] \
-	     || [regexp -nocase -- {(this|last|next) (Mon|Monday|Tue|Tuesday|Wed|Wednesday|Thu|Thurs|Thursday|Fri|Friday|Sat|Saturday|Sun|Sunday)} $string] \
-	     || [regexp -nocase -- {today|yesterday|tomorrow} $string] } {
-	return [clock scan $string]
-    }
-    #### RELAXED ####
-    # Look for time hh:mm or hh:mm:ss
-    if { ![regexp {(^|\W)(\d{1,2}:\d{1,2}(:\d{1,2})?)(\W|$)} $string -> ~ time ~] } { set time "" }
-    # ISO format
-    if { [regexp {(^|[^0-9])(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})([^0-9]|$)} $string -> start year month day end] } {
-	 return [clock scan "$year-$month-$day $time"]
-    }
-    if { [regexp {(^|[^0-9])(\d{1,2})[/\.](\d{1,2})[/\.](\d{4}|\d{2}|\d)([^0-9]|$)} $string -> start day month year end] } {
-	# Assume UK locale dd/mm/yy or dd.mm.yy
-	return [clock scan "$year-$month-$day $time"]
-    }
-    # dd/mm or dd.mm
-    if { [regexp {(^|\W)(\d{1,2})[/\.](\d{1,2})(\W|$)} $string -> start day month end] } {
-	set year [clock format [clock seconds] -format "%Y"]
-	return [clock scan "$year-$month-$day $time"]
-    }
-    if { [regexp {(^|[^0-9])(\d{4})([^0-9]|$)} $string -> start year end] } {
-	#### Matched YEAR ####
-	# year && month && dom
-	# 23 June 2006 or June 23rd 2006
-	if { [regexp -nocase -- {(^|[^a-zA-Z])(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)([^a-zA-Z]|$)} $string -> start month_name end] \
-	     && [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)?(\W|$)} $string -> start dom suffix end] } {
-	    # month and dom
-	    return [clock scan "$dom $month_name $year $time"]
-	}
-    } else {
-	#### NO YEAR ####
-	# no year && month && dom
-	# 23rd June or Sept 11th
-	if { [regexp -nocase -- {(^|[^a-zA-Z])(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)([^a-zA-Z]|$)} $string -> start month_name end] \
-		 && [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)(\W|$)} $string -> start dom suffix end] } {	 
-	    set year [clock format [clock seconds] -format "%Y"]
-	    return [clock scan "$dom $month_name $year $time"]
-	}
-	# dd or dd+suffix eg 23rd or 2nd ONLY 
-	if { [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)?(\W|$)} $string -> start day suffix end] } {
-	    set year [clock format [clock seconds] -format "%Y"]
-	    set month [clock format [clock seconds] -format "%m"]
-	    return [clock scan "$year-$month-$day $time"]
-	}	
-	if { [regexp -nocase -- {(^|\W)(Mon|Monday|Tue|Tuesday|Wed|Wednesday|Thu|Thurs|Thursday|Fri|Friday|Sat|Saturday|Sun|Sunday)(\W|$)} $string -> start dow end] } {
-	    return [clock scan "$dow $time"]
-	}
-    }
-    # try TCL
-    return [clock scan $string]
+    return [qc::cast epoch $string]
 }
 
 proc qc::cast_boolean { string {true t} {false f} } {
+    #| Deprecated - see qc::cast boolean
     #| Cast a string as a boolean
-    # strip html
-    # TODO Aolserver only
-    set string [qc::strip_html $string]
-    if { [in {Y YES TRUE T 1} [upper $string]] } {
-	return $true
-    } elseif { [in {N NO FALSE F 0} [upper $string]] } {
-	return $false
-    } else {
-	error "Can't cast \"$string\" to boolean data type"
-    }
+    return [qc::cast boolean $string $true $false]
 }
 
 proc qc::cast_bool { string {true t} {false f} } {
-    return [qc::cast_boolean $string $true $false]
+    #| Deprecated - see qc::cast boolean
+    return [qc::cast boolean $string $true $false]
 }
 
 proc qc::cast_postcode { postcode } {
+    #| Deprecated - see qc::cast postcode
     #| Try to cast a string into UK Postcode form
-    set saved $postcode
-    set postcode [string toupper $postcode]
-    # BFPO 
-    if { [eq [string range $postcode 0 3] BFPO] } {
-	return $postcode
-    }
-    # convert AB12CD -> AB1 2CD or AB123CD -> AB12 3CD
-    if { [string first " " $postcode] == -1 } {
-	set cut [expr {[string length $postcode]-3-1}]
-	set postcode "[string range $postcode 0 $cut] [string range $postcode [expr {$cut+1}] end]"
-    }
-    if { [is_postcode $postcode] } {
-	return $postcode
-    }
-    # Convert zero -> CAPITAL O e.g. "Y023 3CD" -> "YO23 3CD"
-    regsub {^([A-Z])0([0-9]{1,2}) (.+)$} $postcode {\1O\2 \3} postcode
-
-    if { [is_postcode $postcode] } {
-	return $postcode
-    } else {
-	error "Could not cast $saved to Postcode."
-    }
+    return [qc::cast postcode $postcode]
 }
 
 proc qc::cast_creditcard { no } {
-    regsub -all {[^0-9]} $no "" no
-    if { [is_creditcard $no] } {
-	return $no
-    } else {
-	error "$no is not a valid credit card number"
-    }
+    #| Deprecated - see qc::cast creditcard
+    return [qc::cast creditcard $no]
 }
 
 proc qc::cast_period {string} {
+    #| Deprecated - see qc::cast period
     #| Return a pair of dates defining the period.
-    set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
-    set regexp_map [list \$month_names_regexp [join $month_names |]]
+    return [qc::cast period $string]
+}
 
-    if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
-        # Period defined by two periods eg "Jan 2011 to March 2011"
-        lassign [qc::cast_period $period1] from_date .
-        lassign [qc::cast_period $period2] . to_date
+proc qc::cast_url {string} {
+    #| Deprecated - see qc::cast url
+    #| (See also qc::is url)
+    return [qc::cast url $string]
+}
 
-    } elseif { [qc::is_date $string] } {
-        # String is an iso date eg "2014-01-01"
-        set from_date $string
-        set to_date $from_date
-
-    } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
-        # Exact match for year eg "2006"
-        set from_date [date_year_start $year-01-01]
-        set to_date [date_year_end $year-01-01]
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([12]\d{3})$}] $string -> month_name year] } {
-        # Exact match in format "Jan 2006"
-        set epoch [clock scan "01 $month_name $year"]
-        set from_date [date_month_start $epoch]
-        set to_date [date_month_end $epoch]
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)$}] $string -> month_name] } {
-        # Exact match in format "Jan" (assume current year)
-        set epoch [clock scan "01 $month_name [date_year now]"]
-        set from_date [date_month_start $epoch]
-        set to_date [date_month_end $epoch]
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)\s+([12]\d{3})$}] $string -> dom month_name year] } {
-        # Exact match for castable date in format "1st Jan 2014"
-        set epoch [clock scan "$dom $month_name $year"]
-        set from_date [cast_date $epoch]
-        set to_date $from_date
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)$}] $string -> dom month_name] } {
-        # Exact match for castable date in format "1st Jan" (assume current year)
-        set epoch [clock scan "$dom $month_name [date_year now]"]
-        set from_date [cast_date $epoch]
-        set to_date $from_date
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?\s+([12]\d{3})$}] $string -> month_name dom year] } {
-        # Exact match for castable date in format "Jan 1st 2014"
-        set epoch [clock scan "$dom $month_name $year"]
-        set from_date [cast_date $epoch]
-        set to_date $from_date
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?$}] $string -> month_name dom] } {
-        # Exact match for castable date in format "Jan 1st" (assume current year)
-        set epoch [clock scan "$dom $month_name [date_year now]"]
-        set from_date [cast_date $epoch]
-        set to_date $from_date
-
-    } else {
-        # error - could not parse string
-        error "Could not parse string \"$string\" into dates that define a period."
-    }
-    
-    return [list $from_date $to_date]
+proc qc::cast_relative_url {string} {
+    #| Deprecated - see qc::cast url
+    #| (See also qc::is url)
+    return [qc::cast relative_url $string]
 }
 
 proc qc::is_period {string} {
+    #| Deprecated - see qc::is period
     #| Test if string can be casted to a pair of dates defining a period.
-    set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
-    set regexp_map [list \$month_names_regexp [join $month_names |]]
+    return [qc::is period $string]
+}
 
-    if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
-        # Period defined by two periods eg "Jan 2011 to March 2011"
-        if { [qc::is_period $period1] && [qc::is_period $period2] } {
-            return true
-        } else {
-            return false
-        }
-
-    } elseif { [qc::is_date $string] } {
-        # String is an iso date eg "2014-01-01"
-        return true
-
-    } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
-        # Exact match for year eg "2006"
-        return true
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([12]\d{3})$}] $string -> month_name year] } {
-        # Exact match in format "Jan 2006"
-        return true
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)$}] $string -> month_name] } {
-        # Exact match in format "Jan" (assume current year)
-        return true
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)\s+([12]\d{3})$}] $string -> dom month_name year] } {
-        # Exact match for castable date in format "1st Jan 2014"
-        return true
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)$}] $string -> dom month_name] } {
-        # Exact match for castable date in format "1st Jan" (assume current year)
-        return true       
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?\s+([12]\d{3})$}] $string -> month_name dom year] } {
-        # Exact match for castable date in format "Jan 1st 2014"
-        return true
-
-    } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?$}] $string -> month_name dom] } {
-        # Exact match for castable date in format "Jan 1st" (assume current year)
-        return true
-
-    } else {
-        # could not parse string
-        return false
+proc qc::cast_value2model {name value} {
+    #| Return the value cast to the data model.
+    #| Name can be a partial or fully qualified column identifier.
+    
+    # Resolve name to column, table, and schema
+    lassign [qc::memoize qc::db_resolve_field_name $name] {*}{
+        schema
+        table
+        column
     }
 
-    if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
-        # Period defined by two periods eg "Jan 2011 to March 2011"
-        if { [qc::is_period $period1] && [qc::is_period $period2] } {
-            return true
-        } else {
-            return false
-        }
+    set data_type [qc::memoize qc::db_column_type \
+                       -qualified -- $schema $table $column]
+    set nullable [qc::memoize qc::db_column_nullable $schema $table $column]
 
-    } elseif { [qc::is_date $string] } {
-        # String is an iso date eg "2014-01-01"
-        return true
+    # Check if nullable
+    if {! $nullable && $value eq ""} {
+        error "$column cannot be empty."
+    } elseif {$nullable && $value eq ""} {
+        return $value
+    }
 
-    } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
-        # Exact match for year eg "2006"
-        return true
-
-    } elseif { [regexp -nocase -- {^([0-9]+)(?:st|th|nd|rd)?\s+(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)(?:\s+([12]\d{3}))?$} $string -> dom month_name year] } {
-        # Exact match for castable date in format "1st Jan 2014" or "1st Jan"
-        return true
-
-    } elseif { [regexp -nocase -- {^(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)\s+([0-9]+)(?:st|th|nd|rd)?(?:\s+([12]\d{3}))?$} $string -> month_name dom year] } {
-        # Exact match for castable date in format "Jan 1st 2014" or "Jan 1st"
-        return true
-
-    }  elseif { [regexp -nocase -- {^(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)(?:\s+([12]\d{3}))?$} $string -> month_name year] } {
-        # Exact match in format "Jan 2006" or "Jan"
-        return true
-
-    }  else {
-        # could not parse string
-        return false
+    # Check value against data type
+    if {[qc::castable $data_type $value]} {
+        return [qc::cast $data_type $value]
+    } else {
+        error [qc::data_type_error_check $data_type $value]
     }
 }
 
+proc qc::cast_values2model {args} {
+    #| Check the data types of the values against the definitions for these names.
+    #| Returns a new list of values after casting to appropriate type.
+    #| Throws an error if type-checking fails.
+    if { [llength $args]%2 != 0 } {
+        return -code error "usage cast_values2model name value ?name value?"
+    }
+    set casted_dict {}
+    set errors {}
+    
+    dict for {name value} $args {
+
+        # Resolve name to column, table, and schema
+        lassign [qc::memoize qc::db_resolve_field_name $name] {*}{
+            schema
+            table
+            column
+        }
+        
+        set data_type [qc::memoize qc::db_column_type \
+                           -qualified -- $schema $table $column]
+        set nullable [qc::memoize qc::db_column_nullable $schema $table $column]
+
+        # Check if nullable
+        if {! $nullable && $value eq ""} {
+            lappend errors "$column cannot be empty."
+            continue
+        } elseif {$nullable && $value eq ""} {
+            lappend casted_dict $name $value
+            continue
+        }
+
+        # Check value against data type
+        if {[qc::castable $data_type $value]} {
+            lappend casted_dict $name [qc::cast $data_type $value]
+        } else {           
+            lappend errors [qc::html_escape [qc::data_type_error_check $data_type $value]]
+        }
+    }
+    
+    if {[llength $errors] > 0} {
+        return -code error -errorcode USER [qc::html_list $errors]
+    } else {
+        return $casted_dict
+    }
+}
+
+proc qc::data_type_error_check {data_type value} {
+    #| Checks the given value against the data type and reports any error.
+    switch -regexp -matchvar matches -- $data_type {
+        {^varchar(\(([0-9]+)\))?$} {
+            set length [string range [lindex $matches 1] 1 [expr {[string length [lindex $matches 1]] - 2}]]              
+            if {! [qc::is varchar $length $value]} {
+                return "\"[qc::trunc $value 100]...\" is too long. Must be $length characters or less."
+            }
+        }
+        {^char(\(([0-9]+)\))?$} {
+            set length [string range [lindex $matches 1] 1 [expr {[string length [lindex $matches 1]] - 2}]]
+            set chars "characters"
+            if {$length eq ""} {
+                set length 1
+                set chars "character"
+            }
+            if {! [qc::is char $length $value]} {
+                if {[string length $value] < $length} {
+                    return "\"$value\" is too short. Must be exactly $length $chars."
+                } elseif {[string length $value] > $length} {
+                    return "\"[qc::trunc $value 100]...\" is too long. Must be exactly $length $chars."
+                }
+            }
+        }
+        ^int4$ {
+            if {! [qc::is integer $value] && ! [qc::castable integer $value]} {
+                return "\"$value\" is not a valid integer. It must be a number between -2147483648 and 2147483647."
+            }
+        }
+        ^int8$ {
+            if {! [qc::is bigint $value] && ! [qc::castable bigint $value]} {
+                return "\"$value\"is not a valid big int. It must be a number between -9223372036854775808 and 9223372036854775807."
+            } 
+        }
+        ^int2$ {
+            if {! [qc::is smallint $value] && ![qc::castable smallint $value]} {
+                return "\"$value\"is not a valid small int. It must be a number between -32768 and 32767."
+            }  
+        }
+        ^bool$ {
+            if {! [qc::is boolean $value] && ! [qc::castable boolean $value]} {
+                return "\"$value\"is not a valid boolean value."
+            }
+        }
+        ^timestamp$ {
+            if {! [qc::is timestamp $value] && ! [qc::castable timestamp $value]} {
+                return "\"$value\"is not a valid timestamp."
+            }
+            
+        }
+        ^timestamptz$ {
+            if {! [qc::is timestamptz $value] && ! [qc::castable timestamptz $value]} {
+                return "\"$value\"is not a valid timestamptz."
+            }           
+        }
+        {^(numeric|decimal)$} {
+            if {! [qc::is decimal $value] && ! [qc::castable decimal $value]} {
+                return "\"$value\"is not a valid decimal."
+            }
+        }
+        ^text$ {
+            return
+        }
+        ^safe_html$ {
+            if {! [qc::is safe_html $value]} {
+                return "\"[qc::trunc $value 50]...\" contains invalid or unsafe HTML."
+            }
+        }
+        ^safe_markdown$ {
+            if {! [qc::is safe_markdown $value]} {
+                return "\"[qc::trunc $value 50]...\" contains invalid or unsafe HTML."
+            }
+        }
+        default {
+            # might be an enumeration or domain
+            if {[qc::memoize qc::db_enum_exists $data_type]} {
+                if {! [qc::castable enumeration $data_type $value]} {
+                    return "\"$value\" is not a valid value for enum \"$data_type\"."
+                }
+            } elseif {[qc::memoize qc::db_domain_exists $data_type]} {
+                set base_type [qc::memoize qc::db_domain_base_type $data_type]
+                set constraints [qc::memoize qc::db_domain_constraints $data_type]
+                set is_base_type [qc::is $base_type $value]
+                set failed_constraints [list]
+                dict for {constraint_name check_clause} $constraints {
+                    if { ! [qc::db_eval_domain_constraint $value $base_type $check_clause] } {
+                        lappend failed_constraints $constraint_name
+                    }
+                }
+                if { ! $is_base_type && [llength $failed_constraints] > 0 } {
+                    return "[data_type_error_check $base_type $value] and failed to meet the constraint(s) [join $failed_constraints ", "]"
+                } elseif { ! $is_base_type } {
+                    return [qc::data_type_error_check $base_type $value]
+                } elseif { [llength $failed_constraints] > 0 } {
+                    return "\"[qc::trunc $value 100]...\" failed to meet the constraint(s) [join $failed_constraints ", "]"
+                }
+            } else {
+                return -code error "Unrecognised data type \"$data_type\""
+            }
+        }
+    }
+    return
+}
+
+
 namespace eval qc::cast {
-    namespace export decimal
-    namespace ensemble create 
+    
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown date postcode creditcard period epoch url url_relative url_path time
+    namespace ensemble create -unknown {
+        data_type_parser
+    }
+
+    proc integer {string} {
+        #| Try to cast given string into an integer
+        set result [integer_convert $string]
+        if { [qc::is integer $result] } {
+            return $result
+        } else {
+            return -code error -errorcode CAST "Could not cast $string to integer."
+        }
+    }
+
+    proc bigint {string} {
+        #| Try to cast the given string into an integer checking if it falls into big int range.
+        set result [integer_convert $string]
+        if { [qc::is bigint $result] } {
+            return $result
+        } else {
+            return -code error -errorcode CAST "Could not cast $string to bigint."
+        }
+    }
+
+    proc smallint {string} {
+        #| Try to cast the given string into an integer checking if it falls into small int range.
+        set result [integer_convert $string]
+        if { [qc::is smallint $result] } {
+            return $result
+        } else {
+            return -code error -errorcode CAST "Could not cast $string to smallint."
+        }
+    }
+
+    proc integer_convert {string} {
+        #| Tries to form an integer from the given string.
+        set original $string
+        # Convert e notation
+        if { [string first e $string]!=-1 || [string first E $string]!=-1 } {
+            set string [qc::exp2string $string]
+        }
+        set string [string map {, {} % {}} $string]
+        # Strip leading zeros if followed by digit
+        # This copes with 0 and 00
+        regsub {^(-?)0+([0-9]+)$} $string {\1\2} string
+        # Convert decimals
+        if { [string first . $string]!=-1 } {
+            set string [qc::round $string 0]
+        }
+        return $string
+    }
 
     proc decimal {args} {
         #| Try to cast given string into a decimal value with the given precision and/or scale if present.
@@ -427,5 +384,449 @@ namespace eval qc::cast {
         } else {
             return -code error -errorcode CAST "Could not cast $original to decimal."
         }
+    }
+
+    proc boolean { string {true t} {false f} } {
+        #| Cast a string as a boolean.
+        if { [string toupper $string] in {Y YES TRUE T 1} } {
+            return $true
+        } elseif {[string toupper $string] in {N NO FALSE F 0} } {
+            return $false
+        } else {
+            return -code error -errorcode CAST "Can't cast \"$string\" to boolean data type."
+        }
+    }
+
+    proc timestamp {string} {
+        #| Try to convert the given string into an ISO datetime.
+        return [clock format [epoch $string] -format "%Y-%m-%d %H:%M:%S"]
+    }
+
+    proc timestamptz {string} {
+        #| Try to convert the given string into an ISO datetime with timezone.
+        return [clock format [epoch $string] -format "%Y-%m-%d %H:%M:%S %z"]
+    }
+
+    proc char {length string} {
+        #| Cast to char.
+        if { [string length $string] == $length } {
+            return $string
+        } else {
+            return -code error -errorcode CAST "Can't cast \"$string\" to char($length) data type."
+        }
+    }
+
+    proc varchar {length string} {
+        #| Cast to varchar.
+        if { [string length $string] <= $length } {
+            return $string
+        } else {
+            return -code error -errorcode CAST "Can't cast \"$string\" to varchar($length). String is too long."
+        }
+    }
+
+    proc text {string} {
+        #| Cast to text.
+        return $string
+    }
+    
+    proc enumeration {name value} {
+        #| Cast $value to enumeration of $name.
+        set value [string toupper $value]
+        if {$value in [qc::memoize qc::db_enum_values $name]} {
+            return $value
+        } else {
+            return -code error -errorcode CAST "Can't cast \"$value\": not a valid value for enumeration \"$name\"."
+        }
+    }
+
+    proc domain {domain_name value} {
+        #| Cast value to the domain $domain_name.
+        set base_type [qc::memoize qc::db_domain_base_type $domain_name]
+        if { [qc::castable $base_type $value] } {
+            set value [qc::cast $base_type $value]
+        } else {
+            return -code error -errorcode CAST "Can't cast \"[qc::trunc $value 100]...\": not a valid value for base type \"$base_type\" while checking \"$domain_name\" type."
+        }
+
+        if { [qc::is $domain_name $value] } {
+            return $value
+        } else {
+            return -code error -errorcode CAST "Can't cast \"[qc::trunc $value 100]...\": not a valid value for \"$domain_name\"."
+        }
+    }
+
+    proc safe_html {text} {
+        #| Cast text to safe html.
+        if { [qc::is safe_html $text] } {
+            return $text
+        } else {
+            return -code error -errorcode CAST "Can't cast \"[qc::trunc $text 100]...\": not safe html."
+        }
+    }
+
+    proc safe_markdown {text} {
+        #| Cast text to safe markdown.
+        if {[qc::is safe_markdown $text]} {
+            return $text
+        } else {
+            return -code error -errorcode CAST "Can't cast \"[qc::trunc $text 100]...\": not safe markdown."
+        }
+    }
+
+    proc date {string} {
+        #| Try to convert the given string into an ISO date.
+        return [clock format [epoch $string] -format "%Y-%m-%d"]
+    }
+
+    proc time {time} {
+        #| Try to convert the given string into a time,
+        # in hh:mm:ss or hh:mm:ss.xxxxxx format
+        if { [regexp {^((?:[0-1])?[0-9]|2[0-3]):((?:[0-5])?[0-9]):([0-5][0-9])\.(\d+)$} \
+                  $time -> hours minutes seconds subseconds] } {
+        } elseif {[regexp {^((?:[0-1])?[0-9]|2[0-3]):((?:[0-5])?[0-9]):([0-5][0-9])$} \
+                  $time -> hours minutes seconds] } {
+            set subseconds 0
+        } elseif {[regexp {^((?:[0-1])?[0-9]|2[0-3]):((?:[0-5])?[0-9])$} \
+                       $time -> hours minutes] } {
+            set seconds 00
+            set subseconds 0
+        } elseif { [regexp {^24:00(:00(\.0+)?)?$} $time] } {
+            set hours 24
+            set minutes 00
+            set seconds 00
+            set subseconds 0
+        } else {
+            return -code error -errorcode CAST "Can't cast \"[qc::trunc $time 100]...\": not recognised time."            
+        }
+        set hours [format %02s $hours]
+        set minutes [format %02s $minutes]
+        set seconds [format %02s $seconds]
+        set subseconds [qc::cast decimal -precision 7 -scale 6 "0.$subseconds"]
+
+        if { $subseconds > 0.0 } {
+            set subseconds [string range [string trimright $subseconds 0] 2 end]
+            return "${hours}:${minutes}:${seconds}.$subseconds"
+            
+        } else {
+            return "${hours}:${minutes}:${seconds}"
+        }
+    }
+
+    proc epoch {string} {
+        #| Try to convert the given string into an epoch.
+        set string [string map [list "&#8209;" -] $string]
+
+        #### EXACT MATCHES ####
+        if { [string equal $string ""] } {
+            return -code error -errorcode CAST "Can't cast an empty string to epoch"
+        }
+
+        # Looks like an eight-digit number, try to interpret as yyyymmdd or ddmmyyyy
+        if { [regexp {^\d{8}$} $string] } {
+
+            # Try yyyymmdd
+            set year1 [string range $string 0 3]
+            set month1 [string range $string 4 5]
+            set day1 [string range $string 6 7]
+
+            if { 0 < $month1 && $month1 <= 12
+                 &&
+                 0 < $day1 && $day1 <= [lindex {
+                     - 31 29 31 30 31 30 31 31 30 31 30 31
+                 } [string trimleft $month1 0]]
+                 &&
+                 1990 <= $year1 && $year1 < 2100
+             } {
+                set date1_valid true
+            } else {
+                set date1_valid false
+            }
+
+            # Try ddmmyyyy
+            set year2 [string range $string 4 7]
+            set month2 [string range $string 2 3]
+            set day2 [string range $string 0 1]
+
+            if { 0 < $month2 && $month2 <= 12
+                 &&
+                 0 < $day2 && $day2 <= [lindex {
+                     - 31 29 31 30 31 30 31 31 30 31 30 31
+                 } [string trimleft $month2 0]]
+                 &&
+                 1990 <= $year2 && $year2 < 2100
+             } {
+                set date2_valid true
+            } else {
+                set date2_valid false
+            }
+
+            # If one result is valid, return it. If both are, error.
+            if { $date1_valid && $date2_valid } {
+                return -code error -errorcode CAST "Ambiguous date"
+
+            } elseif { $date1_valid } {
+                return [clock scan "$year1-$month1-$day1"]
+
+            } elseif { $date2_valid } {
+                return [clock scan "$year2-$month2-$day2"]
+
+            }
+        }
+
+        # Already an epoch
+        if { [string is wideinteger -strict $string] } {
+            if { $string > [clock scan "5000-01-01"] } {
+                # Interpret as milliseconds past epoch
+                return [expr {${string}/1000}]
+            } elseif { $string>31 } {
+                return $string
+            }
+        }
+
+        # Exact ISO date
+        if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})$} $string -> year month day] } {
+            return [clock scan "$year-$month-$day"]
+        }
+
+        # Exact ISO datetime
+        if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})( |T)(\d{1,2}:\d{1,2}(:\d{1,2})?)$} $string -> year month day . time] } {
+            return [clock scan "$year-$month-$day $time"]
+        }
+
+        # Exact ISO datetime with offset timezone e.g. "2012-08-13 10:21:23.7777 -06:00"
+        # Accepts offsets in formats -hh, -hhmm, or -hh:mm
+        if { [regexp {^(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})(?: |T)(\d{1,2}:\d{1,2})(?::(\d{1,2})(?:\.\d+)?)?\s?(Z|[-+]\d\d(:?\d\d)?)$} $string -> year month day time sec timezone] } {
+            if { $timezone eq "Z" } {
+                set timezone "+00"
+            }
+            if { $sec ne "" } {
+                set time "$time:$sec"
+            }
+            return [clock scan "$year-$month-$day $time" -timezone "$timezone"]
+        }
+
+        # rfc-822 style dates used in emails.
+        # "Fri, 17 Aug 2012 12:51:36 +0100"
+        if { [regexp {(\d{1,2}) +(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December) +(\d{4}) +(\d{1,2}:\d{1,2})(?::(\d{1,2})(?:\.\d+)?)?\s?(Z|[-+]\d\d(:?\d\d)?)} $string -> day mon year time sec timezone] } {
+            if { $timezone eq "Z" } {
+                set timezone "+00"
+            }
+            if { $sec ne "" } {
+                set time "$time:$sec"
+            }
+            set month [expr {[lsearch {January February March April May June July August September October November December} "${mon}*"]+1}]
+            return [clock scan "$year-$month-$day $time" -timezone "$timezone"]
+        }
+
+        # ISO datetime Don't match the end of line for e.g. "2009-04-06 12:25:18.343"
+        if { [regexp {^(19\d\d|20\d\d)(\d\d)(\d\d)( |T)(\d{1,2}:\d{1,2}(:\d{1,2})?)} $string -> year month day . time] } {
+            return [clock scan "$year-$month-$day $time"]
+        }
+
+        # dd/mm/yyYY
+        if { [regexp {^(\d{1,2})[-/\.](\d{1,2})[-/\.](\d{4}|\d{2}|\d)$} $string -> day month year] } {
+            # Assume UK locale dd/mm/yy, dd.mm.yy, or dd-mm-yy
+            return [clock scan "$year-$month-$day"]
+        }
+
+        #### RELATIVE ####
+        if { [regexp -nocase -- {(\+-)? ?(this|last|next|[0-9]+) ?(year|month|week|day|hour|minute)s?( ago)?} $string] \
+                 || [regexp -nocase -- {(this|last|next) (Mon|Monday|Tue|Tuesday|Wed|Wednesday|Thu|Thurs|Thursday|Fri|Friday|Sat|Saturday|Sun|Sunday)} $string] \
+                 || [regexp -nocase -- {today|yesterday|tomorrow} $string] } {
+            return [clock scan $string]
+        }
+
+        #### RELAXED ####
+
+        # Look for time hh:mm or hh:mm:ss
+        if { ![regexp {(^|\W)(\d{1,2}:\d{1,2}(:\d{1,2})?)(\W|$)} $string -> ~ time ~] } { set time "" }
+
+        # ISO format
+        if { [regexp {(^|[^0-9])(\d{4}|\d{2}|\d)-(\d{1,2})-(\d{1,2})([^0-9]|$)} $string -> start year month day end] } {
+            return [clock scan "$year-$month-$day $time"]
+        }
+
+        if { [regexp {(^|[^0-9])(\d{1,2})[/\.](\d{1,2})[/\.](\d{4}|\d{2}|\d)([^0-9]|$)} $string -> start day month year end] } {
+            # Assume UK locale dd/mm/yy or dd.mm.yy
+            return [clock scan "$year-$month-$day $time"]
+        }
+
+        # dd/mm or dd.mm
+        if { [regexp {(^|\W)(\d{1,2})[/\.](\d{1,2})(\W|$)} $string -> start day month end] } {
+            set year [clock format [clock seconds] -format "%Y"]
+            return [clock scan "$year-$month-$day $time"]
+        }
+
+        if { [regexp {(^|[^0-9])(\d{4})([^0-9]|$)} $string -> start year end] } {
+            #### Matched YEAR ####
+            # year && month && dom
+            # 23 June 2006 or June 23rd 2006
+            if { [regexp -nocase -- {(^|[^a-zA-Z])(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)([^a-zA-Z]|$)} $string -> start month_name end] \
+                     && [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)?(\W|$)} $string -> start dom suffix end] } {
+                # month and dom
+                return [clock scan "$dom $month_name $year $time"]
+            }
+        } else {
+            #### NO YEAR ####
+            # no year && month && dom
+            # 23rd June or Sept 11th
+            if { [regexp -nocase -- {(^|[^a-zA-Z])(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)([^a-zA-Z]|$)} $string -> start month_name end] \
+                     && [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)(\W|$)} $string -> start dom suffix end] } {	 
+                set year [clock format [clock seconds] -format "%Y"]
+                return [clock scan "$dom $month_name $year $time"]
+            }
+            # dd or dd+suffix eg 23rd or 2nd ONLY 
+            if { [regexp -nocase -- {(^|\W)(\d{1,2})(st|nd|rd|th)?(\W|$)} $string -> start day suffix end] } {
+                set year [clock format [clock seconds] -format "%Y"]
+                set month [clock format [clock seconds] -format "%m"]
+                return [clock scan "$year-$month-$day $time"]
+            }	
+            if { [regexp -nocase -- {(^|\W)(Mon|Monday|Tue|Tuesday|Wed|Wednesday|Thu|Thurs|Thursday|Fri|Friday|Sat|Saturday|Sun|Sunday)(\W|$)} $string -> start dow end] } {
+                return [clock scan "$dow $time"]
+            }
+        }
+
+        if { [regexp -nocase -- {(year|fortnight|month|week|day|hour|min|sec|tomorrow|yesterday|today|now|last|next|ago)} $string] } {
+            return [clock scan $string]
+        }
+
+        return -code error -errorcode CAST "Could not cast string to epoch"
+    }
+
+    proc postcode {string} {
+        #| Try to cast a string into UK Postcode form
+        set saved $string
+        set postcode [string toupper $string]
+        # BFPO 
+        if { [string range $postcode 0 3] eq "BFPO" } {
+            return $postcode
+        }
+        # convert AB12CD -> AB1 2CD or AB123CD -> AB12 3CD
+        if { [string first " " $postcode] == -1 } {
+            set cut [expr {[string length $postcode]-3-1}]
+            set postcode "[string range $postcode 0 $cut] [string range $postcode [expr {$cut+1}] end]"
+        }
+        if { [qc::is postcode $postcode] } {
+            return $postcode
+        }
+        # Convert zero -> CAPITAL O e.g. "Y023 3CD" -> "YO23 3CD"
+        regsub {^([A-Z])0([0-9]{1,2}) (.+)$} $postcode {\1O\2 \3} postcode
+
+        if { [qc::is postcode $postcode] } {
+            return $postcode
+        } else {
+            return -code error -errorcode CAST "Could not cast $saved to postcode."
+        }
+    }
+
+    proc creditcard {string} {
+        #| Cast the given string to a credit card number.
+        regsub -all {[^0-9]} $string "" number
+        if { [qc::is creditcard $number] } {
+            return $number
+        } else {
+            return -code error -errorcode CAST "$number is not a valid credit card number"
+        }
+    }
+
+    proc period {string} {
+        #| Return a pair of dates defining the period.
+        set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
+        set regexp_map [list \$month_names_regexp [join $month_names |]]
+
+        if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
+            # Period defined by two periods eg "Jan 2011 to March 2011"
+            lassign [period $period1] from_date .
+            lassign [period $period2] . to_date
+
+        } elseif { [qc::is date $string] } {
+            # String is an iso date eg "2014-01-01"
+            set from_date $string
+            set to_date $from_date
+
+        } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
+            # Exact match for year eg "2006"
+            set from_date [qc::date_year_start $year-01-01]
+            set to_date [qc::date_year_end $year-01-01]
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([12]\d{3})$}] $string -> month_name year] } {
+            # Exact match in format "Jan 2006"
+            set epoch [clock scan "01 $month_name $year"]
+            set from_date [qc::date_month_start $epoch]
+            set to_date [qc::date_month_end $epoch]
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)$}] $string -> month_name] } {
+            # Exact match in format "Jan" (assume current year)
+            set epoch [clock scan "01 $month_name [qc::date_year now]"]
+            set from_date [qc::date_month_start $epoch]
+            set to_date [qc::date_month_end $epoch]
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)\s+([12]\d{3})$}] $string -> dom month_name year] } {
+            # Exact match for castable date in format "1st Jan 2014"
+            set epoch [clock scan "$dom $month_name $year"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)$}] $string -> dom month_name] } {
+            # Exact match for castable date in format "1st Jan" (assume current year)
+            set epoch [clock scan "$dom $month_name [qc::date_year now]"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?\s+([12]\d{3})$}] $string -> month_name dom year] } {
+            # Exact match for castable date in format "Jan 1st 2014"
+            set epoch [clock scan "$dom $month_name $year"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?$}] $string -> month_name dom] } {
+            # Exact match for castable date in format "Jan 1st" (assume current year)
+            set epoch [clock scan "$dom $month_name [qc::date_year now]"]
+            set from_date [date $epoch]
+            set to_date $from_date
+
+        } else {
+            # error - could not parse string
+            return -code error -errorcode CAST "Could not parse string \"$string\" into dates that define a period."
+        }
+        
+        return [list $from_date $to_date]
+    }
+
+    proc url {string} {
+        #| Cast the given string to an url
+        #| (See also qc::is url)
+        set lower [string tolower $string]
+        if { [qc::is url $lower] } {
+            return $lower
+        }
+        if { [qc::is url "http://${lower}"] } {
+            return "http://${lower}"
+        }
+        return -code error -errorcode CAST "Could not cast $string to an url."
+    }
+
+    proc relative_url {string} {
+        #| Cast the given string to a relative url
+        #| (See also qc::is url)
+        set lower [string tolower $string]
+        if { [qc::is url -relative $lower] } {
+            return $lower
+        }  
+        return -code error -errorcode CAST "Could not cast $string to an url."      
+    }
+    
+    proc url_path {string} {
+	#| Cast the given string to an url_path
+	#| (See also qc::is url_path)
+	set lower [string tolower $string]
+	if { [qc::is url_path $lower] } {
+	    return $lower
+	}
+	if { [qc::is url_path "/${lower}"] } {
+	    return "/${lower}"
+	}
+	return -code error -errorcode CAST "Could not cast $string to an url path"
     }
 }

--- a/tcl/castable.tcl
+++ b/tcl/castable.tcl
@@ -1,0 +1,220 @@
+namespace eval qc::castable {
+    
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date postcode creditcard period url relative_url url_path time
+    namespace ensemble create -unknown {
+        data_type_parser
+    }
+
+    proc integer {string} {
+        #| Test if the given string can be cast to an integer.
+        try {
+            qc::cast integer $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc bigint {string} {
+        #| Test if the given string can be cast to a big integer.
+        try {
+            qc::cast bigint $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc smallint {string} {
+        #| Test if the given string can be cast to a small integer.
+        try {
+            qc::cast smallint $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc decimal {args} {
+        #| Test if the given value can be cast to a decimal.
+        try {
+            qc::cast decimal {*}$args
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc boolean { string {true t} {false f} } {
+        #| Test if the given string can be cast to an boolean.
+        try {
+            qc::cast boolean $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }        
+    }
+
+    proc timestamp {string} {
+        #| Test if the given string can be cast to a timestamp without timezone.
+        try {
+            qc::cast timestamp $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }        
+    }
+
+    proc timestamptz {string} {
+        #| Test if the given string can be cast to a timestamp with timezone.
+        try {
+            qc::cast timestamptz $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }        
+    }
+
+    proc char {length string} {
+        #| Test if the given string can be cast to a fixed length string.
+        try {
+            qc::cast char $length $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }        
+    }
+
+    proc varchar {length string} {
+        #| Test if the given string can be cast to a varchar of given length.
+        try {
+            qc::cast varchar $length $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }        
+    }
+
+    proc enumeration {name value} {
+        #| Test if the given value can be cast to an enumeration value in $name.
+        try {
+            qc::cast enumeration $name $value
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc text {string} {
+        #| Test if the given string can be cast to text.
+        try {
+            qc::cast text $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc domain {domain_name value} {
+        #| Test if the given value can be cast to domain $domain_name.
+        try {
+            qc::cast domain $domain_name $value
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc safe_html {text} {
+        #| Test if the given text can be cast to safe html.
+        return [qc::is safe_html $text]
+    }
+
+    proc safe_markdown {text} {
+        #| Test if the given text can be cast to safe markdown.
+        return [qc::is safe_markdown $text]
+    }
+
+    proc date {string} {
+        #| Test if the given string can be cast to a date.
+        try {
+            qc::cast date $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc time {string} {
+        #| Test if the given string can be cast to a time.
+        try {
+            qc::cast time $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc postcode {string} {
+        #| Test if the given string can be cast to a UK postcode.
+        try {
+            qc::cast postcode $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc creditcard {string} {
+        #| Test if the given string can be cast to a credit card number.
+        try {
+            qc::cast creditcard $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc period {string} {
+        #| Test if the given string can be cast to a period.
+        try {
+            qc::cast period $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc url {string} {
+        #| Test if the given string can be cast to an url.
+        #| (See qc::is url)
+        try {
+            qc::cast url $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+
+    proc relative_url {string} {
+        #| Test if the given string can be cast to a relative url.
+        #| (See qc::is url)
+        try {
+            qc::cast relative_url $string
+            return true
+        } on error [list error_message options] {
+            return false
+        }
+    }
+    
+    proc url_path {string} {
+	#| Test if the given string can be cast to an url path
+	#| (See qc::is url_path)
+	try {
+	    qc::cast url_path $string
+	    return true
+	} on error [list error_message options] {
+	    return false
+	}
+    }
+}

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -3,7 +3,8 @@ namespace eval qc {
 }
 
 proc qc::is_boolean {bool} {
-    return [in {Y N YES NO TRUE FALSE T F 0 1} [upper $bool]]
+    #| Deprecated - see qc::is boolean
+    return [qc::is boolean $bool]
 }
 
 proc qc::is_integer {int} {
@@ -12,6 +13,7 @@ proc qc::is_integer {int} {
 }
 
 proc qc::is_pos {number} {
+    #| Deprecated
     if { [is_decimal $number] && $number>=0 } {
 	return 1
     } else {
@@ -20,6 +22,7 @@ proc qc::is_pos {number} {
 }
 
 proc qc::is_pnz {number} {
+    #| Deprecated
     if { [is_decimal $number] && $number>0 } {
 	return 1
     } else {
@@ -28,6 +31,7 @@ proc qc::is_pnz {number} {
 }
 
 proc qc::is_non_zero_integer {int} {
+    #| Deprecated
     if { [is_integer $int] && $int!=0 } {
 	return 1
     } else {
@@ -36,6 +40,7 @@ proc qc::is_non_zero_integer {int} {
 }
 
 proc qc::is_non_zero {number} {
+    #| Deprecated
     if { [is_decimal $number] && $number!=0 } {
 	return 1
     } else {
@@ -44,6 +49,7 @@ proc qc::is_non_zero {number} {
 }
 
 proc qc::is_pnz_int { int } {
+    #| Deprecated
     # positive non zero integer
     if { [is_integer $int] && $int > 0 } {
 	return 1
@@ -53,14 +59,12 @@ proc qc::is_pnz_int { int } {
 }
 
 proc qc::is_decimal { number } {
-    if { [string is double -strict $number]} {
-	return 1
-    } else {
-	return 0
-    }
+    #| Deprecated - see qc::is decimal
+    return [qc::is decimal $number]
 }
 
 proc qc::is_positive_decimal { number } {
+    #| Deprecated
     if { [string is double -strict $number] && $number>=0 } {
 	return 1
     } else {
@@ -69,6 +73,7 @@ proc qc::is_positive_decimal { number } {
 }
 
 proc qc::is_non_zero_decimal { number } {
+    #| Deprecated
     if { [string is double -strict $number] && $number!=0 } {
 	return 1
     } else {
@@ -77,6 +82,7 @@ proc qc::is_non_zero_decimal { number } {
 }
 
 proc qc::is_pnz_decimal { price } {
+    #| Deprecated
     # positive non-zero double
     if { [string is double -strict $price] && $price>0 } {
 	return 1
@@ -86,144 +92,88 @@ proc qc::is_pnz_decimal { price } {
 }
 
 proc qc::is_date { date } {
+    #| Deprecated - see qc::is date
     # dates are expected to be in iso format 
-    return [regexp {^\d{4}-\d{2}-\d{2}$} $date]   
+    return [qc::is date $date] 
 }
 
 proc qc::is_timestamp_http { date } {
+    #| Deprecated - see qc::is timestamp_http
     #| Returns true if date is an acceptable HTTP timestamp. Note although all three should be accepted,
     #| only RFC 1123 format should be generated.
     # RFC 1123 - Sun, 06 Nov 1994 08:49:37 GMT
-    if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)][,]\s\d{2}\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{4}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {
-        return 1
-    }
-    # RFC 850 - Sunday, 06-Nov-94 08:49:37 GMT
-    if { [regexp {([(Monday)|(Tuesday)|(Wednesday)|(Thursday)|(Friday)|(Saturday)|(Sunday)][,]\s\d{2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {
-        return 1
-    }
-    # ANCI C - Sun Nov  6 08:49:37 1994
-    if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)]\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\s|\d)\d\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d \d{4})} $date] } {
-        return 1
-    }
-    return 0
+    return [qc::is timestamp_http $date]
 }
 
 proc qc::is_timestamp { date } {
+    #| Deprecated - see qc::is timestamp
     # timestamps are expected to be in iso format 
-    return [regexp {^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$} $date]   
+    return [qc::is timestamp $date]
 }
 
 proc qc::is_email { email } {
-    return [regexp {^[a-zA-Z0-9_\-]+([\.\+][a-zA-Z0-9_\-]+)*@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+$} $email]
+    #| Deprecated - see qc::is email
+    return [qc::is email $email]
 }
 
 proc qc::is_postcode { postcode } {
+    #| Deprecated - see qc::is postcode
     # uk postcode
-    return [expr [regexp {^[A-Z]{1,2}[0-9R][0-9A-Z]? [0-9][ABD-HJLNP-UW-Z]{2}$} $postcode] || [regexp {^BFPO ?[0-9]+$} $postcode]]
+    return [qc::is postcode $postcode]
 }
 
 proc qc::is_creditcard { no } {
+    #| Deprecated - see qc::is creditcard
     #| Checks if no is an allowable credit card number
     #| Checks, number of digits are >13 & <19, all characters are integers, luhn 10 check
-    regsub -all {[ -]} $no "" no
-    set mult 1
-    set sum 0
-    if { [string length $no]<13 || [string length $no]>19 } {
-	return 0
-    }
-    foreach digit [lreverse [split $no ""]] {
-	if { ![is_integer $digit] } {
-	    return 0
-	}
-	set t [expr {$digit*$mult}]
-	if { $t >= 10 } {
-	    set sum [expr {$sum + $t%10 +1}]
-	} else {
-	    set sum [expr {$sum + $t}]
-	}
-	if { $mult == 1 } { set mult 2 } else { set mult 1 }
-    }
-    if { $sum%10 == 0 } {
-	return 1
-    } else {
-	return 0
-    }
+    return [qc::is creditcard $no]
 }
 
 proc qc::is_creditcard_masked { no } {
+    #| Deprecated - see qc::is creditcard_masked
     #| Check the credit card number is masked to PCI requirements
-    regsub -all {[^0-9\*]} $no "" no
-
-    # 13-19 chars masked with < 6 prefix and < 4 suffix digits
-    return [expr [regexp {[0-9\*]{13,19}} $no] && [regexp {^[3-6\*][0-9]{0,5}\*+[0-9]{0,4}$} $no]]
+    return [qc::is creditcard_masked $no]
 }
 
 proc qc::is_varchar {string length} {
+    #| Deprecated - see qc::is varchar
     #| Checks string would fit in a varchar of length $length
-    if { [string length $string]<=$length } {
-	return 1
-    } else {
-	return 0
-    }
+    return [qc::is varchar $length $string]
 }
 
 proc qc::is_base64 {string} {
+    #| Deprecated - see qc::is base64
     #| Checks input has only allowable base64 characters and is of the correct format
-    if { [regexp {^[A-Za-z0-9/+\r\n]+=*$} $string] \
-	&& ([string length $string]-[regexp -all -- \r?\n $string])*6%8==0 } {
-	return 1
-    } else {
-	return 0
-    }
+    return [qc::is base64 $string]
 }
 
 proc qc::is_int_castable {string} {
+    #| Deprecated - see qc::castable integer
     #| Can input be cast to an integer?
-    qc::try {
-	cast_integer $string
-	return true
-    } {
-	return false
-    }
+    return [qc::castable integer $string]
 }
 
 proc qc::is_decimal_castable {string} {
-    qc::try {
-	qc::cast_decimal $string
-	return true
-    } {
-	return false
-    }
+    #| Deprecated - see qc::castable decimal
+    return [qc::castable decimal $string]
 }
 
 proc qc::is_date_castable {string} {
+    #| Deprecated - see qc::castable date
     #| Can string be cast into date format?
-    qc::try {
-	cast_date $string
-	return true
-    } {
-	return false
-    }
+    return [qc::castable date $string]
 }
 
 proc qc::is_timestamp_castable {string} {
+    #| Deprecated - see qc::castable timestamp
     #| Can string be cast into timestamp format?
-    qc::try {
-	cast_timestamp $string
-	return true
-    } {
-	return false
-    }
+    return [qc::castable timestamp $string]
 }
 
 proc qc::is_mobile_number {string} {
+    #| Deprecated - see qc::is mobile_number
     # uk mobile telephone number
-    regsub -all {[^0-9]} $string {} tel_no
-    if {  [regexp {^07(5|7|8|9)[0-9]{8}$} $tel_no] } {
-	return true
-    } else {
-	return false
-    }
+    return [qc::is mobile_number $string]
 }
 
 proc qc::contains_creditcard {string} {
@@ -248,223 +198,41 @@ proc qc::contains_creditcard {string} {
 }
 
 proc qc::is_hex {string} {
+    #| Deprecated - see qc::is hex
     #| Does the input look like a hex number?
-    return [regexp -nocase {^[0-9a-f]*$} $string]
+    return [qc::is hex $string]
 }
 
 proc qc::is_url {args} {
+    #| Deprecated - see qc::is url
     #| This is a more restrictive subset of all legal uri's defined by RFC 3986
     #| Relax as needed
-    args $args -relative -- url
-    default relative false
-    if { $relative } {
-        return [regexp -expanded {
-            # path
-            ^([a-zA-Z0-9_\-\.~+/%]+)?
-            # query
-            (\?[a-zA-Z0-9_\-\.~+/%=&]+)?
-            # anchor
-            (\#[a-zA-Z0-9_\-\.~+/%]+)?
-            $
-        } $url]
-    } else {
-        return [regexp -expanded {
-            # protocol
-            ^https?://
-            # domain
-            [a-z0-9\-\.]+
-            # port
-            (:[0-9]+)?
-            # path
-            ([a-zA-Z0-9_\-\.~+/%]+)?
-            # query
-            (\?[a-zA-Z0-9_\-\.~+/%=&]+)?
-            # anchor
-            (\#[a-zA-Z0-9_\-\.~+/%]+)?
-            $
-        } $url]
-    }
+    return [qc::is url {*}$args]
 }
 
 proc qc::is_ipv4 {string} {
+    #| Deprecated - see qc::is ipv4
     # TODO checks structure only, will allow 9999.9999.9999.9999
-    if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$} $string] } {
-        return true
-    } else {
-        return false
-    }
+    return [qc::is ipv4 $string]
 }
 
 proc qc::is_cidrnetv4 {string} {
-    if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$} $string] } {
-        return true
-    } else {
-        return false
-    }
+    #| Deprecated - see qc::is cidrnetv4
+    return [qc::is cidrnetv4 $string]
 }
 
 proc qc::is_uri_valid {uri} {
+    #| Deprecated - see qc::is uri
     #| Test if the given uri is valid according to rfc3986 (https://tools.ietf.org/html/rfc3986)
-  
-    set unreserved {
-        (?:[a-zA-Z0-9\-._~])
-    }
-    
-    set sub_delims {
-        (?:[!$&'()*+,;=])
-    }
-    
-    set pct_encoded {
-        (?:%[0-9a-fA-F]{2})
-    }
-
-    set pchar [subst -nocommands -nobackslashes {
-        (?:${unreserved}|${pct_encoded}|${sub_delims}|[:@])
-    }]
-    
-    set segment [subst -nocommands -nobackslashes {
-        (?:${pchar}*)
-    }]
-
-    set segment_nz [subst -nocommands -nobackslashes {
-        (?:${pchar}+)
-    }]
-    
-    set segment_nz_nc [subst -nocommands -nobackslashes {
-        (?:(?:${unreserved}|${pct_encoded}|${sub_delims}|[@])+)
-    }]    
-
-    set scheme {
-        (?:[a-zA-Z][a-zA-Z+\-.]*)
-    }
-
-    set dec_octet {
-        (?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
-    }
-    
-    set ipv4_address [subst -nocommands -nobackslashes {
-        (?:${dec_octet}\.${dec_octet}\.${dec_octet}\.${dec_octet})
-    }]
-
-    set h16 {
-        (?:[0-9a-fA-F]{1,4})
-    }
-
-    set ls32 [subst -nocommands -nobackslashes {
-        (?:
-         ${h16}:${h16}
-         |
-         ${ipv4_address}
-         )
-    }]
-
-    set ipv6_address [subst -nocommands -nobackslashes {
-        (?:
-         (?:${h16}:){6}${ls32}
-         |
-         ::(?:${h16}:){5}${ls32}
-         |
-         (?:${h16})?::(?:${h16}:){4}${ls32}
-         |
-         (?:(?:${h16}:)?${h16})?::(?:${h16}:){3}${ls32}
-         |
-         (?:(?:${h16}:){0,2}${h16})?::(?:${h16}:){2}${ls32}
-         |
-         (?:(?:${h16}:){0,3}${h16})?::${h16}:${ls32}
-         |
-         (?:(?:${h16}:){0,4}${h16})?::${ls32}
-         |
-         (?:(?:${h16}:){0,5}${h16})?::${h16}
-         |
-         (?:(?:${h16}:){0,6}${h16})?::
-         )
-    }]
-
-    set ipvfuture [subst -nocommands -nobackslashes {
-        (?:v[0-9a-fA-F]+\.(?:${unreserved}|${sub_delims}|:)+)
-    }]
-    
-    set ip_literal [subst -nocommands -nobackslashes {
-        (?:\[(?:${ipv6_address}|${ipvfuture})\])
-    }]
-    
-    set host [subst -nocommands -nobackslashes {
-        (?:${ip_literal}|${ipv4_address}|(?:${unreserved}|${pct_encoded}|${sub_delims})*)
-    }]
-
-    set user_info [subst -nocommands -nobackslashes {
-        (?:(?:${unreserved}|${pct_encoded}|${sub_delims}|:)*)
-    }]
-
-    set port [subst -nocommands -nobackslashes {
-        (?:[0-9]*)
-    }]
-
-    set authority [subst -nocommands -nobackslashes {
-        (?:${user_info}@)?${host}(?::${port})?
-    }]           
-
-    set path_abempty [subst -nocommands -nobackslashes {
-        (?:(?:/${segment})*)
-    }]
-    
-    set path_absolute [subst -nocommands -nobackslashes {
-        (?:/(?:${segment_nz}(?:/${segment})*)?)
-    }]
-    
-    set path_noscheme [subst -nocommands -nobackslashes {
-        (?:${segment_nz_nc}(?:/${segment})*)
-    }]
-
-    set path_rootless [subst -nocommands -nobackslashes {
-        (?:${segment_nz}(?:/${segment})*)
-    }]
-
-    set path_empty [subst -nocommands -nobackslashes {
-        (?:${pchar}{0})
-    }]
-
-    set fragment_char [subst -nobackslashes {
-        (?:${pchar}|/|\?)
-    }]
-
-    set query_char [subst -nobackslashes {
-        (?:${pchar}|/|\?)
-    }]   
-    
-    set relative_uri [subst -nocommands -nobackslashes {
-        (?:
-         (?://${authority}${path_abempty}|${path_absolute}|${path_noscheme}|${path_empty})
-         (?:\?${query_char}+)?
-         (\#${fragment_char}+)?
-         )
-    }]
-
-    set absolute_uri [subst -nocommands -nobackslashes {
-        (?:
-         ${scheme}:
-         (?:(?://${authority}${path_abempty})|${path_absolute}|${path_rootless}|${path_empty})
-         (?:\?${query_char}+)?
-         (?:\#${fragment_char}+)?
-         )
-    }]
-
-    set re [subst -nocommands -nobackslashes {
-        ^
-        (?:
-         ${absolute_uri}
-         |
-         ${relative_uri}
-         )
-        $
-    }]
-    
-    return [regexp -expanded $re $uri]
+    return [qc::is uri $uri]
 }
 
 namespace eval qc::is {
-    namespace export integer
-    namespace ensemble create
+    
+    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path time
+    namespace ensemble create -unknown {
+        data_type_parser
+    }
     
     proc integer {int} {
         #| Checks if the given number is a 32-bit signed integer.
@@ -474,4 +242,612 @@ namespace eval qc::is {
             return 0
         }
     }
+
+    proc smallint {int} {
+        #| Checks if the given number is an 8-bit signed integer.
+        if {[string is integer -strict $int] && $int >= -32768 && $int <= 32767} {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc bigint {int} {
+        #| Checks if the given number is a 64-bit signed integer.
+        if {[string is wideinteger -strict $int] && $int >= -9223372036854775808 && $int <= 9223372036854775807} {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc boolean {bool} {
+        #| Checks if the given number is a boolean.
+        return [expr {[string toupper $bool] in {Y N YES NO TRUE FALSE T F 0 1}}]
+    }
+
+    proc decimal {args} {
+        #| Checks if the given number is a decimal.
+        qc::args $args -precision ? -scale ? -- string
+        if {[string is double -strict $string]} {
+            if { ! [info exists precision] && ! [info exists scale] } {
+                # Scale and precision not given.
+                return 1
+            } elseif { ! [info exists precision] && [info exists scale] } {
+                # Scale given but not precision.
+                return -code error "Precision must be provided with scale."
+            } elseif { [info exists precision] } {
+                # Precision given.
+                if { $precision <= 0 || ! [qc::is integer $precision]} {
+                    return -code error "Precision must be a positive integer."
+                }
+                # Count the number of digits before and after the decimal point.
+                set number [qc::exp2string $string]
+                set parts [split $number .]
+                set left_count [string length [lindex $parts 0]]
+                set right_count [string length [lindex $parts 1]]
+                if { $left_count == 0 } {
+                    # The leading zero wasn't given.
+                    return -code error "Incomplete numeric string."
+                }
+
+                set total_count [expr {$left_count + $right_count}]
+                if { $precision < $total_count } {
+                    # Precision is less than the total number of digits in the given decimal.
+                    return 0
+                }
+                
+                if { ! [info exists scale] } {
+                    # Scale wasn't given so set it to 0.
+                    set scale 0
+                }
+
+                if { $scale < 0 || ! [qc::is integer $scale]} {
+                    return -code error "Scale must be a non-negative integer."
+                }
+
+                set left_digit_max [expr {$precision - $scale}]
+                if { $left_count > $left_digit_max || $right_count > $scale } {
+                    return 0
+                } else {
+                    return 1
+                }
+                
+            }
+        } else {
+            return 0
+        }
+    }
+
+    proc timestamp { date } {
+        #| Checks if the given date is a timestamp (in iso format).
+        return [regexp {^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$} $date]   
+    }
+
+    proc timestamptz {date} {
+        #| Checks if the given date is a timestamp with a time zone (in iso format).
+        return [regexp {^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\+|-)([0-9][0-9])$} $date] 
+    }
+
+    proc char {length string} {
+        #| Checks if string would fit exactly into a character string of the given length.
+        if { [string length $string] == $length } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc varchar {length string} {
+        #| Checks if string would fit in a varchar of the given length.
+        if { $length eq "" } {
+            # PostgreSQL specification - missing length means any size
+            return 1
+        } elseif { [string length $string] <= $length } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc enumeration {enum_name value} {
+        #| Checks if the given value is a value in enumeration enum_name.
+        if {[qc::memoize qc::db_enum_exists $enum_name] && $value in [qc::memoize qc::db_enum_values $enum_name]} {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc text {string} {
+        #| Check if the given string is text
+        return 1
+    }
+
+    proc domain {domain_name value} {
+        #| Checks if the given value falls under the domain domain_name.
+        if {[qc::memoize qc::db_domain_exists $domain_name]} {
+            set base_type [qc::memoize qc::db_domain_base_type $domain_name]
+            if { ! [qc::is $base_type $value] } {
+                return 0
+            }
+            set constraints [qc::memoize qc::db_domain_constraints $domain_name]
+            dict for {constraint_name check_clause} $constraints {
+                if { ! [qc::db_eval_domain_constraint $value $base_type $check_clause] } {
+                    return 0
+                }
+            }
+            return 1
+        }
+        return 0
+    }
+
+    proc safe_html {text} {
+        #| Checks if the given text contains only safe html.
+        try {
+            # wrap the text up in <root> to preserve text outwith the html
+            set text [qc::h root $text]
+            set doc [dom parse -html $text]
+            set root [$doc documentElement]
+            
+            if {$root eq ""} {
+                $doc delete
+                return 1
+            } else {
+                set safe [expr {[qc::safe_elements_check $root] && [qc::safe_attributes_check $root]}]
+                $doc delete
+                return $safe
+            }
+        } on error [list error_message options] {
+            return 0
+        }
+    }
+
+    proc safe_markdown {markdown} {
+        #| Checks if the given markdown text contains HTML elements that are deemed safe.
+        try {
+            qc::commonmark2html $markdown
+            return 1
+        } on error [list error_message options] {
+            return 0
+        }
+    }
+
+    proc date {string} {
+        #| Checks if the given string is a date.
+        #| Dates are expected to be in ISO format.
+        return [regexp {^\d{4}-\d{2}-\d{2}$} $string]
+    }
+
+    proc timestamp_http {date} {
+        #| Checks if the given date is an acceptable HTTP timestamp. Note although all three should be accepted,
+        #| only RFC 1123 format should be generated.
+        # RFC 1123 - Sun, 06 Nov 1994 08:49:37 GMT
+        if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)][,]\s\d{2}\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{4}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {
+            return 1
+        }
+        # RFC 850 - Sunday, 06-Nov-94 08:49:37 GMT
+        if { [regexp {([(Monday)|(Tuesday)|(Wednesday)|(Thursday)|(Friday)|(Saturday)|(Sunday)][,]\s\d{2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2}\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d\s(GMT))} $date] } {
+            return 1
+        }
+        # ANCI C - Sun Nov  6 08:49:37 1994
+        if { [regexp {([(Mon)|(Tue)|(Wed)|(Thu)|(Fri)|(Sat)|(Sun)]\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\s|\d)\d\s[0-2]\d(\:)[0-5]\d(\:)[0-5]\d \d{4})} $date] } {
+            return 1
+        }
+        return 0
+    }
+
+    proc time {time} {
+        #| Check if the given date is a time
+        #| in the form 23:59:59 or 23:59:59.01
+        return [regexp {^(([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|24:00:00)(\.\d{1,6})?$} $time]
+    }
+
+    proc email {email} {
+        #| Checks if the given string follows the form of an email address.
+        return [regexp {^[a-zA-Z0-9_\-]+([\.\+][a-zA-Z0-9_\-]+)*@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+$} $email]
+    }
+
+    proc postcode {postcode} {
+        #| Checks if the given string is a UK postcode.
+        return [expr [regexp {^[A-Z]{1,2}[0-9R][0-9A-Z]? [0-9][ABD-HJLNP-UW-Z]{2}$} $postcode] || [regexp {^BFPO ?[0-9]+$} $postcode]]
+    }
+
+    proc creditcard {number} {
+        #| Checks if the given string is an allowable credit card number.
+        #| Checks, number of digits are >13 & <19, all characters are integers, luhn 10 check
+        regsub -all {[ -]} $number "" number
+        set mult 1
+        set sum 0
+        if { [string length $number]<13 || [string length $number]>19 } {
+            return 0
+        }
+        foreach digit [lreverse [split $number ""]] {
+            if { ![qc::is integer $digit] } {
+                return 0
+            }
+            set t [expr {$digit*$mult}]
+            if { $t >= 10 } {
+                set sum [expr {$sum + $t%10 +1}]
+            } else {
+                set sum [expr {$sum + $t}]
+            }
+            if { $mult == 1 } { set mult 2 } else { set mult 1 }
+        }
+        if { $sum%10 == 0 } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc creditcard_masked {string} {
+        #| Check the credit card number is masked to PCI requirements.
+        regsub -all {[^0-9\*]} $string "" number
+
+        # 13-19 chars masked with < 6 prefix and < 4 suffix digits
+        return [expr [regexp {[0-9\*]{13,19}} $number] && [regexp {^[3-6\*][0-9]{0,5}\*+[0-9]{0,4}$} $number]]
+    }
+
+    proc period {string} {
+        #| Check if the given string is a period.
+        set month_names [list Jan January Feb February Mar March Apr April May Jun June Jul July Aug August Sep September Oct October Nov November Dec December]
+        set regexp_map [list \$month_names_regexp [join $month_names |]]
+
+        if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
+            # Period defined by two periods eg "Jan 2011 to March 2011"
+            if { [qc::is period $period1] && [qc::is period $period2] } {
+                return 1
+            } else {
+                return 0
+            }
+
+        } elseif { [qc::is date $string] } {
+            # String is an iso date eg "2014-01-01"
+            return 1
+
+        } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
+            # Exact match for year eg "2006"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([12]\d{3})$}] $string -> month_name year] } {
+            # Exact match in format "Jan 2006"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)$}] $string -> month_name] } {
+            # Exact match in format "Jan" (assume current year)
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)\s+([12]\d{3})$}] $string -> dom month_name year] } {
+            # Exact match for castable date in format "1st Jan 2014"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^([0-9]{1,2})(?:st|th|nd|rd)?\s+($month_names_regexp)$}] $string -> dom month_name] } {
+            # Exact match for castable date in format "1st Jan" (assume current year)
+            return 1       
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?\s+([12]\d{3})$}] $string -> month_name dom year] } {
+            # Exact match for castable date in format "Jan 1st 2014"
+            return 1
+
+        } elseif { [regexp -nocase -- [string map $regexp_map {^($month_names_regexp)\s+([0-9]{1,2})(?:st|th|nd|rd)?$}] $string -> month_name dom] } {
+            # Exact match for castable date in format "Jan 1st" (assume current year)
+            return 1
+
+        } else {
+            # could not parse string
+            return 0
+        }
+
+        if { [regexp -nocase {^\s*(.*?)\s+to\s+(.*?)\s*$} $string -> period1 period2] } {
+            # Period defined by two periods eg "Jan 2011 to March 2011"
+            if { [qc::is period $period1] && [qc::is period $period2] } {
+                return 1
+            } else {
+                return 0
+            }
+
+        } elseif { [qc::is date $string] } {
+            # String is an iso date eg "2014-01-01"
+            return 1
+
+        } elseif { [regexp {^([12]\d{3})$} $string -> year] } {
+            # Exact match for year eg "2006"
+            return 1
+
+        } elseif { [regexp -nocase -- {^([0-9]+)(?:st|th|nd|rd)?\s+(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)(?:\s+([12]\d{3}))?$} $string -> dom month_name year] } {
+            # Exact match for castable date in format "1st Jan 2014" or "1st Jan"
+            return 1
+
+        } elseif { [regexp -nocase -- {^(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)\s+([0-9]+)(?:st|th|nd|rd)?(?:\s+([12]\d{3}))?$} $string -> month_name dom year] } {
+            # Exact match for castable date in format "Jan 1st 2014" or "Jan 1st"
+            return 1
+
+        }  elseif { [regexp -nocase -- {^(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)(?:\s+([12]\d{3}))?$} $string -> month_name year] } {
+            # Exact match in format "Jan 2006" or "Jan"
+            return 1
+
+        }  else {
+            # could not parse string
+            return 0
+        }
+    }
+
+    proc base64 {string} {
+        #| Checks if the given string has only allowable base64 characters and is of the correct format.
+        if { [regexp {^[A-Za-z0-9/+\r\n]+=*$} $string] \
+                 && ([string length $string]-[regexp -all -- \r?\n $string])*6%8==0 } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc mobile_number {string} {
+        #| Checks if the given string is of the form of a UK mobile telephone number.
+        regsub -all {[^0-9]} $string {} tel_no
+        if {  [regexp {^07(5|7|8|9)[0-9]{8}$} $tel_no] } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc hex {string} {
+        #| Checks if the given string is a hex number.
+        return [regexp -nocase {^[0-9a-f]*$} $string]
+    }
+
+    proc url {args} {
+        #| Checks if the given string is a URL.
+        #| This is a more restrictive subset of all legal uri's defined by RFC 3986
+        #| Relax as needed
+        qc::args $args -relative -- url
+        qc::default relative false
+        if { $relative } {
+            return [regexp -expanded {
+                # path
+                ^([a-zA-Z0-9_\-\.~+/%&]+)?
+                # query
+                (\?[a-zA-Z0-9_\-\.~+/%=&]+)?
+                # anchor
+                (\#[a-zA-Z0-9_\-\.~+/%]+)?
+                $
+            } $url]
+        } else {
+            return [regexp -expanded {
+                # protocol
+                ^https?://
+                # domain
+                [a-z0-9\-\.]+
+                # port
+                (:[0-9]+)?
+                # path
+                ([a-zA-Z0-9_\-\.~+/%&]+)?
+                # query
+                (\?[a-zA-Z0-9_\-\.~+/%=&]+)?
+                # anchor
+                (\#[a-zA-Z0-9_\-\.~+/%]+)?
+                $
+            } $url]
+        }
+    }
+
+    proc url_path {string} {
+	#| Checks if the given string is an url path.
+	return [regexp {/([a-zA-Z0-9\-._~]|%[0-9a-fA-F]{2}|[!$&'()*+,;=:@]|/)*$} $string]
+    }
+
+    proc ipv4 {string} {
+        #| Checks if the given string follows the IPv4 format.
+        # TODO checks structure only, will allow 9999.9999.9999.9999
+        if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$} $string] } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc cidrnetv4 {string} {
+        #| Checks if the given string follows the CIDR NETv4 format.
+        if { [regexp {^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$} $string] } {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    proc uri {uri} {
+        #| Test if the given uri is valid according to rfc3986 (https://tools.ietf.org/html/rfc3986)
+        
+        set unreserved {
+            (?:[a-zA-Z0-9\-._~])
+        }
+        
+        set sub_delims {
+            (?:[!$&'()*+,;=])
+        }
+        
+        set pct_encoded {
+            (?:%[0-9a-fA-F]{2})
+        }
+
+        set pchar [subst -nocommands -nobackslashes {
+            (?:${unreserved}|${pct_encoded}|${sub_delims}|[:@])
+        }]
+        
+        set segment [subst -nocommands -nobackslashes {
+            (?:${pchar}*)
+        }]
+
+        set segment_nz [subst -nocommands -nobackslashes {
+            (?:${pchar}+)
+        }]
+        
+        set segment_nz_nc [subst -nocommands -nobackslashes {
+            (?:(?:${unreserved}|${pct_encoded}|${sub_delims}|[@])+)
+        }]    
+
+        set scheme {
+            (?:[a-zA-Z][a-zA-Z+\-.]*)
+        }
+
+        set dec_octet {
+            (?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
+        }
+        
+        set ipv4_address [subst -nocommands -nobackslashes {
+            (?:${dec_octet}\.${dec_octet}\.${dec_octet}\.${dec_octet})
+        }]
+
+        set h16 {
+            (?:[0-9a-fA-F]{1,4})
+        }
+
+        set ls32 [subst -nocommands -nobackslashes {
+            (?:
+             ${h16}:${h16}
+             |
+             ${ipv4_address}
+             )
+        }]
+
+        set ipv6_address [subst -nocommands -nobackslashes {
+            (?:
+             (?:${h16}:){6}${ls32}
+             |
+             ::(?:${h16}:){5}${ls32}
+             |
+             (?:${h16})?::(?:${h16}:){4}${ls32}
+             |
+             (?:(?:${h16}:)?${h16})?::(?:${h16}:){3}${ls32}
+             |
+             (?:(?:${h16}:){0,2}${h16})?::(?:${h16}:){2}${ls32}
+             |
+             (?:(?:${h16}:){0,3}${h16})?::${h16}:${ls32}
+             |
+             (?:(?:${h16}:){0,4}${h16})?::${ls32}
+             |
+             (?:(?:${h16}:){0,5}${h16})?::${h16}
+             |
+             (?:(?:${h16}:){0,6}${h16})?::
+             )
+        }]
+
+        set ipvfuture [subst -nocommands -nobackslashes {
+            (?:v[0-9a-fA-F]+\.(?:${unreserved}|${sub_delims}|:)+)
+        }]
+        
+        set ip_literal [subst -nocommands -nobackslashes {
+            (?:\[(?:${ipv6_address}|${ipvfuture})\])
+        }]
+        
+        set host [subst -nocommands -nobackslashes {
+            (?:${ip_literal}|${ipv4_address}|(?:${unreserved}|${pct_encoded}|${sub_delims})*)
+        }]
+
+        set user_info [subst -nocommands -nobackslashes {
+            (?:(?:${unreserved}|${pct_encoded}|${sub_delims}|:)*)
+        }]
+
+        set port [subst -nocommands -nobackslashes {
+            (?:[0-9]*)
+        }]
+
+        set authority [subst -nocommands -nobackslashes {
+            (?:${user_info}@)?${host}(?::${port})?
+        }]           
+
+        set path_abempty [subst -nocommands -nobackslashes {
+            (?:(?:/${segment})*)
+        }]
+        
+        set path_absolute [subst -nocommands -nobackslashes {
+            (?:/(?:${segment_nz}(?:/${segment})*)?)
+        }]
+        
+        set path_noscheme [subst -nocommands -nobackslashes {
+            (?:${segment_nz_nc}(?:/${segment})*)
+        }]
+
+        set path_rootless [subst -nocommands -nobackslashes {
+            (?:${segment_nz}(?:/${segment})*)
+        }]
+
+        set path_empty [subst -nocommands -nobackslashes {
+            (?:${pchar}{0})
+        }]
+
+        set fragment_char [subst -nobackslashes {
+            (?:${pchar}|/|\?)
+        }]
+
+        set query_char [subst -nobackslashes {
+            (?:${pchar}|/|\?)
+        }]   
+
+        set absolute_uri_re [subst -nocommands -nobackslashes {
+            ^
+            (?:
+             ${scheme}:
+             (?:(?://${authority}${path_abempty})|${path_absolute}|${path_rootless}|${path_empty})
+             (?:\?${query_char}*)?
+             (?:\#${fragment_char}*)?
+             )
+            $
+        }]
+        
+        set relative_uri_re1 [subst -nocommands -nobackslashes {
+            ^
+            (?:
+             ${path_absolute}
+             (?:\?${query_char}*)?
+             (\#${fragment_char}*)?
+             )
+            $
+        }]
+
+        set relative_uri_re2 [subst -nocommands -nobackslashes {
+            ^
+            (?:
+             ${path_noscheme}
+             (?:\?${query_char}*)?
+             (\#${fragment_char}*)?
+             )
+            $
+        }]
+
+        set relative_uri_re3 [subst -nocommands -nobackslashes {
+            ^
+            (?:
+             ${path_empty}
+             (?:\?${query_char}*)?
+             (\#${fragment_char}*)?
+             )
+            $
+        }]
+
+        set relative_uri_re4 [subst -nocommands -nobackslashes {
+            ^
+            (?:
+             //${authority}${path_abempty}
+             (?:\?${query_char}*)?
+             (\#${fragment_char}*)?
+             )
+            $
+        }]      
+
+        if {
+            [regexp -expanded $absolute_uri_re $uri] 
+            || [regexp -expanded $relative_uri_re1 $uri] 
+            || [regexp -expanded $relative_uri_re2 $uri]
+            || [regexp -expanded $relative_uri_re3 $uri]
+            || [regexp -expanded $relative_uri_re4 $uri] 
+        } {
+            return 1
+        } else {
+            return 0
+        }
+    }
 }
+

--- a/test/cast.test
+++ b/test/cast.test
@@ -8,92 +8,129 @@ namespace eval ::qcode::test {
     namespace import ::tcltest::*
     namespace path ::qc
 
-    test cast_integer-1.0 {cast_integer commas} {qc::cast_integer 2,305} 2305
-    test cast_integer-1.1 {cast_integer leading zeros} {qc::cast_integer "001"} 1
-    test cast_integer-1.2 {cast_integer percentages} {qc::cast_integer "10%"} 10
-    test cast_integer-1.3 {cast_integer e notation} {qc::cast_integer "43e2"} 4300
-    test cast_integer-1.4 {cast_integer upper limit} {qc::cast_integer "2147483647"} 2147483647
-    test cast_integer-1.5 {cast_integer outside integer range} -body {qc::cast_integer "2147483648"} -result "Could not cast 2147483648 to integer" -returnCodes error 
-    test cast_integer-1.6 {cast_integer outside integer range} -body {qc::cast_integer "2e100"} -result "Could not cast 2e100 to integer" -returnCodes error 
-    test cast_integer-1.7 {cast_integer lower limit} {qc::cast_integer "-2147483648"} -2147483648
-    test cast_integer-1.8 {cast_integer outside integer range} -body {qc::cast_integer "-2147483649"} -result "Could not cast -2147483649 to integer" -returnCodes error 
-    test cast_integer-1.9 {cast_integer leading zeros} {qc::cast_integer "-08"} -8
-    test cast_integer-1.10 {cast_integer leading zeros} {qc::cast_integer "-1.008"} -1
-    test cast_integer-1.10 {cast_integer leading zeros} {qc::cast_integer "0008"} 8
+    test cast-integer-1.0 {cast integer commas} {qc::cast integer 2,305} 2305
+    test cast-integer-1.1 {cast integer leading zeros} {qc::cast integer "001"} 1
+    test cast-integer-1.2 {cast integer percentages} {qc::cast integer "10%"} 10
+    test cast-integer-1.3 {cast integer e notation} {qc::cast integer "43e2"} 4300
+    test cast-integer-1.4 {cast integer upper limit} {qc::cast integer "2147483647"} 2147483647
+    test cast-integer-1.5 {cast integer outside integer range} -body {qc::cast integer "2147483648"} -result "Could not cast 2147483648 to integer." -returnCodes error 
+    test cast-integer-1.6 {cast integer outside integer range} -body {qc::cast integer "2e100"} -result "Could not cast 2e100 to integer." -returnCodes error 
+    test cast-integer-1.7 {cast integer lower limit} {qc::cast integer "-2147483648"} -2147483648
+    test cast-integer-1.8 {cast integer outside integer range} -body {qc::cast integer "-2147483649"} -result "Could not cast -2147483649 to integer." -returnCodes error 
+    test cast-integer-1.9 {cast integer leading zeros} {qc::cast integer "-08"} -8
+    test cast-integer-1.10 {cast integer leading zeros} {qc::cast integer "-1.008"} -1
+    test cast-integer-1.10 {cast integer leading zeros} {qc::cast integer "0008"} 8
 
 
-    test cast_decimal-1.0 {cast_decimal commas} {qc::cast_decimal "2,305.25"} 2305.25
-    test cast_decimal-1.1 {cast_decimal percentages} {qc::cast_decimal "100%"} 100
-    test cast_decimal-1.2 {cast_decimal precision} {qc::cast_decimal 3.689 2} 3.69
-    test cast_decimal-1.3 {cast_decimal precision} {qc::cast_decimal 3 4} 3.0000
+    test cast-decimal-1.0 {cast decimal commas} {qc::cast decimal "2,305.25"} 2305.25
+    test cast-decimal-1.1 {cast decimal percentages} {qc::cast decimal "100%"} 100
+    test cast-decimal-1.2 {cast decimal exponent} {qc::cast decimal 3.689e4} 36890
+    test cast-decimal-1.3 {cast decimal exponent precision scale} {qc::cast decimal -precision 6 -scale 2 3e3} 3000.00
+    test cast-decimal-1.4 {cast decimal precision} {qc::cast decimal -precision 4 3} 3
+    test cast-decimal-1.5 {cast decimal precision} {qc::cast decimal -precision 1 3} 3 
+    test cast-decimal-1.6 {cast decimal precision scale} -body {qc::cast decimal -precision 4 -scale 4 3} -result "The resulting number (3.0000) is too large for the given precision (4) and scale (4)." -returnCodes error
+    test cast-decimal-1.7 {cast decimal precision scale} {qc::cast decimal -precision 4 -scale 2 3} 3.00
+    test cast-decimal-1.8 {cast decimal precision scale} {qc::cast decimal -precision 4 -scale 2 3.6534} 3.65
 
-    test cast_date-1.0 {cast_date forward slashes} {qc::cast_date 12/5/07} 2007-05-12
-    test cast_date-1.1 {cast_date relative time} -body {
-        qc::cast_date yesterday
+    # Cast Date
+    test cast-date-1.0 {cast date forward slashes} {
+        qc::cast date 12/5/07
+    } 2007-05-12
+    test cast-date-1.1 {cast date relative time} -body {
+        qc::cast date yesterday
     } -result [clock format [clock scan yesterday] -format "%Y-%m-%d"]
-    test cast_date-1.2 {cast_date long format} {qc::cast_date "June 23rd 2010"} 2010-06-23
+    test cast-date-1.2 {cast date long format} {
+        qc::cast date "June 23rd 2010"
+    } 2010-06-23
+    test cast-date-1.3 {cast date yyyymmdd} {
+        qc::cast date 20180412
+    } 2018-04-12
+    test cast-date-1.4 {cast date ddmmyyyy} {
+        qc::cast date 12042018
+    } 2018-04-12
+    test cast-date-1.5 {cast date dd-mm-yyyy} {
+        qc::cast date 12-04-2018
+    } 2018-04-12
 
-    test cast_timestamp-1.0 {cast_timestamp relative time} -body {
-        qc::cast_timestamp tomorrow
+    test cast-timestamp-1.0 {cast timestamp relative time} -body {
+        qc::cast timestamp tomorrow
     } -result [clock format [clock scan tomorrow] -format "%Y-%m-%d %H:%M:%S"]
 
-    test cast_epoch-1.0 {cast_epoch empty string} -body {
-        qc::cast_epoch ""
+    test cast-epoch-1.0 {cast epoch empty string} -body {
+        qc::cast epoch ""
     } -result "Can't cast an empty string to epoch" -returnCodes error 
-    test cast_epoch-1.1 {cast_epoch iso date no delimiter} {qc::cast_epoch 20100810} [clock scan "2010-08-10"]
-    test cast_epoch-1.2 {cast_epoch epoch} {qc::cast_epoch 1281394800} 1281394800
-    test cast_epoch-1.3 {cast_epoch exact iso date} {qc::cast_epoch "2012-06-12"} [clock scan "2012-06-12"]
-    test cast_epoch-1.4 {cast_epoch iso datetime} {qc::cast_epoch "2012-06-12 12:12:12"} [clock scan "2012-06-12 12:12:12"]
-    test cast_epoch-1.4a {cast_epoch iso datetime T format} {qc::cast_epoch "2012-06-12T12:12:12"} [clock scan "2012-06-12 12:12:12"]
-    test cast_epoch-1.5 {cast_epoch iso datetime with offset} {qc::cast_epoch "2012-06-12 12:12:12.777 -06:00"} [clock scan "2012-06-12 12:12:12" -timezone -06:00]
-    test cast_epoch-1.5a {cast_epoch iso datetime with offset & zulu} {qc::cast_epoch "2012-06-12 12:12:12Z"} [clock scan "2012-06-12 12:12:12" -timezone +00]
-    test cast_epoch-1.5b {cast_epoch iso datetime with offset T format & zulu} {qc::cast_epoch "2012-06-12T12:12:12Z"} [clock scan "2012-06-12 12:12:12" -timezone +00]
-    test cast_epoch-1.6 {cast_epoch iso date time no end anchor} {qc::cast_epoch "2012-06-12 12:12:12.777"} [clock scan "2012-06-12 12:12:12"]
-    test cast_epoch-1.7 {cast_epoch forward slash date format} {qc::cast_epoch "12/06/12"} [clock scan "2012-06-12"]
-    test cast_epoch-1.8 {cast_epoch forward slash date format long year} {qc::cast_epoch "12/06/2012"} [clock scan "2012-06-12"]
-    test cast_epoch-1.9 {cast_epoch relative} {qc::cast_epoch "today"} [clock scan today]
-    test cast_epoch-1.9a {cast_epoch relative2} {qc::cast_epoch "1 year ago"} [clock scan "1 year ago"]
-    test cast_epoch-1.10 {cast_epoch relaxed1} {qc::cast_epoch "12:12:12 22/06/99"} [clock scan "1999-06-22 12:12:12"]
-    test cast_epoch-1.10a {cast_epoch relaxed2} {qc::cast_epoch "12:12:12 22/06/1999"} [clock scan "1999-06-22 12:12:12"]
-    test cast_epoch-1.10b {cast_epoch relaxed3} {qc::cast_epoch "22 June 1999 12:12:12"} [clock scan "1999-06-22 12:12:12"]
-    test cast_epoch-1.10c {cast_epoch relaxed4} {qc::cast_epoch "June 22nd 1999 12:12:12"} [clock scan "1999-06-22 12:12:12"]
+    test cast-epoch-1.1 {cast epoch iso date no delimiter} {qc::cast epoch 20100810} [clock scan "2010-08-10"]
+    test cast-epoch-1.2 {cast epoch epoch} {qc::cast epoch 1281394800} 1281394800
+    test cast-epoch-1.3 {cast epoch exact iso date} {qc::cast epoch "2012-06-12"} [clock scan "2012-06-12"]
+    test cast-epoch-1.4 {cast epoch iso datetime} {qc::cast epoch "2012-06-12 12:12:12"} [clock scan "2012-06-12 12:12:12"]
+    test cast-epoch-1.4a {cast epoch iso datetime T format} {qc::cast epoch "2012-06-12T12:12:12"} [clock scan "2012-06-12 12:12:12"]
+    test cast-epoch-1.5 {cast epoch iso datetime with offset} {qc::cast epoch "2012-06-12 12:12:12.777 -06:00"} [clock scan "2012-06-12 12:12:12" -timezone -06:00]
+    test cast-epoch-1.5a {cast epoch iso datetime with offset & zulu} {qc::cast epoch "2012-06-12 12:12:12Z"} [clock scan "2012-06-12 12:12:12" -timezone +00]
+    test cast-epoch-1.5b {cast epoch iso datetime with offset T format & zulu} {qc::cast epoch "2012-06-12T12:12:12Z"} [clock scan "2012-06-12 12:12:12" -timezone +00]
+    test cast-epoch-1.6 {cast epoch iso date time no end anchor} {qc::cast epoch "2012-06-12 12:12:12.777"} [clock scan "2012-06-12 12:12:12"]
+    test cast-epoch-1.7 {cast epoch forward slash date format} {qc::cast epoch "12/06/12"} [clock scan "2012-06-12"]
+    test cast-epoch-1.8 {cast epoch forward slash date format long year} {qc::cast epoch "12/06/2012"} [clock scan "2012-06-12"]
+    test cast-epoch-1.9 {cast epoch relative} {qc::cast epoch "today"} [clock scan today]
+    test cast-epoch-1.9a {cast epoch relative2} {qc::cast epoch "1 year ago"} [clock scan "1 year ago"]
+    test cast-epoch-1.10 {cast epoch relaxed1} {qc::cast epoch "12:12:12 22/06/99"} [clock scan "1999-06-22 12:12:12"]
+    test cast-epoch-1.10a {cast epoch relaxed2} {qc::cast epoch "12:12:12 22/06/1999"} [clock scan "1999-06-22 12:12:12"]
+    test cast-epoch-1.10b {cast epoch relaxed3} {qc::cast epoch "22 June 1999 12:12:12"} [clock scan "1999-06-22 12:12:12"]
+    test cast-epoch-1.10c {cast epoch relaxed4} {qc::cast epoch "June 22nd 1999 12:12:12"} [clock scan "1999-06-22 12:12:12"]
 
 #   Aolserver dependent
-#   test cast_boolean-1.0 {cast_boolean default true} {qc::cast_boolean yes} t
-#   test cast_boolean-1.1 {cast_boolean default false} {qc::cast_boolean no} f
-#   test cast_boolean-1.2 {cast_boolean custom true} {qc::cast_boolean 1 Si No} Si
+#   test cast-boolean-1.0 {cast boolean default true} {qc::cast boolean yes} t
+#   test cast-boolean-1.1 {cast boolean default false} {qc::cast boolean no} f
+#   test cast-boolean-1.2 {cast boolean custom true} {qc::cast boolean 1 Si No} Si
 
-    test cast_postcode-1.0 {cast_postcode no space} {qc::cast_postcode EH123DE} "EH12 3DE"
-    test cast_postcode-1.1 {cast_postcode no space2} {qc::cast_postcode EH12DE} "EH1 2DE"
-    test cast_postcode-1.2 {cast_postcode extra zero} {qc::cast_postcode "Y043 3AH"} "YO43 3AH"
+    test cast-postcode-1.0 {cast postcode no space} {qc::cast postcode EH123DE} "EH12 3DE"
+    test cast-postcode-1.1 {cast postcode no space2} {qc::cast postcode EH12DE} "EH1 2DE"
+    test cast-postcode-1.2 {cast postcode extra zero} {qc::cast postcode "Y043 3AH"} "YO43 3AH"
 
-    test cast_creditcard-1.0 {cast_creditcard invalid} -body {
-        qc::cast_creditcard "4213 3222 1121 1112"
+    test cast-creditcard-1.0 {cast creditcard invalid} -body {
+        qc::cast creditcard "4213 3222 1121 1112"
     } -returnCodes error -result "4213322211211112 is not a valid credit card number"
-    test cast_creditcard-1.1 {cast_creditcard spaces} {qc::cast_creditcard "4111 1111 1111 1111"} 4111111111111111
+    test cast-creditcard-1.1 {cast creditcard spaces} {qc::cast creditcard "4111 1111 1111 1111"} 4111111111111111
 
 
-    test cast_period-1.0 {qc::cast_period ""} -body {qc::cast_period ""} -result "Could not parse string \"\" into dates that define a period." -returnCodes error 
-    test cast_period-1.1 {qc::cast_period "Jan"} {qc::cast_period "Jan"} [list [qc::date_year now]-01-01 [qc::date_year now]-01-31]
-    test cast_period-1.2 {qc::cast_period "January"} {qc::cast_period "January"} [list [qc::date_year now]-01-01 [qc::date_year now]-01-31]
-    test cast_period-1.3 {qc::cast_period "2014"} {qc::cast_period "2014"} [list 2014-01-01 2014-12-31]
-    test cast_period-1.4 {qc::cast_period "Jan 2014"} {qc::cast_period "Jan 2013"} [list 2013-01-01 2013-01-31]
-    test cast_period-1.5 {qc::cast_period "January 2014"} {qc::cast_period "January 2013"} [list 2013-01-01 2013-01-31]
-    test cast_period-1.6 {qc::cast_period "Jan 2014 to March 2014"} {qc::cast_period "Jan 2014 to March 2014"} [list 2014-01-01 2014-03-31]
-    test cast_period-1.7 {qc::cast_period "Febuary 2014"} -body {qc::cast_period "Febuary 2013"} -result "Could not parse string \"Febuary 2013\" into dates that define a period." -returnCodes error 
-    test cast_period-1.8 {qc::cast_period "1st February 2014 to 14th February 2014"} {qc::cast_period "1st February 2014 to 14th February 2014"} [list 2014-02-01 2014-02-14]
-    test cast_period-1.9 {qc::cast_period "1st February 2014"} {qc::cast_period "1st February 2014"} [list 2014-02-01 2014-02-01]
+    test cast-period-1.0 {qc::cast period ""} -body {qc::cast period ""} -result "Could not parse string \"\" into dates that define a period." -returnCodes error 
+    test cast-period-1.1 {qc::cast period "Jan"} {qc::cast period "Jan"} [list [date_year now]-01-01 [date_year now]-01-31]
+    test cast-period-1.2 {qc::cast period "January"} {qc::cast period "January"} [list [date_year now]-01-01 [date_year now]-01-31]
+    test cast-period-1.3 {qc::cast period "2014"} {qc::cast period "2014"} [list 2014-01-01 2014-12-31]
+    test cast-period-1.4 {qc::cast period "Jan 2014"} {qc::cast period "Jan 2013"} [list 2013-01-01 2013-01-31]
+    test cast-period-1.5 {qc::cast period "January 2014"} {qc::cast period "January 2013"} [list 2013-01-01 2013-01-31]
+    test cast-period-1.6 {qc::cast period "Jan 2014 to March 2014"} {qc::cast period "Jan 2014 to March 2014"} [list 2014-01-01 2014-03-31]
+    test cast-period-1.7 {qc::cast period "Febuary 2014"} -body {qc::cast period "Febuary 2013"} -result "Could not parse string \"Febuary 2013\" into dates that define a period." -returnCodes error 
+    test cast-period-1.8 {qc::cast period "1st February 2014 to 14th February 2014"} {qc::cast period "1st February 2014 to 14th February 2014"} [list 2014-02-01 2014-02-14]
+    test cast-period-1.9 {qc::cast period "1st February 2014"} {qc::cast period "1st February 2014"} [list 2014-02-01 2014-02-01]
 
 
-    test is_period-1.0 {qc::is_period ""} {qc::is_period ""} "false"
-    test is_period-1.1 {qc::is_period "Jan"} {qc::is_period "Jan"} "true"
-    test is_period-1.2 {qc::is_period "January"} {qc::is_period "January"} "true"
-    test is_period-1.3 {qc::is_period "2014"} {qc::is_period "2014"} "true"
-    test is_period-1.4 {qc::is_period "Jan 2014"} {qc::is_period "Jan 2013"} "true"
-    test is_period-1.5 {qc::is_period "January 2014"} {qc::is_period "January 2014"} "true"
-    test is_period-1.6 {qc::is_period "Jan 2014 to March 2014"} {qc::is_period "Jan 2014 to March 2014"} "true"
-    test is_period-1.7 {qc::is_period "Febuary 2014"} {qc::is_period "Febuary 2014"} "false"
-    test is_period-1.8 {qc::is_period "1st February 2014 to 14th February 2014"} {qc::is_period "1st February 2014 to 14th February 2014"} "true"
+    test cast-time-1.0 {qc::cast time "00:00:00.000000"} -body {
+        qc::cast time "00:00:00.000000"
+    } -result "00:00:00"
+
+    test cast-time-1.1 {qc::cast time "00:00:00"} -body {
+        qc::cast time "00:00:00"
+    } -result "00:00:00"
+
+    test cast-time-1.2 {qc::cast time "24:00:00.000000"} -body {
+        qc::cast time "24:00:00.000000"
+    } -result "24:00:00"
+
+    test cast-time-1.3 {qc::cast time "24:00:00"} -body {
+        qc::cast time "24:00:00"
+    } -result "24:00:00"
+
+    test cast-time-1.4 {qc::cast time "12:34:56.789"} -body {
+        qc::cast time "12:34:56.789"
+    } -result "12:34:56.789"
+
+    test cast-time-1.5 {qc::cast time "12:34:56"} -body {
+        qc::cast time "12:34:56"
+    } -result "12:34:56"
+
+    test cast-time-1.6 {qc::cast time "12:59"} -body {
+        qc::cast time "12:59"
+    } -result "12:59:00"
 
     cleanupTests
 }

--- a/test/castable.test
+++ b/test/castable.test
@@ -1,0 +1,376 @@
+package require tcltest
+eval ::tcltest::configure $argv
+# Ensure package is loaded from ./package rather than /usr/lib/tcltk
+set auto_path [linsert $auto_path 0 ./package]
+package require -exact qcode $::env(VERSION)
+
+namespace eval ::qcode::test {
+    namespace import ::tcltest::*
+    namespace path ::qc
+
+    test castable-integer1.0 {castable integer already int} -setup {
+    } -body {
+        castable integer 1
+    } -result true
+
+    test castable-integer-1.1 {castable integer exponential} -setup {
+    } -body {
+        castable integer 42e2
+    } -result true
+
+    test castable-integer-1.2 {castable integer percent} -setup {
+    } -body {
+        castable integer 2.366%
+    } -result true
+
+    test castable-integer-1.3 {castable integer comma} -setup {
+    } -body {
+        castable integer 2,366
+    } -result true
+
+    test castable-integer-1.4 {castable integer invalid} -setup {
+    } -body {
+        castable integer 1A
+    } -result false
+
+    test castable-bigint1.0 {castable bigint already int} -setup {
+    } -body {
+        castable bigint 1
+    } -result true
+    
+    test castable-bigint1.1 {castable bigint exponential} -setup {
+    } -body {
+        castable bigint 3.14e6
+    } -result true
+    
+    test castable-bigint1.2 {castable bigint percent} -setup {
+    } -body {
+        castable bigint 3.14159%
+    } -result true
+    
+    test castable-bigint1.3 {castable bigint comma} -setup {
+    } -body {
+        castable bigint 3,1459
+    } -result true
+
+    test castable-bigint1.4 {castable bigint invalid} -setup {
+    } -body {
+        castable bigint foo
+    } -result false
+
+    test castable-bigint1.5 {castable bigint out of range upper} -setup {
+    } -body {
+        castable bigint 9223372036854775808
+    } -result false
+
+    test castable-bigint1.6 {castable bigint out of range lower} -setup {
+    } -body {
+        castable bigint -9223372036854775809
+    } -result false
+
+    test castable-bigint1.7 {castable bigint negative} -setup {
+    } -body {
+        castable bigint -31459
+    } -result true
+
+    test castable-smallint1.0 {castable smallint already int} -setup {
+    } -body {
+        castable smallint 1
+    } -result true
+    
+    test castable-smallint1.1 {castable smallint exponential} -setup {
+    } -body {
+        castable smallint 3.14e2
+    } -result true
+    
+    test castable-smallint1.2 {castable smallint percent} -setup {
+    } -body {
+        castable smallint 3.14159%
+    } -result true
+    
+    test castable-smallint1.3 {castable smallint comma} -setup {
+    } -body {
+        castable smallint 3,1459
+    } -result true
+
+    test castable-smallint1.4 {castable smallint invalid} -setup {
+    } -body {
+        castable smallint foo
+    } -result false
+
+    test castable-smallint1.5 {castable smallint out of range upper} -setup {
+    } -body {
+        castable smallint 35000
+    } -result false
+
+    test castable-smallint1.6 {castable smallint out of range lower} -setup {
+    } -body {
+        castable smallint -35000
+    } -result false
+
+    test castable-smallint1.7 {castable smallint negative} -setup {
+    } -body {
+        castable smallint -31459
+    } -result true
+
+    test castable-decimal-1.0 {castable decimal valid} -setup {
+    } -body {
+        castable decimal 2,305.25
+    } -result true
+
+    test castable-decimal-1.1 {castable decimal percent} -setup {
+    } -body {
+        castable decimal 2,305%
+    } -result true
+
+    test castable-decimal-1.2 {castable decimal invalid} -setup {
+    } -body {
+        castable decimal 1A
+    } -result false
+
+    test castable-decimal-1.3 {castable decimal long} -setup {
+    } -body {
+        castable decimal 1.123456789e9
+    } -result true
+
+    test castable-decimal-1.4 {castable decimal precision} -setup {
+    } -body {
+        castable decimal -precision 3 3.14159
+    } -result true
+
+    test castable-decimal-1.5 {castable decimal precision invalid} -setup {
+    } -body {
+        castable decimal -precision 1 314.159
+    } -result false
+
+    test castable-decimal-1.6 {castable decimal precision scale} -setup {
+    } -body {
+        castable decimal -precision 4  -scale 3 3.14159
+    } -result true
+
+    test castable-decimal-1.7 {castable decimal precision scale invalid} -setup {
+    } -body {
+        castable decimal -precision 4 -scale 4 314.15926
+    } -result false
+
+    test castable-decimal-1.8 {castable decimal precision scale invalid} -setup {
+    } -body {
+        castable decimal -precision 7 -scale 5 314.15926
+    } -result false
+
+    test castable-decimal-1.9 {castable decimal precision scale exponent} -setup {
+    } -body {
+        castable decimal -precision 7 -scale 2 3.14e4 
+    } -result true
+
+    test castable-boolean-1.0 {castable boolean already boolean} -setup {
+    } -body {
+        castable boolean true
+    } -result true
+
+    test castable-boolean-1.1 {castable boolean invalid} -setup {
+    } -body {
+        castable boolean foo
+    } -result false
+
+    test castable-timestamp-1.0 {castable timestamp relative} -setup {
+    } -body {
+        castable timestamp today
+    } -result true
+
+    test castable-timestamp-1.1 {castable timestamp uk format date only} -setup {
+    } -body {
+        castable timestamp 12/5/12
+    } -result true
+
+    test castable-timestamp-1.2 {castable timestamp illegal} -setup {
+    } -body {
+        castable timestamp "A moment ago"
+    } -result false
+
+    test castable-timestamptz-1.0 {castable timestamptz relative} -setup {
+    } -body {
+        castable timestamptz today
+    } -result true
+
+    test castable-timestamptz-1.1 {castable timestamptz uk format date only} -setup {
+    } -body {
+        castable timestamptz 12/5/12
+    } -result true
+
+    test castable-timestamptz-1.2 {castable timestamptz illegal} -setup {
+    } -body {
+        castable timestamptz "A moment ago"
+    } -result false
+
+    test castable-varchar-1.0 {castable varchar too long} -setup {
+    } -body {
+        castable varchar 12 "Too long a string"
+    } -result false
+
+    test castable-varchar-1.1 {castable varchar OK} -setup {
+    } -body {
+        castable varchar 12 "Short enough"
+    } -result true
+
+    test castable-char-1.0 {castable char too long} -setup {
+    } -body {
+        castable char 12 "Too long a string"
+    } -result false
+
+    test castable-char-1.1 {castable char exact} -setup {
+    } -body {
+        castable char 12 "Short enough"
+    } -result true
+
+    test castable-char-1.1 {castable char too short} -setup {
+    } -body {
+        castable char 12 "foo"
+    } -result false
+    
+    test castable-date-1.0 {castable date short} -setup {
+    } -body {
+        castable date 10
+    } -result true
+
+    test castable-date-1.1 {castable date long without year} -setup {
+    } -body {
+        castable date "June 20th"
+    } -result true
+
+    test castable-date-1.2 {castable date relative} -setup {
+    } -body {
+        castable date tomorrow
+    } -result true
+
+    test castable-date-1.3 {castable date month only} -setup {
+    } -body {
+        castable date May
+    } -result false
+
+    test castable-date-1.4 {castable date illegal} -setup {
+    } -body {
+        castable date Xmas
+    } -result false
+
+    test castable-postcode-1.0 {castable postcode partial} -setup {
+    } -body {
+        castable postcode EH3
+    } -result false
+
+    test castable-postcode-1.1 {castable postcode lowercase} -setup {
+    } -body {
+        castable postcode "eh2 9ee"
+    } -result true
+
+    test castable-postcode-1.2 {castable postcode already postcode} -setup {
+    } -body {
+        castable postcode "EH2 9EE"
+    } -result true
+
+    test castable-postcode-1.3 {castable postcode no space} -setup {
+    } -body {
+        castable postcode "W1P2BB"
+    } -result true
+
+    test castable-postcode-1.4 {castable postcode zero in place of capital 'o'} -setup {
+    } -body {
+        castable postcode "y023 5ng"
+    } -result true
+
+    test castable-creditcard-1.0 {castable creditcard with separators} -setup {
+    } -body {
+        castable creditcard "4111-1111+1111 1111"
+    } -result true
+
+    test castable-creditcard-1.1 {castable creditcard invalid} -setup {
+    } -body {
+        castable creditcard "4111 1111 1111 1112"
+    } -result false
+
+    test castable-creditcard-1.2 {castable creditcard too short} -setup {
+    } -body {
+        castable creditcard 4111111111111
+    } -result false
+
+    test castable-creditcard-1.3 {castable creditcard masked} -setup {
+    } -body {
+        castable creditcard 411111******1111
+    } -result false
+
+    test castable-period-1.0 {castable period empty} -body {
+        castable period ""
+    } -result false
+    
+    test castable-period-1.1 {castable period shorthand month} -body {
+        castable period "Jan"
+    } -result true
+    
+    test castable-period-1.2 {castable period full name month} -body {
+        castable period "January"
+    } -result true
+    
+    test castable-period-1.3 {castable period year} -body {
+        castable period "2014"
+    } -result true
+    
+    test castable-period-1.4 {castable period shorthand month with year} -body {
+        castable period "Jan 2014"
+    } -result true
+    
+    test castable-period-1.5 {castable period full name month with year} -body {
+        castable period "January 2014"
+    } -result true
+    
+    test castable-period-1.6 {castable period month year to month year} -body {
+        castable period "Jan 2014 to March 2014"
+    } -result true
+    
+    test castable-period-1.7 {castable period day month year to day month year} -body {
+        castable period "1st February 2014 to 14th February 2014"
+    } -result true
+
+    test castable-period-1.8 {castable period invalid} -body {
+        castable period "Foo 2000"
+    } -result false
+
+
+    test castable-time-1.0 {qc::castable time "00:00:00.000000"} -body {
+        qc::castable time "00:00:00.000000"
+    } -result true
+
+    test castable-time-1.1 {qc::castable time "00:00:00"} -body {
+        qc::castable time "00:00:00"
+    } -result true
+
+    test castable-time-1.2 {qc::castable time "24:00:00.000000"} -body {
+        qc::castable time "24:00:00.000000"
+    } -result true
+
+    test castable-time-1.3 {qc::castable time "24:00:00"} -body {
+        qc::castable time "24:00:00"
+    } -result true
+
+    test castable-time-1.4 {qc::castable time "12:34:56.789"} -body {
+        qc::castable time "12:34:56.789"
+    } -result true
+
+    test castable-time-1.5 {qc::castable time "12:34:56"} -body {
+        qc::castable time "12:34:56"
+    } -result true
+
+    test castable-time-1.6 {qc::castable time "24:00:01"} -body {
+        qc::castable time "24:00:01"
+    } -result false
+
+    test castable-time-1.7 {qc::castable time "98:76:54"} -body {
+        qc::castable time "98:76:54"
+    } -result false
+
+    test castable-time-1.8 {qc::castable time "12:59"} -body {
+        qc::castable time "12:59"
+    } -result true
+    
+    cleanupTests
+}
+namespace delete ::qcode::test

--- a/test/is.test
+++ b/test/is.test
@@ -8,61 +8,61 @@ namespace eval ::qcode::test {
     namespace import ::tcltest::*
     namespace path ::qc
 
-    test is_boolean-1.0 {is_boolean true } -setup {
+    test is-boolean-1.0 {is boolean true } -setup {
     } -body {
-        is_boolean true
+        is boolean true
     } -result {1}
 
-    test is_boolean-1.1 {is_boolean false } -setup {
+    test is-boolean-1.1 {is boolean false } -setup {
     } -body {
-        is_boolean false
+        is boolean false
     } -result {1}
 
-    test is_boolean-1.2 {is_boolean yes lower } -setup {
+    test is-boolean-1.2 {is boolean yes lower } -setup {
     } -body {
-        is_boolean yes
+        is boolean yes
     } -result {1}
 
-    test is_boolean-1.3 {is_boolean no lower } -setup {
+    test is-boolean-1.3 {is boolean no lower } -setup {
     } -body {
-        is_boolean no
+        is boolean no
     } -result {1}
 
-    test is_boolean-1.4 {is_boolean non-boolean } -setup {
+    test is-boolean-1.4 {is boolean non-boolean } -setup {
     } -body {
-        is_boolean theremin
+        is boolean theremin
     } -result {0}
 
-    test is_boolean-1.5 {is_boolean non-boolean 2 } -setup {
+    test is-boolean-1.5 {is boolean non-boolean 2 } -setup {
     } -body {
-        is_boolean 999
+        is boolean 999
     } -result {0}
 
-    test is_integer-1.0 {is_integer 999 } -setup {
+    test is-integer-1.0 {is integer 999 } -setup {
     } -body {
-        is_integer 999
+        is integer 999
     } -result {1}
 
-    test is_integer-1.1 {is_integer 0.1 } -setup {
+    test is-integer-1.1 {is integer 0.1 } -setup {
     } -body {
-        is_integer 0.1
+        is integer 0.1
     } -result {0}
 
-    test is_integer-1.2 {is_integer 0 } -setup {
+    test is-integer-1.2 {is integer 0 } -setup {
     } -body {
-        is_integer 0
+        is integer 0
     } -result {1}
 
-    test is_integer-1.3 {is_integer true } -setup {
+    test is-integer-1.3 {is integer true } -setup {
     } -body {
-        is_integer true
+        is integer true
     } -result {0}
 
-    test is_integer-1.4 {is_integer upper limit} {qc::is_integer "2147483647"} 1
-    test is_integer-1.5 {is_integer outside integer range} {qc::is_integer "2147483648"} 0
-    test is_integer-1.6 {is_integer outside integer range} {qc::is_integer "2e100"} 0
-    test is_integer-1.7 {is_integer lower limit} {qc::is_integer "-2147483648"} 1
-    test is_integer-1.8 {is_integer outside integer range} {qc::is_integer "-2147483649"} 0
+    test is-integer-1.4 {is integer upper limit} {qc::is integer "2147483647"} 1
+    test is-integer-1.5 {is integer outside integer range} {qc::is integer "2147483648"} 0
+    test is-integer-1.6 {is integer outside integer range} {qc::is integer "2e100"} 0
+    test is-integer-1.7 {is integer lower limit} {qc::is integer "-2147483648"} 1
+    test is-integer-1.8 {is integer outside integer range} {qc::is integer "-2147483649"} 0
 
     test is_pos-1.0 {is_pos -1 } -setup {
     } -body {
@@ -139,16 +139,61 @@ namespace eval ::qcode::test {
         is_pnz_int -10
     } -result {0}
 
-    test is_decimal-1.0 {is_decimal 1A} -setup {
+    test is-decimal-1.0 {is decimal 1A} -setup {
     } -body {
-        is_decimal 1A
+        is decimal 1A
     } -result {0}
 
-    test is_decimal-1.1 {is_decimal 9.99999} -setup {
+    test is-decimal-1.1 {is decimal 9.99999} -setup {
     } -body {
-        is_decimal 9.99999
+        is decimal 9.99999
     } -result {1}
 
+    test is-decimal-1.2 {is decimal -precision 5 123} -setup {
+    } -body {
+        is decimal -precision 5 123
+    } -result {1}
+
+    test is-decimal-1.3 {is decimal -precision 3 123.45} -setup {
+    } -body {
+        is decimal -precision 3 123.45
+    } -result {0}
+
+    test is-decimal-1.4 {is decimal -scale 3 123.45} -setup {
+    } -body {
+        is decimal -scale 3 123.45
+    } -result "Precision must be provided with scale." -returnCodes error
+
+    test is-decimal-1.5 {is decimal -precision 4 -scale 1 123.4} -setup {
+    } -body {
+        is decimal -precision 4 -scale 1 123.4
+    } -result {1}
+
+    test is-decimal-1.6 {is decimal -precision 4 -scale 3 123.4} -setup {
+    } -body {
+        is decimal -precision 4 -scale 3 123.4
+    } -result {0}
+
+    test is-decimal-1.7 {is decimal 1.5e3} -setup {
+    } -body {
+        is decimal 1.5e3
+    } -result {1}
+    
+    test is-decimal-1.8 {is decimal -precision 4 1.5e3} -setup {
+    } -body {
+        is decimal -precision 4 1.5e3
+    } -result {1}
+
+    test is-decimal-1.9 {is decimal -precision 3 1.5e3} -setup {
+    } -body {
+        is decimal -precision 3 1.5e3
+    } -result {0}
+
+    test is-decimal-1.10 {is decimal 1,100} -setup {
+    } -body {
+        is decimal 1,100
+    } -result {0}
+    
     test is_positive_decimal-1.0 {is_positive_decimal -99.9999} -setup {
     } -body {
         is_positive_decimal -99.9999
@@ -189,224 +234,224 @@ namespace eval ::qcode::test {
         is_pnz_decimal 0.01
     } -result {1}
 
-    test is_date-1.0 {is_date 12/12/12} -setup {
+    test is-date-1.0 {is date 12/12/12} -setup {
     } -body {
-        is_date 12/12/12
+        is date 12/12/12
     } -result {0}
 
-    test is_date-1.1 {is_date 12:38:00} -setup {
+    test is-date-1.1 {is date 12:38:00} -setup {
     } -body {
-        is_date 12:38:00
+        is date 12:38:00
     } -result {0}
 
-    test is_date-1.2 {is_date 2012-08-23} -setup {
+    test is-date-1.2 {is date 2012-08-23} -setup {
     } -body {
-        is_date 2012-08-23
+        is date 2012-08-23
     } -result {1}
 
-    test is_timestamp-1.0 {is_timestamp 12/12/12} -setup {
+    test is-timestamp-1.0 {is timestamp 12/12/12} -setup {
     } -body {
-        is_timestamp 12/12/12
+        is timestamp 12/12/12
     } -result {0}
 
-    test is_timestamp-1.1 {is_timestamp 12:38:00} -setup {
+    test is-timestamp-1.1 {is timestamp 12:38:00} -setup {
     } -body {
-        is_timestamp 12:38:00
+        is timestamp 12:38:00
     } -result {0}
 
-    test is_timestamp-1.2 {is_timestamp 2012-01-01 12:38:00} -setup {
+    test is-timestamp-1.2 {is timestamp 2012-01-01 12:38:00} -setup {
     } -body {
-        is_timestamp "2012-01-01 12:38:00"
+        is timestamp "2012-01-01 12:38:00"
     } -result {1}
 
-    test is_timestamp-1.3 {is_timestamp 2012-01-01 } -setup {
+    test is-timestamp-1.3 {is timestamp 2012-01-01 } -setup {
     } -body {
-        is_timestamp "2012-01-01"
+        is timestamp "2012-01-01"
     } -result {0}
 
-    test is_timestamp_http-1.0 {is_timestamp_http 12/12/12} -setup {
+    test is-timestamp_http-1.0 {is timestamp_http 12/12/12} -setup {
     } -body {
-        is_timestamp_http 12/12/12
+        is timestamp_http 12/12/12
     } -result {0}
 
-    test is_timestamp_http-1.1 {is_timestamp_http RFC 1123} -setup {
+    test is-timestamp_http-1.1 {is timestamp_http RFC 1123} -setup {
     } -body {
-        is_timestamp_http "Sun, 06 Nov 1994 08:49:37 GMT"
+        is timestamp_http "Sun, 06 Nov 1994 08:49:37 GMT"
     } -result {1}
 
-    test is_timestamp_http-1.2 {is_timestamp_http RFC 1123 neg} -setup {
+    test is-timestamp_http-1.2 {is timestamp_http RFC 1123 neg} -setup {
     } -body {
-        is_timestamp_http "Sunday, 06 Nov 1994 08:49:37 GMT"
+        is timestamp_http "Sunday, 06 Nov 1994 08:49:37 GMT"
     } -result {0}
 
-    test is_timestamp_http-1.3 {is_timestamp_http RFC 850 } -setup {
+    test is-timestamp_http-1.3 {is timestamp_http RFC 850 } -setup {
     } -body {
-        is_timestamp_http "Sunday, 06-Nov-94 08:49:37 GMT"
+        is timestamp_http "Sunday, 06-Nov-94 08:49:37 GMT"
     } -result {1}
 
-    test is_timestamp_http-1.4 {is_timestamp_http RFC 850 neg} -setup {
+    test is-timestamp_http-1.4 {is timestamp_http RFC 850 neg} -setup {
     } -body {
-        is_timestamp_http "Sunday, 06-Nov-1994 08:49:37 GMT"
+        is timestamp_http "Sunday, 06-Nov-1994 08:49:37 GMT"
     } -result {0}
 
-    test is_timestamp_http-1.5 {is_timestamp_http ANSI C} -setup {
+    test is-timestamp_http-1.5 {is timestamp_http ANSI C} -setup {
     } -body {
-        is_timestamp_http "Sun Nov  6 08:49:37 1994"
+        is timestamp_http "Sun Nov  6 08:49:37 1994"
     } -result {1}
 
-    test is_timestamp_http-1.6 {is_timestamp_http ANSI C 2 digit} -setup {
+    test is-timestamp_http-1.6 {is timestamp_http ANSI C 2 digit} -setup {
     } -body {
-        is_timestamp_http "Sun Nov 16 08:49:37 1994"
+        is timestamp_http "Sun Nov 16 08:49:37 1994"
     } -result {1}
 
-    test is_timestamp_http-1.7 {is_timestamp_http ANSI C neg} -setup {
+    test is-timestamp_http-1.7 {is timestamp_http ANSI C neg} -setup {
     } -body {
-        is_timestamp_http "Sun Nov 6 08:49:37 1994"
+        is timestamp_http "Sun Nov 6 08:49:37 1994"
     } -result {0}
 
-    test is_timestamp_http-1.8 {is_timestamp_http ANSI C neg2} -setup {
+    test is-timestamp_http-1.8 {is timestamp_http ANSI C neg2} -setup {
     } -body {
-        is_timestamp_http "2013-05-24 10:17:01"
+        is timestamp_http "2013-05-24 10:17:01"
     } -result {0}
 
-    test is_email-1.0 {is_email partial email} -setup {
+    test is-email-1.0 {is email partial email} -setup {
     } -body {
-        is_email @gmail.com
+        is email @gmail.com
     } -result {0}
 
-    test is_email-1.1 {is_email invalid format} -setup {
+    test is-email-1.1 {is email invalid format} -setup {
     } -body {
-        is_email dave.@gmail.com
+        is email dave.@gmail.com
     } -result {0}
 
-    test is_email-1.2 {is_email incomplete domain } -setup {
+    test is-email-1.2 {is email incomplete domain } -setup {
     } -body {
-        is_email dave@gmail
+        is email dave@gmail
     } -result {0}
 
-    test is_email-1.3 {is_email valid} -setup {
+    test is-email-1.3 {is email valid} -setup {
     } -body {
-        is_email dave.smith_2-2@gmail.com
+        is email dave.smith_2-2@gmail.com
     } -result {1}
 
-    test is_email-1.4 {is_email valid} -setup {
+    test is-email-1.4 {is email valid} -setup {
     } -body {
-        is_email dave.smith_2-2+1@gmail.com
+        is email dave.smith_2-2+1@gmail.com
     } -result {1}
 
-    test is_postcode-1.0 {is_postcode partial} -setup {
+    test is-postcode-1.0 {is postcode partial} -setup {
     } -body {
-        is_postcode EH3
+        is postcode EH3
     } -result {0}
 
-    test is_postcode-1.1 {is_postcode BFPO} -setup {
+    test is-postcode-1.1 {is postcode BFPO} -setup {
     } -body {
-        is_postcode "BFPO 61"
+        is postcode "BFPO 61"
     } -result 1
 
-    test is_postcode-1.2 {is_postcode standard} -setup {
+    test is-postcode-1.2 {is postcode standard} -setup {
     } -body {
-        is_postcode "EH2 9EE"
+        is postcode "EH2 9EE"
     } -result 1
 
-    test is_postcode-1.3 {is_postcode high density district} -setup {
+    test is-postcode-1.3 {is postcode high density district} -setup {
     } -body {
-        is_postcode "W1P 2BB"
+        is postcode "W1P 2BB"
     } -result 1
 
-    test is_postcode-1.4 {is_postcode no space} -setup {
+    test is-postcode-1.4 {is postcode no space} -setup {
     } -body {
-        is_postcode "W1P2BB"
+        is postcode "W1P2BB"
     } -result 0
 
-    test is_creditcard-1.0 {is_creditcard valid} -setup {
+    test is-creditcard-1.0 {is creditcard valid} -setup {
     } -body {
-        is_creditcard 4111111111111111
+        is creditcard 4111111111111111
     } -result 1
 
-    test is_creditcard-1.1 {is_creditcard invalid} -setup {
+    test is-creditcard-1.1 {is creditcard invalid} -setup {
     } -body {
-        is_creditcard 4111111111111112
+        is creditcard 4111111111111112
     } -result 0
 
-    test is_creditcard-1.2 {is_creditcard too short} -setup {
+    test is-creditcard-1.2 {is creditcard too short} -setup {
     } -body {
-        is_creditcard 4111111111111
+        is creditcard 4111111111111
     } -result 0
 
-    test is_creditcard-1.3 {is_creditcard masked} -setup {
+    test is-creditcard-1.3 {is creditcard masked} -setup {
     } -body {
-        is_creditcard 411111******1111
+        is creditcard 411111******1111
     } -result 0
 
-    test is_creditcard_masked-1.0 {is_creditcard_masked unmasked number} -setup {
+    test is-creditcard_masked-1.0 {is creditcard_masked unmasked number} -setup {
     } -body {
-        is_creditcard_masked 4111111111111111
+        is creditcard_masked 4111111111111111
     } -result 0
 
-    test is_creditcard_masked-1.1 {is_creditcard_masked too few masked digits} -setup {
+    test is-creditcard_masked-1.1 {is creditcard_masked too few masked digits} -setup {
     } -body {
-        is_creditcard_masked 41111111****1111
+        is creditcard_masked 41111111****1111
     } -result 0
 
-    test is_creditcard_masked-1.2 {is_creditcard_masked min masked} -setup {
+    test is-creditcard_masked-1.2 {is creditcard_masked min masked} -setup {
     } -body {
-        is_creditcard_masked 411111******1111
+        is creditcard_masked 411111******1111
     } -result 1
 
-    test is_creditcard_masked-1.3 {is_creditcard_masked more masked} -setup {
+    test is-creditcard_masked-1.3 {is creditcard_masked more masked} -setup {
     } -body {
-        is_creditcard_masked 411111**********
+        is creditcard_masked 411111**********
     } -result 1
 
-    test is_creditcard_masked-1.4 {is_creditcard_masked all masked} -setup {
+    test is-creditcard_masked-1.4 {is creditcard_masked all masked} -setup {
     } -body {
-        is_creditcard_masked ****************
+        is creditcard_masked ****************
     } -result 1
 
-    test is_creditcard_masked-1.4 {is_creditcard_masked dashes valid} -setup {
+    test is-creditcard_masked-1.4 {is creditcard_masked dashes valid} -setup {
     } -body {
-        is_creditcard_masked 4111-11**-****-1111
+        is creditcard_masked 4111-11**-****-1111
     } -result 1
 
-    test is_varchar-1.0 {is_varchar too long} -setup {
+    test is-varchar-1.0 {is varchar too long} -setup {
     } -body {
-        is_varchar "Too long a string" 12
+        is varchar 12 "Too long a string"
     } -result 0
 
-    test is_varchar-1.1 {is_varchar OK} -setup {
+    test is-varchar-1.1 {is varchar OK} -setup {
     } -body {
-        is_varchar "Short enough" 12
+        is varchar 12 "Short enough"
     } -result 1
 
-    test is_varchar-1.2 {is_varchar empty} -setup {
+    test is-varchar-1.2 {is varchar empty} -setup {
     } -body {
-        is_varchar {} 12
+        is varchar 12 {}
     } -result 1
 
-    test is_base64-1.0 {is_base64 invalid} -setup {
+    test is-base64-1.0 {is base64 invalid} -setup {
     } -body {
-        is_base64 10.0.0.1
+        is base64 10.0.0.1
     } -result 0
 
-    test is_base64-1.1 {is_base64 valid} -setup {
+    test is-base64-1.1 {is base64 valid} -setup {
     } -body {
-        is_base64 RG9sbHkgUGFydG9uCg==
+        is base64 RG9sbHkgUGFydG9uCg==
     } -result 1
 
-    test is_base64-1.2 {is_base64 truncated} -setup {
+    test is-base64-1.2 {is base64 truncated} -setup {
     } -body {
-        is_base64 RG9sbHkgUGFydG9uCg
+        is base64 RG9sbHkgUGFydG9uCg
     } -result 0
 
-    test is_base64-1.3 {is_base64 empty} -setup {
+    test is-base64-1.3 {is base64 empty} -setup {
     } -body {
-        is_base64 {}
+        is base64 {}
     } -result 0
 
-    test is_base64-1.4 {is_base64 long} -setup {
+    test is-base64-1.4 {is base64 long} -setup {
     } -body {
-        is_base64 {JVBERi0xLjQKMSAwIG9iago8PAovVGl0bGUgKP7/AFEAYwBvAGQAZQAgAFMAbwBmAHQAdwBhAHIA
+        is base64 {JVBERi0xLjQKMSAwIG9iago8PAovVGl0bGUgKP7/AFEAYwBvAGQAZQAgAFMAbwBmAHQAdwBhAHIA
 ZSkKL1Byb2R1Y2VyICh3a2h0bWx0b3BkZikKL0NyZWF0aW9uRGF0ZSAoRDoyMDEyMDkwMzEzMzMw
 NCkKPj4KZW5kb2JqCjQgMCBvYmoKPDwKL1R5cGUgL0V4dEdTdGF0ZQovU0EgdHJ1ZQovU00gMC4w
 MgovY2EgMS4wCi9DQSAxLjAKL0FJUyBmYWxzZQovU01hc2sgL05vbmU+PgplbmRvYmoKNSAwIG9i
@@ -2554,115 +2599,31 @@ ODA0MiAwMDAwMCBuIAowMDAwMTE3NzM4IDAwMDAwIG4gCnRyYWlsZXIKPDwKL1NpemUgMTcxCi9J
 bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
     } -result 1
 
-    test is_int_castable-1.0 {is_int_castable already int} -setup {
-    } -body {
-        is_int_castable 1
-    } -result true
 
-    test is_int_castable-1.1 {is_int_castable exponential} -setup {
+    test is-mobile_number-1.0 {is mobile_number valid} -setup {
     } -body {
-        is_int_castable 42e2
-    } -result true
+        is mobile_number 07768777777
+    } -result 1
 
-    test is_int_castable-1.2 {is_int_castable percent} -setup {
+    test is-mobile_number-1.1 {is mobile_number exta chars} -setup {
     } -body {
-        is_int_castable 2.366%
-    } -result true
+        is mobile_number "07768 - 777-777 "
+    } -result 1
 
-    test is_int_castable-1.3 {is_int_castable comma} -setup {
+    test is-mobile_number-1.2 {is mobile_number invalid} -setup {
     } -body {
-        is_int_castable 2,366
-    } -result true
+        is mobile_number 09768777777
+    } -result 0
 
-    test is_int_castable-1.4 {is_int_castable invalid} -setup {
+    test is-mobile_number-1.3 {is mobile_number too short} -setup {
     } -body {
-        is_int_castable 1A
-    } -result false
+        is mobile_number 0751111111
+    } -result 0
 
-    test is_decimal_castable-1.0 {is_decimal_castable valid} -setup {
+    test is-mobile_number-1.4 {is mobile_number empty} -setup {
     } -body {
-        is_decimal_castable 2,305.25
-    } -result true
-
-    test is_decimal_castable-1.1 {is_decimal_castable percent} -setup {
-    } -body {
-        is_decimal_castable 2,305%
-    } -result true
-
-    test is_decimal_castable-1.2 {is_decimal_castable invalid} -setup {
-    } -body {
-        is_decimal_castable 1A
-    } -result false
-
-    test is_decimal_castable-1.3 {is_decimal_castable long} -setup {
-    } -body {
-        is_decimal_castable 1.123456789e9
-    } -result true
-
-    test is_date_castable-1.0 {is_date_castable short} -setup {
-    } -body {
-        is_date_castable 10
-    } -result true
-
-    test is_date_castable-1.1 {is_date_castable long without year} -setup {
-    } -body {
-        is_date_castable "June 20th"
-    } -result true
-
-    test is_date_castable-1.2 {is_date_castable relative} -setup {
-    } -body {
-        is_date_castable tomorrow
-    } -result true
-
-    test is_date_castable-1.3 {is_date_castable month only} -setup {
-    } -body {
-        is_date_castable May
-    } -result false
-
-    test is_date_castable-1.4 {is_date_castable illegal} -setup {
-    } -body {
-        is_date_castable Xmas
-    } -result false
-
-    test is_timestamp_castable-1.0 {is_timestamp_castable relative} -setup {
-    } -body {
-        is_timestamp_castable today
-    } -result true
-
-    test is_timestamp_castable-1.1 {is_timestamp_castable uk format date only} -setup {
-    } -body {
-        is_timestamp_castable 12/5/12
-    } -result true
-
-    test is_timestamp_castable-1.2 {is_timestamp_castable illegal} -setup {
-    } -body {
-        is_timestamp_castable "A moment ago"
-    } -result false
-
-    test is_mobile_number-1.0 {is_mobile_number valid} -setup {
-    } -body {
-        is_mobile_number 07768777777
-    } -result true
-
-    test is_mobile_number-1.1 {is_mobile_number exta chars} -setup {
-    } -body {
-        is_mobile_number "07768 - 777-777 "
-    } -result true
-
-    test is_mobile_number-1.2 {is_mobile_number invalid} -setup {
-    } -body {
-        is_mobile_number 09768777777
-    } -result false
-
-    test is_mobile_number-1.3 {is_mobile_number too short} -setup {
-    } -body {
-        is_mobile_number 0751111111
-    } -result false
-
-    test is_mobile_number-1.4 {is_mobile_number empty} -setup {
-    } -body {
-       is_mobile_number {}
-    } -result false
+        is mobile_number {}
+    } -result 0
 
     test contains_creditcard-1.0 {contains_creditcard cc no only} -setup {
     } -body {
@@ -2694,219 +2655,332 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
         contains_creditcard "The cc number 411111******1111 is in the middle of this string."
     } -result false
 
-    test is_hex-1.0 {is_hex valid} -setup {
+    test is-hex-1.0 {is hex valid} -setup {
     } -body {
-        is_hex 9F
+        is hex 9F
     } -result 1
 
-    test is_hex-1.1 {is_hex valid lower} -setup {
+    test is-hex-1.1 {is hex valid lower} -setup {
     } -body {
-        is_hex 1a
+        is hex 1a
     } -result 1
 
-    test is_hex-1.2 {is_hex invalid} -setup {
+    test is-hex-1.2 {is hex invalid} -setup {
     } -body {
-        is_hex 9G
+        is hex 9G
     } -result 0
 
-    test is_hex-1.3 {is_hex longer} -setup {
+    test is-hex-1.3 {is hex longer} -setup {
     } -body {
-        is_hex 2F57B7A02180369
+        is hex 2F57B7A02180369
     } -result 1
 
-    test is_url-1.0 {is_url valid brief} -setup {
+    test is-url-1.0 {is url valid brief} -setup {
     } -body {
-        is_url www.domain.com
+        is url www.domain.com
     } -result 0
 
-    test is_url-1.1 {is_url valid full uk} -setup {
+    test is-url-1.1 {is url valid full uk} -setup {
     } -body {
-        is_url https://www.domain.co.uk
+        is url https://www.domain.co.uk
     } -result 1
 
-    test is_url-1.2 {is_url valid full uk with port & form vars} -setup {
+    test is-url-1.2 {is url valid full uk with port & form vars} -setup {
     } -body {
-        is_url https://www.domain.co.uk:433/subdir?formvar1=foo&formvar2=bar#anchor
+        is url https://www.domain.co.uk:433/subdir?formvar1=foo&formvar2=bar#anchor
     } -result 1
 
-    test is_url-1.3 {is_url long formvar } -setup {
+    test is-url-1.3 {is url long formvar } -setup {
     } -body {
-        is_url "https://www.domain.co.uk/subdir?formvar1=MDgzNjIgMDAwMDAgbiAKMDAwMDExODU1NiAwMDAwMCBuIAowMDAwMDAyODM5IDAwMDAwIG4gCjAwMDAwMDMwMjUgMDAwMDAgbiAKMDAwMDAwMzA0NCAwMDAwMCBuIAowMDAwMDAzODc1IDAwMDAwIG4gCjAwMDAwMDM4OTUgMDAwMDAgbiAKMDAwMDExNDc1NSAwMDAwMCBuIAowMDAwMDA0MTc2IDAwMDAwIG4gCjAwMDAwMDUyNzQgMDAwMDAgbiAKMDAwMDAwNTI5NCAwMDAwMCBuIAowMDAwMDExMzA0IDAwMDAwIG4gCjAwMDAwMTEzMjUgMDAwMDAgbiAKMDAwMDAxMjQ2MSAwMDAwMCBuIAowMDAwMDEyNDgxIDAwMDAwIG4gCjAwMDAwMTc2MTAgMDAwMDAgbiAKMDAwMDAxNzYzMSAwMDAwMCBuIAowMDAwMDE4ODA0IDAwMDAwIG4gCjAwMDAwMTg4MjUgMDAwMDAgbiAKMDAwMDAyNDc3OSAwMDAwMCBuIAowMDAwMDI0ODAwIDAwMDAwIG4gCjAwMDAwMjU4ODAgMDAwMDAgbiAKMDAwMDAyNTkwMCAwMDAwMCBuIAowMDAwMDMwODY2IDAwMDAwIG4gCjAwMDAwMzA4ODcgMDAwMDAgbiAKMDAwMDAzMTIwOSAwMDAwMCBuIAowMDAwMDMxMjI5IDAwMDAwIG4gCjAwMDAwMzIyNDggMDAwMDAgbiAKMDAwMDAzMjI2OCAwMDAwMCBuIAowMDAwMDMyNDQ3IDAwMDAwIG4gCjAwMDAwMzI0NjYgMDAwMDAgbiAKMDAwMDAzMzI5NyAwMDAwMCBuIAowMDAwMDMzMzE3IDAwMDAwIG4gCjAwMDAwMzM1OTggMDAwMDAgbiAKMDAwMDAzODUyNiAwMDAwMCBuIAowMDAwMDM4NTQ3IDAwMDAwIG4gCjAwMDAwNDM2NzEgMDAwMDAgbiAKMDAwMDA0MzY5MiAwMDAwMCBuIAowMDAwMDQzNzI4IDAwMDAwIG4gCjAwMDAwNDczMTMgMDAwMDAgbiAKMDAwMDA0NzMzNCAwMDAwMCBuIAowMDAwMDU2MTQwIDAwMDAwIG4gCjAwMDAwNTYxNjEgMDAwMDAgbiAKMDAwMDA1NjQ1OSAwMDAwMCBuIAowMDAwMDU2NDc5IDAwMDAwIG4gCjAwMDAwNTc1MDQgMDAwMDAgbiAKMDAwMDA1NzUyNCAwMDAwMCBuIAowMDAwMDU3ODUwIDAwMDAwIG4gCjAwMDAwNTc4NzAgMDAwMDAgbiAKMDAwMDA1ODkwMSAwMDAwMCBuIAowMDAwMDU4OTIxIDAwMDAwIG4gCjAwMDAwNTkxMDQgMDAwMDAgbiAKMDAwMDA1OTEyMyAwMDAwMCBuIAowMDAwMDU5OTUzIDAwMDAwIG4gCjAwMDAwNTk5NzMgMDAwMDAgbiAKMDAwMDA5NjUyNyAwMDAwMCBuIAowMDAwMDYwMjU0IDAwMDAwIG4gCjAwMDAwNjA0MjcgMDAwMDAgbiAKMDAwMDA2MDQ0NiAwMDAwMCBuIAowMDAwMDYxMzI1IDAwMDAwIG4gCjAwMDAwNjEzNDUgMDAwMDAgbiAKMDAwMDA2MTM5NyAwMDAwMCBuIAowMDAwMDYxNDQ5IDAwMDAwIG4gCjAwMDAwNjE1MDEgMDAwMDAgbiAKMDAwMDA2MTU1MyAwMDAwMCBuIAowMDAwMDYxNjA1IDAwMDAwIG4gCjAwMDAwNjE2NTcgMDAwMDAgbiAKMDAwMDA2MTcwOSAwMDAwMCBuIAowMDAwMDYxNzYxIDAwMDAwIG4gCjAwMDAwNjE5NDQgMDAwMDAgbiAKMDAwMDA2MjE1OSAwMDAwMCBuIAowMDAwMDYyMzQzIDAwMDAwIG4gCjAwMDAwNjI1MzYgMDAwMDAgbiAKMDAwMDA2MjcxOSAwMDAwMCBuIAowMDAwMDYyOTA4IDAwMDAwIG4gCjAwMDAwNjMwOTggMDAwMDAgbiAKMDAwMDA2MzI4NiAwMDAwMCBuIAowMDAwMDYzNDc4IDAwMDAwIG4gCjAwMDAwNjM2NjMgMDAwMDAgbiAKMDAwMDA2Mzg1OSAwMDAwMCBuIAowMDAwMDY0MDM4IDAwMDAwIG4gCjAwMDAwNjQyMTcgMDAwMDAgbiAKMDAwMDA2NDM4OSAwMDAwMCBuIAowMDAwMDY0NTYyIDAwMDAwIG4gCjAwMDAwNjQ3NDAgMDAwMDAgbiAKMDAwMDA2NDkxMSAwMDAwMCBuIAowMDAwMDY1MTM0IDAwMDAwIG4gCjAwMDAwNjUzNDQgMDAwMDAgbiAKMDAwMDA2NTU1NCAwMDAwMCBuIAowMDAwMDY1NzY0IDAwMDAwIG4gCjAwMDAwNjY3MzggMDAwMDAgbiAKMDAwMDA3MTE5NyAwMDAwMCBuIAowMDAwMDY2MDk3IDAwMDAwIG4gCjAwMDAwNjY1NTUgMDAwMDAgbiAKMDAwMDA3NzA3OCAwMDAwMCBuIAowMDAwMDcxMjE5IDAwMDAwIG4gCjAwMDAwNzE1MDEgMDAwMDAgbiAKMDAwMDA3MTc4MyAwMDAwMCBuIAowMDAwMDcxOTk5IDAwMDAwIG4gCjAwMDAwNzIwMTkgMDAwMDAgbiAKMDAwMDA3MjkzMSAwMDAwMCBuIAowMDAwMDcyOTUyIDAwMDAwIG4gCjAwMDAwNzMyMzQgMDAwMDAgbiAKMDAwMDA3MzUxNiAwMDAwMCBuIAowMDAwMDczNzk4IDAwMDAwIG4gCjAwMDAwNzQwODAgMDAwMDAgbiAKMDAwMDA3NDM2MiAwMDAwMCBuIAowMDAwMDc0NjQ0IDAwMDAwIG4gCjAwMDAwNz"
+        is url "https://www.domain.co.uk/subdir?formvar1=MDgzNjIgMDAwMDAgbiAKMDAwMDExODU1NiAwMDAwMCBuIAowMDAwMDAyODM5IDAwMDAwIG4gCjAwMDAwMDMwMjUgMDAwMDAgbiAKMDAwMDAwMzA0NCAwMDAwMCBuIAowMDAwMDAzODc1IDAwMDAwIG4gCjAwMDAwMDM4OTUgMDAwMDAgbiAKMDAwMDExNDc1NSAwMDAwMCBuIAowMDAwMDA0MTc2IDAwMDAwIG4gCjAwMDAwMDUyNzQgMDAwMDAgbiAKMDAwMDAwNTI5NCAwMDAwMCBuIAowMDAwMDExMzA0IDAwMDAwIG4gCjAwMDAwMTEzMjUgMDAwMDAgbiAKMDAwMDAxMjQ2MSAwMDAwMCBuIAowMDAwMDEyNDgxIDAwMDAwIG4gCjAwMDAwMTc2MTAgMDAwMDAgbiAKMDAwMDAxNzYzMSAwMDAwMCBuIAowMDAwMDE4ODA0IDAwMDAwIG4gCjAwMDAwMTg4MjUgMDAwMDAgbiAKMDAwMDAyNDc3OSAwMDAwMCBuIAowMDAwMDI0ODAwIDAwMDAwIG4gCjAwMDAwMjU4ODAgMDAwMDAgbiAKMDAwMDAyNTkwMCAwMDAwMCBuIAowMDAwMDMwODY2IDAwMDAwIG4gCjAwMDAwMzA4ODcgMDAwMDAgbiAKMDAwMDAzMTIwOSAwMDAwMCBuIAowMDAwMDMxMjI5IDAwMDAwIG4gCjAwMDAwMzIyNDggMDAwMDAgbiAKMDAwMDAzMjI2OCAwMDAwMCBuIAowMDAwMDMyNDQ3IDAwMDAwIG4gCjAwMDAwMzI0NjYgMDAwMDAgbiAKMDAwMDAzMzI5NyAwMDAwMCBuIAowMDAwMDMzMzE3IDAwMDAwIG4gCjAwMDAwMzM1OTggMDAwMDAgbiAKMDAwMDAzODUyNiAwMDAwMCBuIAowMDAwMDM4NTQ3IDAwMDAwIG4gCjAwMDAwNDM2NzEgMDAwMDAgbiAKMDAwMDA0MzY5MiAwMDAwMCBuIAowMDAwMDQzNzI4IDAwMDAwIG4gCjAwMDAwNDczMTMgMDAwMDAgbiAKMDAwMDA0NzMzNCAwMDAwMCBuIAowMDAwMDU2MTQwIDAwMDAwIG4gCjAwMDAwNTYxNjEgMDAwMDAgbiAKMDAwMDA1NjQ1OSAwMDAwMCBuIAowMDAwMDU2NDc5IDAwMDAwIG4gCjAwMDAwNTc1MDQgMDAwMDAgbiAKMDAwMDA1NzUyNCAwMDAwMCBuIAowMDAwMDU3ODUwIDAwMDAwIG4gCjAwMDAwNTc4NzAgMDAwMDAgbiAKMDAwMDA1ODkwMSAwMDAwMCBuIAowMDAwMDU4OTIxIDAwMDAwIG4gCjAwMDAwNTkxMDQgMDAwMDAgbiAKMDAwMDA1OTEyMyAwMDAwMCBuIAowMDAwMDU5OTUzIDAwMDAwIG4gCjAwMDAwNTk5NzMgMDAwMDAgbiAKMDAwMDA5NjUyNyAwMDAwMCBuIAowMDAwMDYwMjU0IDAwMDAwIG4gCjAwMDAwNjA0MjcgMDAwMDAgbiAKMDAwMDA2MDQ0NiAwMDAwMCBuIAowMDAwMDYxMzI1IDAwMDAwIG4gCjAwMDAwNjEzNDUgMDAwMDAgbiAKMDAwMDA2MTM5NyAwMDAwMCBuIAowMDAwMDYxNDQ5IDAwMDAwIG4gCjAwMDAwNjE1MDEgMDAwMDAgbiAKMDAwMDA2MTU1MyAwMDAwMCBuIAowMDAwMDYxNjA1IDAwMDAwIG4gCjAwMDAwNjE2NTcgMDAwMDAgbiAKMDAwMDA2MTcwOSAwMDAwMCBuIAowMDAwMDYxNzYxIDAwMDAwIG4gCjAwMDAwNjE5NDQgMDAwMDAgbiAKMDAwMDA2MjE1OSAwMDAwMCBuIAowMDAwMDYyMzQzIDAwMDAwIG4gCjAwMDAwNjI1MzYgMDAwMDAgbiAKMDAwMDA2MjcxOSAwMDAwMCBuIAowMDAwMDYyOTA4IDAwMDAwIG4gCjAwMDAwNjMwOTggMDAwMDAgbiAKMDAwMDA2MzI4NiAwMDAwMCBuIAowMDAwMDYzNDc4IDAwMDAwIG4gCjAwMDAwNjM2NjMgMDAwMDAgbiAKMDAwMDA2Mzg1OSAwMDAwMCBuIAowMDAwMDY0MDM4IDAwMDAwIG4gCjAwMDAwNjQyMTcgMDAwMDAgbiAKMDAwMDA2NDM4OSAwMDAwMCBuIAowMDAwMDY0NTYyIDAwMDAwIG4gCjAwMDAwNjQ3NDAgMDAwMDAgbiAKMDAwMDA2NDkxMSAwMDAwMCBuIAowMDAwMDY1MTM0IDAwMDAwIG4gCjAwMDAwNjUzNDQgMDAwMDAgbiAKMDAwMDA2NTU1NCAwMDAwMCBuIAowMDAwMDY1NzY0IDAwMDAwIG4gCjAwMDAwNjY3MzggMDAwMDAgbiAKMDAwMDA3MTE5NyAwMDAwMCBuIAowMDAwMDY2MDk3IDAwMDAwIG4gCjAwMDAwNjY1NTUgMDAwMDAgbiAKMDAwMDA3NzA3OCAwMDAwMCBuIAowMDAwMDcxMjE5IDAwMDAwIG4gCjAwMDAwNzE1MDEgMDAwMDAgbiAKMDAwMDA3MTc4MyAwMDAwMCBuIAowMDAwMDcxOTk5IDAwMDAwIG4gCjAwMDAwNzIwMTkgMDAwMDAgbiAKMDAwMDA3MjkzMSAwMDAwMCBuIAowMDAwMDcyOTUyIDAwMDAwIG4gCjAwMDAwNzMyMzQgMDAwMDAgbiAKMDAwMDA3MzUxNiAwMDAwMCBuIAowMDAwMDczNzk4IDAwMDAwIG4gCjAwMDAwNzQwODAgMDAwMDAgbiAKMDAwMDA3NDM2MiAwMDAwMCBuIAowMDAwMDc0NjQ0IDAwMDAwIG4gCjAwMDAwNz"
         } -result 1
 
-    test is_url-1.4 {is_url many formvars} -setup {
+    test is-url-1.4 {is url many formvars} -setup {
     } -body {
-        is_url https://www.domain.co.uk?formvar1=foo&formvar2=foo&formvar3=foo&formvar4=foo&formvar5=foo&formvar6=foo&formvar7=foo&formvar8=foo&formvar9=foo&formvar10=foo&formvar11=foo&formvar12=foo&formvar13=foo&formvar13=foo&formvar14=foo&formvar15=foo&formvar16=foo&formvar17=foo&formvar18=foo&formvar19=foo&formvar20=foo&formvar21=foo&formvar22=foo&formvar23=foo&formvar24=foo&formvar25=foo&formvar26=foo&formvar27=foo&formvar28=foo&formvar29=foo&formvar30=foo&formvar31=foo&formvar32=foo&formvar33=foo&formvar34=foo&formvar35=foo&formvar35=foo&formvar36=foo&formvar37=foo&formvar38=foo&formvar39=foo&formvar40=foo&formvar41=foo&formvar42=foo&formvar43=foo&formvar44=foo&formvar45=foo&formvar46=foo&formvar47=foo&formvar48=foo&formvar49=foo&formvar50=foo&formvar51=foo&formvar52=foo&formvar53=foo&formvar54=foo
+        is url https://www.domain.co.uk?formvar1=foo&formvar2=foo&formvar3=foo&formvar4=foo&formvar5=foo&formvar6=foo&formvar7=foo&formvar8=foo&formvar9=foo&formvar10=foo&formvar11=foo&formvar12=foo&formvar13=foo&formvar13=foo&formvar14=foo&formvar15=foo&formvar16=foo&formvar17=foo&formvar18=foo&formvar19=foo&formvar20=foo&formvar21=foo&formvar22=foo&formvar23=foo&formvar24=foo&formvar25=foo&formvar26=foo&formvar27=foo&formvar28=foo&formvar29=foo&formvar30=foo&formvar31=foo&formvar32=foo&formvar33=foo&formvar34=foo&formvar35=foo&formvar35=foo&formvar36=foo&formvar37=foo&formvar38=foo&formvar39=foo&formvar40=foo&formvar41=foo&formvar42=foo&formvar43=foo&formvar44=foo&formvar45=foo&formvar46=foo&formvar47=foo&formvar48=foo&formvar49=foo&formvar50=foo&formvar51=foo&formvar52=foo&formvar53=foo&formvar54=foo
     } -result 1
 
-    test is_url-1.5 {is_url ftp} -setup {
+    test is-url-1.5 {is url ftp} -setup {
     } -body {
-        is_url ftp://www.domain.com
+        is url ftp://www.domain.com
     } -result 0
 
-    test is_url-1.6 {is_url -relative} -body {
-        is_url -relative home.html
+    test is-url-1.6 {is url -relative} -body {
+        is url -relative home.html
     } -result 1
 
-    test is_url-1.7 {is_url -relative} -body {
-        is_url -relative /home.html
+    test is-url-1.7 {is url -relative} -body {
+        is url -relative /home.html
     } -result 1
 
-    test is_url-1.8 {is_url -relative} -body {
-        is_url -relative http://www.domain.com
+    test is-url-1.8 {is url -relative} -body {
+        is url -relative http://www.domain.com
     } -result 0
 
-    test is_url-1.9 {is_url -relative} -body {
-        is_url -relative page.html?foo=bar&test=baz
+    test is-url-1.9 {is url -relative} -body {
+        is url -relative page.html?foo=bar&test=baz
     } -result 1
 
 
-    test is_url-1.10 {is_url -relative} -body {
-        is_url -relative index.tcl#here
+    test is-url-1.10 {is url -relative} -body {
+        is url -relative index.tcl#here
     } -result 1
 
-    test is_url-1.11 {is_url -relative} -body {
-        is_url -relative /folder/page.html
+    test is-url-1.11 {is url -relative} -body {
+        is url -relative /folder/page.html
     } -result 1
 
-    test is_url-1.12 {is_url -relative} -body {
-        is_url -relative /folder/page.html?form=variable&and=another&and=#anchor
+    test is-url-1.12 {is url -relative} -body {
+        is url -relative /folder/page.html?form=variable&and=another&and=#anchor
     } -result 1
 
-    test is_url-1.13 {is_url -relative} -body {
-        is_url -relative index.html?foo=bar?test=broken
+    test is-url-1.13 {is url -relative} -body {
+        is url -relative index.html?foo=bar?test=broken
     } -result 0
 
-    test is_ipv4-1.0 {is_ipv4 ip6} -setup {
-    } -body {
-        is_ipv4 2001:0db8:85a3:0042:0000:8a2e:0370:7334
-    } -result false
-
-    test is_ipv4-1.1 {is_ipv4 partial} -setup {
-    } -body {
-        is_ipv4 192.168.1
-    } -result false
-
-    test is_ipv4-1.2 {is_ipv4 invalid but still true} -setup {
-    } -body {
-        is_ipv4 192.168.1.354
-    } -result true
-
-    test is_ipv4-1.3 {is_ipv4 valid} -setup {
-    } -body {
-        is_ipv4 192.168.1.1
-    } -result true
-
-    test is_cidrnetv4-1.0 {is_cidrnetv4 ip only} -setup {
-    } -body {
-        is_cidrnetv4  192.168.1.20
-    } -result false
-
-    test is_cidrnetv4-1.1 {is_cidrnetv4 valid cidr} -setup {
-    } -body {
-        is_cidrnetv4  192.168.1.0/24
-    } -result true
-
-    test is_uri-1.0 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid http://test.com
+    test is-url-1.14 {is url -relative} -body {
+        is url -relative a&b.html?foo=bar&fiz=baz
     } -result 1
 
-    test is_uri-1.1 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid https://test.com:8443
+    test is-url-1.15 {is url} -body {
+        is url https://www.domain.com/a&b.html?foo=bar&fiz=baz
     } -result 1
 
-    test is_uri-1.2 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid http://test.com/test.pdf
+    test is-url-path-1.0 {is url_path} -body {
+	is url_path /home
     } -result 1
 
-    test is_uri-1.3 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid https://test.com:8443/test.pdf
+    test is-url-path-1.1 {is url_path} -body {
+	is url_path /home%
+    } -result 0
+    
+    test is-url-path-1.2 {is url_path} -body {
+	is url_path /home/one
     } -result 1
 
-    test is_uri-1.4 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid http://test.com/test.pdf?a=1&b=2
-    } -result 1
-
-    test is_uri-1.5 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid https://test.com:8443/test.pdf?a=1&b=2
-    } -result 1
-
-    test is_uri-1.6 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid http://test.com/test.pdf#anchor1?a=1&b=2
-    } -result 1
-
-    test is_uri-1.7 {is_uri absolute} -setup {} -body {
-        qc::is_uri_valid https://test.com:8443/test.pdf#anchor1?a=1&b=2
-    } -result 1
-
-    test is_uri-1.8 {is_uri relative} -setup {} -body {
-        qc::is_uri_valid test.pdf
-    } -result 1
-
-    test is_uri-1.9 {is_uri relative} -setup {} -body {
-        qc::is_uri_valid test.pdf#anchor1?a=1&b=2
-    } -result 1
-
-    test is_uri-1.10 {is_uri root relative} -setup {} -body {
-        qc::is_uri_valid /test.pdf#anchor1?a=1&b=2
-    } -result 1
-
-    test is_uri-1.11 {is_uri page relative} -setup {} -body {
-        qc::is_uri_valid #anchor1?a=1&b=2
-    } -result 1
-
-    test is_uri-1.12 {is_uri page relative} -setup {} -body {
-        qc::is_uri_valid #anchor1
-    } -result 1
-
-    test is_uri-1.13 {is_uri relative} -setup {} -body {
-        qc::is_uri_valid  "./../../test.pdf#anchor1?a=1&b=2"
-    } -result 1
-
-    test is_uri-1.14 {is_uri scheme relative} -setup {} -body {
-        qc::is_uri_valid "//test.com/test/test.pdf#anchor1?a=1&b=2"
-    } -result 1
-
-    test is_uri-1.15 {is_uri ipv6} -setup {} -body {
-        qc::is_uri_valid {http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]}
-    } -result 1
-
-    test is_uri-1.16 {is_uri collapsed ipv6} -setup {} -body {
-        qc::is_uri_valid {http://[::2001:db8:0:1]:80}
-    } -result 1
-
-    test is_uri-1.17 {is_uri} -setup {} -body {
-        qc::is_uri_valid "urn:mpeg:mpeg7:schema:2001urn:isbn:0451450523"
-    } -result 1
-
-    test is_uri-1.18 {is_uri} -setup {} -body {
-        qc::is_uri_valid "sip:gateway.com;user=phone"
-    } -result 1
-
-    test is_uri-1.19 {is_uri} -setup {} -body {
-        qc::is_uri_valid "tel:+1-816-555-1212"
-    } -result 1
-
-    test is_uri-1.20 {is_uri} -setup {} -body {
-        qc::is_uri_valid "mailto:John.Doe@example.com"
-    } -result 1
-
-    test is_uri1.21 {is_uri invalid} -setup {} -body {
-        qc::is_uri_valid "htt$%://test.com"
+    test is-url-path-1.3 {is url_path} -body {
+	is url_path home
     } -result 0
 
-    test is_uri1.22 {is_uri invalid} -setup {} -body {
-        qc::is_uri_valid "http://test.co$%^&m"
+    test is-url-path-1.4 {is url_path} -body {
+	is url_path /home%23
+    } -result 1
+
+    test is-url-path-1.5 {is url_path} -body {
+	is url_path /home%af
+    } -result 1
+
+    test is-url-path-1.6 {is url_path} -body {
+	is url_path /home%yx
     } -result 0
 
-    test is_uri1.23 {is_uri invalid} -setup {} -body {
-        qc::is_uri_valid "http://test.com/$%^&m.pdf"
+    test is-url-path-1.7 {is url_path} -body {
+	is url_path /
+    } -result 1
+
+    test is-ipv4-1.0 {is ipv4 ip6} -setup {
+    } -body {
+        is ipv4 2001:0db8:85a3:0042:0000:8a2e:0370:7334
     } -result 0
 
-    test is_uri1.23 {is_uri invalid} -setup {} -body {
-        qc::is_uri_valid "///$%^&m.pdf"
+    test is-ipv4-1.1 {is ipv4 partial} -setup {
+    } -body {
+        is ipv4 192.168.1
     } -result 0
 
+    test is-ipv4-1.2 {is ipv4 invalid but still true} -setup {
+    } -body {
+        is ipv4 192.168.1.354
+    } -result 1
+
+    test is-ipv4-1.3 {is ipv4 valid} -setup {
+    } -body {
+        is ipv4 192.168.1.1
+    } -result 1
+
+    test is-cidrnetv4-1.0 {is cidrnetv4 ip only} -setup {
+    } -body {
+        is cidrnetv4  192.168.1.20
+    } -result 0
+
+    test is-cidrnetv4-1.1 {is cidrnetv4 valid cidr} -setup {
+    } -body {
+        is cidrnetv4  192.168.1.0/24
+    } -result 1
+    
+    test is-uri-1.0 {is uri absolute} -setup {} -body {
+        qc::is uri http://test.com
+    } -result 1
+
+    test is-uri-1.1 {is uri absolute} -setup {} -body {
+        qc::is uri https://test.com:8443
+    } -result 1
+
+    test is-uri-1.2 {is uri absolute} -setup {} -body {
+        qc::is uri http://test.com/test.pdf
+    } -result 1
+
+    test is-uri-1.3 {is uri absolute} -setup {} -body {
+        qc::is uri https://test.com:8443/test.pdf
+    } -result 1
+
+    test is-uri-1.4 {is uri absolute} -setup {} -body {
+        qc::is uri http://test.com/test.pdf?a=1&b=2
+    } -result 1
+
+    test is-uri-1.5 {is uri absolute} -setup {} -body {
+        qc::is uri https://test.com:8443/test.pdf?a=1&b=2
+    } -result 1
+
+    test is-uri-1.6 {is uri absolute} -setup {} -body {
+        qc::is uri http://test.com/test.pdf#anchor1?a=1&b=2
+    } -result 1
+
+    test is-uri-1.7 {is uri absolute} -setup {} -body {
+        qc::is uri https://test.com:8443/test.pdf#anchor1?a=1&b=2
+    } -result 1
+
+    test is-uri-1.8 {is uri relative} -setup {} -body {
+        qc::is uri test.pdf
+    } -result 1
+
+    test is-uri-1.9 {is uri relative} -setup {} -body {
+        qc::is uri test.pdf#anchor1?a=1&b=2
+    } -result 1
+
+    test is-uri-1.10 {is uri root relative} -setup {} -body {
+        qc::is uri /test.pdf#anchor1?a=1&b=2
+    } -result 1
+
+    test is-uri-1.11 {is uri page relative} -setup {} -body {
+        qc::is uri #anchor1?a=1&b=2
+    } -result 1
+
+    test is-uri-1.12 {is uri page relative} -setup {} -body {
+        qc::is uri #anchor1
+    } -result 1
+
+    test is-uri-1.13 {is uri relative} -setup {} -body {
+        qc::is uri  "./../../test.pdf#anchor1?a=1&b=2"
+    } -result 1
+
+    test is-uri-1.14 {is uri scheme relative} -setup {} -body {
+        qc::is uri "//test.com/test/test.pdf#anchor1?a=1&b=2"
+    } -result 1
+
+    test is-uri-1.15 {is uri ipv6} -setup {} -body {
+        qc::is uri {http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]}
+    } -result 1
+
+    test is-uri-1.16 {is uri collapsed ipv6} -setup {} -body {
+        qc::is uri {http://[::2001:db8:0:1]:80}
+    } -result 1
+
+    test is-uri-1.17 {is uri} -setup {} -body {
+        qc::is uri "urn:mpeg:mpeg7:schema:2001urn:isbn:0451450523"
+    } -result 1
+
+    test is-uri-1.18 {is uri} -setup {} -body {
+        qc::is uri "sip:gateway.com;user=phone"
+    } -result 1
+
+    test is-uri-1.19 {is uri} -setup {} -body {
+        qc::is uri "tel:+1-816-555-1212"
+    } -result 1
+
+    test is-uri-1.20 {is uri} -setup {} -body {
+        qc::is uri "mailto:John.Doe@example.com"
+    } -result 1
+
+    test is-uri1.21 {is uri invalid} -setup {} -body {
+        qc::is uri "htt$%://test.com"
+    } -result 0
+
+    test is-uri1.22 {is uri invalid} -setup {} -body {
+        qc::is uri "http://test.co$%^&m"
+    } -result 0
+
+    test is-uri1.23 {is uri invalid} -setup {} -body {
+        qc::is uri "http://test.com/$%^&m.pdf"
+    } -result 0
+
+    test is-uri1.23 {is uri invalid} -setup {} -body {
+        qc::is uri "///$%^&m.pdf"
+    } -result 0
+
+    test is-period-1.0 {qc::is period ""} -body {
+        qc::is period ""
+    } -result 0
+    
+    test is-period-1.1 {qc::is period "Jan"} -body {
+        qc::is period "Jan"
+    } -result 1
+    
+    test is-period-1.2 {qc::is period "January"} -body {
+        qc::is period "January"
+    } -result 1
+    
+    test is-period-1.3 {qc::is period "2014"} -body {
+        qc::is period "2014"
+    } -result 1
+    
+    test is-period-1.4 {qc::is period "Jan 2014"} -body {
+        qc::is period "Jan 2013"
+    } -result 1
+    
+    test is-period-1.5 {qc::is period "January 2014"} -body {
+        qc::is period "January 2014"
+    } -result 1
+    
+    test is-period-1.6 {qc::is period "Jan 2014 to March 2014"} -body {
+        qc::is period "Jan 2014 to March 2014"
+    } -result 1
+    
+    test is-period-1.7 {qc::is period "Febuary 2014"} -body {
+        qc::is period "Febuary 2014"
+    } -result 0
+    
+    test is-period-1.8 {qc::is period "1st February 2014 to 14th February 2014"} -body {
+        qc::is period "1st February 2014 to 14th February 2014"
+    } -result 1
+
+
+    test is-time-1.0 {qc::is time "00:00:00.000000"} -body {
+        qc::is time "00:00:00.000000"
+    } -result 1
+
+    test is-time-1.1 {qc::is time "00:00:00"} -body {
+        qc::is time "00:00:00"
+    } -result 1
+
+    test is-time-1.2 {qc::is time "24:00:00.000000"} -body {
+        qc::is time "24:00:00.000000"
+    } -result 1
+
+    test is-time-1.3 {qc::is time "24:00:00"} -body {
+        qc::is time "24:00:00"
+    } -result 1
+
+    test is-time-1.4 {qc::is time "12:34:56.789"} -body {
+        qc::is time "12:34:56.789"
+    } -result 1
+
+    test is-time-1.5 {qc::is time "12:34:56"} -body {
+        qc::is time "12:34:56"
+    } -result 1
+
+    test is-time-1.6 {qc::is time "24:00:01"} -body {
+        qc::is time "24:00:01"
+    } -result 0
+
+    test is-time-1.7 {qc::is time "98:76:54"} -body {
+        qc::is time "98:76:54"
+    } -result 0
+
+    test is-time-1.8 {qc::is time "12:59"} -body {
+        qc::is time "12:59"
+    } -result 0
+    
     cleanupTests
 }
 namespace delete ::qcode::test


### PR DESCRIPTION
Tested all existing qc::is_* and qc::cast_* procs still execute.
Run old tcl-tests against updated ```is``` & ```cast``` procs without error (except in the format of the return - eg. 1 vs true or 0 vs false)