### PR TITLE
Image file commit proc and support webp

### DIFF
--- a/tcl/email.tcl
+++ b/tcl/email.tcl
@@ -1117,6 +1117,9 @@ proc qc::mime_type_guess { filename } {
         ".zip" {
             return "application/zip"
         }
+        "webp" {
+            return "image/webp"
+        }
         default {
             return $default_type
         }
@@ -1299,6 +1302,7 @@ proc qc::mime_file_extension { mime_type } {
         "image/x-xwindowdump" ".xwd"
         "application/x-compress" ".z"
         "application/zip" ".zip"
+        "image/webp" ".webp"
     }
     if { [dict exists $map $mime_type] } {
         return [dict get $map $mime_type]

--- a/tcl/image_file.tcl
+++ b/tcl/image_file.tcl
@@ -316,3 +316,27 @@ proc qc::image_redirect_handler {cache_dir}  {
     # Catch All - redirect to Canonical URL
     return [ns_returnredirect $canonical_url]      
 }
+
+proc qc::image_file_convert {old_file mime_type} {
+    #| Convert an image to a new format, return file path of new image
+    set ext [qc::mime_file_extension $mime_type]
+    set file "[file rootname $old_file]$ext"
+    set exec_proxy_flags {
+        -timeout 30000
+    }
+    set exec_flags {
+        -ignorestderr
+    }
+    set convert_flags [subst {
+        -quiet
+    }]
+    exec_proxy \
+        {*}$exec_proxy_flags \
+        {*}$exec_flags \
+        convert \
+        {*}$convert_flags \
+        $old_file \
+        $file
+
+    return $file
+}


### PR DESCRIPTION
Testing
----
- Ran a local make-install and restarted mla-erp
- Used mla cp to run qc::image_file_convert on an image, converting to mime-type "image/webp"