### PR TITLE
session_purge bugfix

### DIFF
--- a/tcl/session.tcl
+++ b/tcl/session.tcl
@@ -128,7 +128,10 @@ proc qc::session_sudo {session_id effective_user_id} {
 proc qc::session_purge { {timeout_secs 0 } } {
     #| Purge all sessions older than time_out_secs
     log Notice "session purge older than $timeout_secs secs"
-    db_dml "delete from session where extract(seconds from current_timestamp-time_modified)>:timeout_secs"
+    db_dml {
+        delete from session
+        where extract(epoch from current_timestamp-time_modified) > :timeout_secs
+    }
 }
 
 proc qc::session_id {} {


### PR DESCRIPTION
Bugfix for ```session_purge```

```extract(seconds from <interval>)``` returns the seconds component of the interval, and not the entire interval converted into seconds.

