### PR TITLE
tabular_text_parse trim option - qcode-tcl-5

### DIFF
--- a/tcl/tabular_text.tcl
+++ b/tcl/tabular_text.tcl
@@ -15,7 +15,7 @@ proc qc::tabular_text_parse  {args} {
     #     % lappend conf [list label "Column 2" var_name "col2"]
     #
     #     % return [tabular_text_parse $text $conf]
-    #     {{col1 col2} {" a      " b}}
+    #     {col1 col2} {{ a      } b}
     qc::args $args -ignore_empty_rows -- text columns_conf
     
     # convert text to list of lines of required min width (determined by line for table header)

--- a/test/tabular_text.test
+++ b/test/tabular_text.test
@@ -127,6 +127,20 @@ namespace eval ::qcode::test {
         return [qc::tabular_text_parse $text $conf]
     } -cleanup {} -result {Unable to locate column heading "OrderCode"} -returnCodes error 
 
+    test tabular_text_parse-9.0 {tabular_text_parse - disable auto trim} -setup {
+    } -body {
+        set lines {}
+        lappend lines {Code         Qty   TOTAL}
+        lappend lines { 1           1     1.10}
+        set text [join $lines \n]
+
+        set conf {}
+        lappend conf [list label "Code" var_name "code" trim false]
+        lappend conf [list label "Qty" var_name "qty" trim true]
+        lappend conf [list label "TOTAL" var_name "total"]
+        return [qc::tabular_text_parse $text $conf]
+    } -cleanup {} -result {{code qty total} {{ 1  } 1 1.10}}
+    
     cleanupTests
 }
 namespace delete ::qcode::test


### PR DESCRIPTION
Adds `trim false` and `true` to columns conf.
E.G.
```tcl
lappend columns_conf [list label "Column A" var_name col_a trim false]
```