### PR TITLE
Improve qc::is date

### DIFF
--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -740,9 +740,9 @@ namespace eval qc::cast {
             lassign [period $period1] from_date .
             lassign [period $period2] . to_date
 
-        } elseif { [qc::is date $string] } {
+        } elseif { [regexp {^\d{4}-\d{2}-\d{2}$} $string] } {
             # String is an iso date eg "2014-01-01"
-            set from_date $string
+            set from_date [qc::cast date $string]
             set to_date $from_date
 
         } elseif { [regexp {^([12]\d{3})$} $string -> year] } {

--- a/tcl/date.tcl
+++ b/tcl/date.tcl
@@ -237,3 +237,13 @@ proc qc::time_hour { datetime } {
     return [qc::cast integer [clock format [cast epoch $datetime] -format "%H"]]
 }
 
+proc qc::date_year_is_leap {year} {
+    #| Check if a year is a leap year
+    if { $year % 4 == 0
+         && ( $year % 100 > 0
+              ||
+              $year % 400 == 0 ) } {
+        return true
+    }
+    return false
+}

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -416,13 +416,40 @@ namespace eval qc::is {
     proc date {string} {
         #| Checks if the given string is a date.
         #| Dates are expected to be in ISO format.
-        if { [regexp {^\d{4}-\d{2}-\d{2}$} $string]
-             && $string eq [qc::cast date $string]
-         } {
-            return true
-        } else {
+        if { ! [regexp {^(\d{4})-(\d{2})-(\d{2})$} $string -- yyyy mm dd] } {
             return false
         }
+        set yyyy [qc::cast int $yyyy]
+        set mm [qc::cast int $mm]
+        set dd [qc::cast int $dd]
+        if { $mm > 12 || $mm == 0 } {
+            return false
+        }
+        if { $dd == 0 } {
+            return false
+        }
+        if { $mm in {1 3 5 7 8 10 12} } {
+            if { $dd > 31 } {
+                return false
+            }
+            return true
+        }
+        if { $mm in {4 6 9 11} } {
+            if { $dd > 30 } {
+                return false
+            }
+            return true
+        }
+        if { [qc::date_year_is_leap $yyyy] } {
+            if { $dd > 29 } {
+                return false
+            }
+            return true
+        }
+        if { $dd > 28 } {
+            return false
+        }
+        return true
     }
 
     proc timestamp_http {date} {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -417,7 +417,7 @@ namespace eval qc::is {
         #| Checks if the given string is a date.
         #| Dates are expected to be in ISO format.
         if { [regexp {^\d{4}-\d{2}-\d{2}$} $string]
-             && $string eq [clock format [epoch $string] -format "%Y-%m-%d"]
+             && $string eq [qc::cast date $string]
          } {
             return true
         } else {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -416,7 +416,13 @@ namespace eval qc::is {
     proc date {string} {
         #| Checks if the given string is a date.
         #| Dates are expected to be in ISO format.
-        return [regexp {^\d{4}-\d{2}-\d{2}$} $string]
+        if { [regexp {^\d{4}-\d{2}-\d{2}$} $string]
+             && $string eq [clock format [epoch $string] -format "%Y-%m-%d"]
+         } {
+            return true
+        } else {
+            return false
+        }
     }
 
     proc timestamp_http {date} {

--- a/test/cast.test
+++ b/test/cast.test
@@ -51,6 +51,9 @@ namespace eval ::qcode::test {
     test cast-date-1.5 {cast date dd-mm-yyyy} {
         qc::cast date 12-04-2018
     } 2018-04-12
+    test cast-date-1.6 {cast date too many days} {
+        qc::cast date 2012-11-31
+    } 2012-12-01
 
     test cast-timestamp-1.0 {cast timestamp relative time} -body {
         qc::cast timestamp tomorrow

--- a/test/castable.test
+++ b/test/castable.test
@@ -253,6 +253,11 @@ namespace eval ::qcode::test {
         castable date Xmas
     } -result false
 
+    test castable-date-1.5 {castable date too many days} -setup {
+    } -body {
+        castable 2012-11-31
+    } -result true
+
     test castable-postcode-1.0 {castable postcode partial} -setup {
     } -body {
         castable postcode EH3

--- a/test/castable.test
+++ b/test/castable.test
@@ -255,7 +255,7 @@ namespace eval ::qcode::test {
 
     test castable-date-1.5 {castable date too many days} -setup {
     } -body {
-        castable 2012-11-31
+        castable date 2012-11-31
     } -result true
 
     test castable-postcode-1.0 {castable postcode partial} -setup {

--- a/test/date.test
+++ b/test/date.test
@@ -81,6 +81,19 @@ namespace eval ::qcode::test {
 
     test time_hour-1.0 {time_hour success} {qc::time_hour "2011-02-25 16:42:12"} 16
 
+    test date_year_is_leap-1.0 {date_year_is_leap 1999} {
+        qc::date_year_is_leap 1999
+    } false
+    test date_year_is_leap-1.1 {date_year_is_leap 1996} {
+        qc::date_year_is_leap 1996
+    } true
+    test date_year_is_leap-1.1 {date_year_is_leap 1900} {
+        qc::date_year_is_leap 1900
+    } false
+    test date_year_is_leap-1.1 {date_year_is_leap 2000} {
+        qc::date_year_is_leap 2000
+    } true
+
     cleanupTests
 
 }

--- a/test/is.test
+++ b/test/is.test
@@ -237,22 +237,22 @@ namespace eval ::qcode::test {
     test is-date-1.0 {is date 12/12/12} -setup {
     } -body {
         is date 12/12/12
-    } -result {0}
+    } -result {false}
 
     test is-date-1.1 {is date 12:38:00} -setup {
     } -body {
         is date 12:38:00
-    } -result {0}
+    } -result {false}
 
     test is-date-1.2 {is date 2012-08-23} -setup {
     } -body {
         is date 2012-08-23
-    } -result {1}
+    } -result {true}
 
     test is-date-1.3 {is date 2012-11-31} -setup {
     } -body {
         is date 2012-11-31
-    } -result {0}
+    } -result {false}
 
     test is-timestamp-1.0 {is timestamp 12/12/12} -setup {
     } -body {

--- a/test/is.test
+++ b/test/is.test
@@ -249,6 +249,11 @@ namespace eval ::qcode::test {
         is date 2012-08-23
     } -result {1}
 
+    test is-date-1.3 {is date 2012-11-31} -setup {
+    } -body {
+        is date 2012-11-31
+    } -result {0}
+
     test is-timestamp-1.0 {is timestamp 12/12/12} -setup {
     } -body {
         is timestamp 12/12/12


### PR DESCRIPTION
2019-11-31 is not a valid date, but we do cast it to 2019-12-01
Tcl accepts it as a date, postgresql does not.