### PR TITLE
s3_url is and cast procs & s3_tools updates

### DIFF
--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -281,7 +281,7 @@ proc qc::data_type_error_check {data_type value} {
 
 namespace eval qc::cast {
     
-    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown date postcode creditcard period epoch url url_relative url_path time interval
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown date postcode creditcard period epoch url url_relative url_path s3_url time interval
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -828,6 +828,30 @@ namespace eval qc::cast {
 	    return "/${lower}"
 	}
 	return -code error -errorcode CAST "Could not cast $string to an url path"
+    }
+
+    proc s3_url {string} {
+        #| Cast the given string to an s3 url
+        #| (See also qc::is s3_url)
+
+        # Split the string into bucket and object key
+        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
+        if { ![qc::is s3_bucket $bucket] } {
+            return -code error -errorcode CAST "Could not cast $string to an s3_url"
+        }
+        if { $object_key ne "" && ![qc::is s3_object_key $object_key] } {
+            return -code error -errorcode CAST "Could not cast $string to an s3_url"
+        }
+        
+        # Force the url to start "S3://"
+        set s3_url $string
+        if {[regexp {^[sS]3://(.*)$} $s3_url -> temp]} {
+            set s3_url $temp
+        } elseif {[regexp {^/(.*)$} $s3_url -> temp]} {
+            set s3_url $temp
+        }
+        
+        return "S3://${$bucket}/{$object_key}"
     }
 
     proc interval {string} {

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -835,7 +835,7 @@ namespace eval qc::cast {
         #| (See also qc::is s3_url)
 
         # Split the string into bucket and object key
-        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
+        lassign [qc::s3_url_bucket_object_key $string] bucket object_key
         if { ![qc::is s3_bucket $bucket] } {
             return -code error -errorcode CAST "Could not cast $string to an s3_url"
         }
@@ -851,7 +851,7 @@ namespace eval qc::cast {
             set s3_url $temp
         }
         
-        return "s3://${$bucket}/{$object_key}"
+        return "s3://${bucket}/${object_key}"
     }
 
     proc interval {string} {

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -837,10 +837,10 @@ namespace eval qc::cast {
         # Split the string into bucket and object key
         lassign [qc::s3_url_bucket_object_key $string] bucket object_key
         if { ![qc::is s3_bucket $bucket] } {
-            return -code error -errorcode CAST "Could not cast $string to an s3_url"
+            return -code error -errorcode CAST "Could not cast \"$string\" to an s3_url"
         }
         if { $object_key ne "" && ![qc::is s3_object_key $object_key] } {
-            return -code error -errorcode CAST "Could not cast $string to an s3_url"
+            return -code error -errorcode CAST "Could not cast \"$string\" to an s3_url"
         }
         
         # Force the url to start "S3://"

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -831,8 +831,8 @@ namespace eval qc::cast {
     }
 
     proc s3_uri {string} {
-        #| Cast the given string to an s3 url
-        #| (See also qc::is s3_url)
+        #| Cast the given string to an s3 uri
+        #| (See also qc::is s3_uri)
 
         # Split the string into bucket and object key
         lassign [qc::s3 uri_bucket_object_key $string] bucket object_key

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -851,7 +851,7 @@ namespace eval qc::cast {
             set s3_url $temp
         }
         
-        return "S3://${$bucket}/{$object_key}"
+        return "s3://${$bucket}/{$object_key}"
     }
 
     proc interval {string} {

--- a/tcl/cast.tcl
+++ b/tcl/cast.tcl
@@ -281,7 +281,7 @@ proc qc::data_type_error_check {data_type value} {
 
 namespace eval qc::cast {
     
-    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown date postcode creditcard period epoch url url_relative url_path s3_url time interval
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar text enumeration domain safe_html safe_markdown date postcode creditcard period epoch url url_relative url_path s3_uri time interval
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -830,25 +830,17 @@ namespace eval qc::cast {
 	return -code error -errorcode CAST "Could not cast $string to an url path"
     }
 
-    proc s3_url {string} {
+    proc s3_uri {string} {
         #| Cast the given string to an s3 url
         #| (See also qc::is s3_url)
 
         # Split the string into bucket and object key
-        lassign [qc::s3_url_bucket_object_key $string] bucket object_key
+        lassign [qc::s3 uri_bucket_object_key $string] bucket object_key
         if { ![qc::is s3_bucket $bucket] } {
-            return -code error -errorcode CAST "Could not cast \"$string\" to an s3_url"
+            return -code error -errorcode CAST "Could not cast \"$string\" to an s3_uri"
         }
         if { $object_key ne "" && ![qc::is s3_object_key $object_key] } {
-            return -code error -errorcode CAST "Could not cast \"$string\" to an s3_url"
-        }
-        
-        # Force the url to start "S3://"
-        set s3_url $string
-        if {[regexp {^[sS]3://(.*)$} $s3_url -> temp]} {
-            set s3_url $temp
-        } elseif {[regexp {^/(.*)$} $s3_url -> temp]} {
-            set s3_url $temp
+            return -code error -errorcode CAST "Could not cast \"$string\" to an s3_uri"
         }
         
         return "s3://${bucket}/${object_key}"

--- a/tcl/castable.tcl
+++ b/tcl/castable.tcl
@@ -1,6 +1,6 @@
 namespace eval qc::castable {
     
-    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date postcode creditcard period url relative_url url_path s3_url time interval
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date postcode creditcard period url relative_url url_path s3_uri time interval
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -218,11 +218,11 @@ namespace eval qc::castable {
 	}
     }
 
-    proc s3_url {string} {
-        #| Test if the given string can be cast to an s3 url
-        #| (See also qc::is s3_url)
+    proc s3_uri {string} {
+        #| Test if the given string can be cast to an s3 uri
+        #| (See also qc::is s3_uri)
         try {
-	    qc::cast s3_url $string
+	    qc::cast s3_uri $string
 	    return true
 	} on error [list error_message options] {
 	    return false

--- a/tcl/castable.tcl
+++ b/tcl/castable.tcl
@@ -1,6 +1,6 @@
 namespace eval qc::castable {
     
-    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date postcode creditcard period url relative_url url_path time interval
+    namespace export integer bigint smallint decimal boolean timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date postcode creditcard period url relative_url url_path s3_url time interval
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -218,6 +218,17 @@ namespace eval qc::castable {
 	}
     }
 
+    proc s3_url {string} {
+        #| Test if the given string can be cast to an s3 url
+        #| (See also qc::is s3_url)
+        try {
+	    qc::cast s3_url $string
+	    return true
+	} on error [list error_message options] {
+	    return false
+	}
+    }
+    
     proc interval {string} {
         #| Test if the given string can be cast to an interval
 	try {

--- a/tcl/http.tcl
+++ b/tcl/http.tcl
@@ -179,7 +179,7 @@ proc qc::http_post {args} {
 		switch $responsecode {
 		    404 {return -code error -errorcode CURL "URL NOT FOUND $url"}
 		    500 {return -code error -errorcode CURL "SERVER ERROR $url $html"}
-		    default {return -code error -errorcode CURL "RESPONSE $responsecode while contacting $url $html"}
+		    default {return -code error -errorcode CURL "RESPONSE $responsecode while contacting $url"}
 		}
 	    }
 	}

--- a/tcl/http.tcl
+++ b/tcl/http.tcl
@@ -240,7 +240,7 @@ proc qc::http_get {args} {
                 switch $responsecode {                    
                     404 {return -code error -errorcode CURL "URL NOT FOUND $url"}
                     500 {return -code error -errorcode CURL "SERVER ERROR $url"}
-                    default {return -code error -errorcode CURL "RESPONSE $responsecode while contacting $url"}
+                    default {return -code error -errorcode CURL "RESPONSE $responsecode while contacting $url $html"}
                 }
             }
 	}

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -229,7 +229,7 @@ proc qc::is_uri_valid {uri} {
 
 namespace eval qc::is {
     
-    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path time interval
+    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path s3_url s3_bucket time interval
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -881,6 +881,77 @@ namespace eval qc::is {
         } else {
             return 0
         }
+    }
+
+    proc s3_bucket {s3_bucket} {
+        #| Checks if the given string is a valid s3 bucket
+        #| Rules from https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+        
+        # Bucket names must be between 3 and 63 characters long
+        if { [string length $s3_bucket] < 3 ||
+             [string length $s3_bucket] > 63 } {
+            return 0
+        }
+
+        # Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)
+        if { [regexp {[^a-z0-9.-]} $s3_bucket] } {
+            return 0
+        }
+
+        # Bucket names must begin and end with a letter or number.
+        if { [regexp {[^a-z0-9]} [string index $s3_bucket 0]] ||
+             [regexp {[^a-z0-9]} [string index $s3_bucket end]] } {
+            return 0
+        }
+
+        # Bucket names must not be formatted as an IP address (for example, 192.168.5.4).
+        if { [qc::is ip $s3_bucket] } {
+            return 0
+        }
+
+        return 1
+    }
+
+    proc s3_object_key {s3_object_key} {
+        #| Checks if the given string is a valid s3 object key
+        #| Limits characters to those defined as safe:
+        #| https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys
+
+        # Restrict to safe characters 
+        if { [regexp {[^a-zA-Z0-9/!-_.*'()]} $s3_object_key] } {
+            return 0
+        }
+
+        # Object keys ending in "." can cause issues
+        if { [string index $s3_object end] eq "." } {
+            return 0
+        }
+
+        return 1
+    }
+    
+    proc s3_url {s3_url} {
+        #| Checks if the given string is a valid s3 URL
+        # Valid Examples:
+        # s3://bucket/location.png
+        # S3://test/location/foo/bar
+        # s3://bucket
+
+        # Check for protocol 
+        if { ![regexp {^[sS]3://} $s3_url]} {
+            return 0
+        }
+
+        # Check the bucket and key are valid
+        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
+        if { ![qc::is s3_bucket $bucket] } {
+            return 0
+        }
+        if { $object_key ne "" && ![qc::is s3_object_key $object_key] } {
+            return 0
+        }
+        
+        return 1
     }
 
     proc interval {text} {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -229,7 +229,7 @@ proc qc::is_uri_valid {uri} {
 
 namespace eval qc::is {
     
-    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path s3_url s3_bucket time interval
+    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path s3_url s3_bucket s3_object_key time interval
     namespace ensemble create -unknown {
         data_type_parser
     }

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -916,11 +916,6 @@ namespace eval qc::is {
         #| Checks if the given string is a valid s3 object key
         #| Limits characters to those defined as safe:
         #| https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys
-
-        # Starts with "/"
-        if { [string index $s3_object_key 0] ne "/" } {
-            return 0
-        }
         
         # Restrict to safe characters (excluding the starting "/")
         if { [regexp {[^-a-zA-Z0-9/!_.*'()]} [string range $s3_object_key 1 end]] } {

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -917,13 +917,18 @@ namespace eval qc::is {
         #| Limits characters to those defined as safe:
         #| https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys
 
-        # Restrict to safe characters 
-        if { [regexp {[^a-zA-Z0-9/!-_.*'()]} $s3_object_key] } {
+        # Starts with "/"
+        if { [string index $s3_object_key 0] ne "/" } {
+            return 0
+        }
+        
+        # Restrict to safe characters (excluding the starting "/")
+        if { [regexp {[^-a-zA-Z0-9/!_.*'()]} [string range $s3_object_key 1 end]] } {
             return 0
         }
 
         # Object keys ending in "." can cause issues
-        if { [string index $s3_object end] eq "." } {
+        if { [string index $s3_object_key end] eq "." } {
             return 0
         }
 

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -918,7 +918,7 @@ namespace eval qc::is {
         #| https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys
         
         # Restrict to safe characters (excluding the starting "/")
-        if { [regexp {[^-a-zA-Z0-9/!_.*'()]} [string range $s3_object_key 1 end]] } {
+        if { [regexp {[^-a-zA-Z0-9/!_.*'()]} $s3_object_key] } {
             return 0
         }
 

--- a/tcl/is.tcl
+++ b/tcl/is.tcl
@@ -229,7 +229,7 @@ proc qc::is_uri_valid {uri} {
 
 namespace eval qc::is {
     
-    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path s3_url s3_bucket s3_object_key time interval
+    namespace export integer smallint bigint boolean decimal timestamp timestamptz char varchar enumeration text domain safe_html safe_markdown date timestamp_http email postcode creditcard creditcard_masked period base64 hex mobile_number ipv4 cidrnetv4 url uri url_path s3_uri s3_bucket s3_object_key time interval
     namespace ensemble create -unknown {
         data_type_parser
     }
@@ -930,20 +930,20 @@ namespace eval qc::is {
         return 1
     }
     
-    proc s3_url {s3_url} {
-        #| Checks if the given string is a valid s3 URL
+    proc s3_uri {s3_uri} {
+        #| Checks if the given string is a valid s3 URI
         # Valid Examples:
         # s3://bucket/location.png
         # S3://test/location/foo/bar
         # s3://bucket
 
         # Check for protocol 
-        if { ![regexp {^[sS]3://} $s3_url]} {
+        if { ![regexp {^[sS]3://} $s3_uri]} {
             return 0
         }
 
         # Check the bucket and key are valid
-        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
+        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
         if { ![qc::is s3_bucket $bucket] } {
             return 0
         }

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -30,18 +30,19 @@ proc qc::_s3_endpoint { args } {
     #| Usage:
     #| qc::_s3_endpoint bucket object_key
     #| qc::_s3_endpoint s3_uri
+    #| qc::_s3_endpoint bucket
     
     if { [llength $args] == 1 } {
         if { [qc::is s3_uri [lindex $args 0]] } {
             lassign [qc::s3 uri_bucket_object_key [lindex $args 0]] bucket object_key
-            if { $object_key eq "" } {
-                unset object_key
-            }
+            set append_key true
         } else {
             set bucket [lindex $args 0]
+            set append_key false
         }
     } elseif { [llength $args] == 2 } {
         lassign $args bucket object_key
+        set append_key true
     } else {
         error "Invalid number of arguments: Usage: \"qc::_s3_endpoint bucket object_key\" or \"qc::_s3_endpoint s3_uri\"."
     } 
@@ -50,7 +51,7 @@ proc qc::_s3_endpoint { args } {
     if { $bucket ne "" } {
         set endpoint [join [list $bucket $endpoint] .]
     }
-    if { [info exists object_key] } {
+    if { $append_key } {
         append endpoint / $object_key
     }
     return $endpoint

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -74,7 +74,7 @@ proc qc::_s3_auth_headers { args } {
     if { $bucket ne "" } {
         # Is there a subresource specified?
         set subresources [list "acl" "lifecycle" "location" "logging" "notification" "partNumber" "policy" "requestPayment" "torrent" "uploadId" "uploads" "versionId" "versioning" "versions" "website" "restore"]
-        if { [regexp {^[^\?]+\?([A-Za-z]+).*$} $object_key -> resource] && [qc::in $subresources $resource] } {
+        if { [regexp {^[^\?]*\?([A-Za-z]+).*$} $object_key -> resource] && [qc::in $subresources $resource] } {
             set canonicalized_resource "/${bucket}/${object_key}"
         } else {
             # otherwise, drop the query part

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -614,7 +614,7 @@ proc qc::s3_url_bucket_object_key {s3_url} {
         set object_key ""
     } else {
         set bucket [string range $s3_url 0 $separator_index-1]
-        set object_key [string range $s3_url $separator_index+1 end]
+        set object_key [string range $s3_url $separator_index end]
     }
 
     return [list $bucket $object_key]

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -598,13 +598,15 @@ proc qc::s3 { args } {
     }
 }
 
-proc qc::s3_url_bucket_object_key {s3_url} {
+proc qc::s3_url_bucket_object_key_v1 {s3_url} {
     #| Return a list of the bucket and object key for the given s3_url
 
+    # Original solution
+    
     # Strip a leading "s3://" or "/"
     if {[regexp {^[sS]3://(.*)$} $s3_url -> temp]} {
         set s3_url $temp
-    }  elseif {[regexp {^/(.*)$} $s3_url -> temp]} {
+    } elseif {[regexp {^/(.*)$} $s3_url -> temp]} {
         set s3_url $temp
     }
 
@@ -616,6 +618,31 @@ proc qc::s3_url_bucket_object_key {s3_url} {
         set bucket [string range $s3_url 0 $separator_index-1]
         set object_key [string range $s3_url $separator_index end]
     }
+
+    return [list $bucket $object_key]
+}
+
+proc qc::s3_url_bucket_object_key_v2 {s3_url} {
+    #| Return a list of the bucket and object key for the given s3_url
+
+    # Pure regexp solution
+    regexp {^(?:[sS]3://|/)?([^/]+)(/?.*)} $s3_url -> bucket object_key
+    return [list $bucket $object_key]
+}
+
+proc qc::s3_url_bucket_object_key_v3 {s3_url} {
+    #| Return a list of the bucket and object key for the given s3_url
+
+    # Regexp free solution
+    if { [string first "s3://" [lower $s3_url]] == 0 } {
+        set s3_url [string range $s3_url 5 end]
+    } elseif { [string first "/" $s3_url] == 0 } {
+        set s3_url [string range $s3_url 1 end]
+    }
+
+    set uri_split [split $s3_url "/"]
+    set bucket [qc::lshift uri_split]
+    set object_key [join $uri_split "/"]
 
     return [list $bucket $object_key]
 }

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -1,4 +1,3 @@
-
 package require sha1
 package require md5
 package require base64
@@ -8,6 +7,7 @@ namespace eval qc {
     namespace export s3 s3_* aws_*
 }
 
+# Public AWS procs
 proc qc::aws_credentials_set { access_key secret_key {token ""}} {
     #| Set globals containing AWS credentials
     set ::env(AWS_ACCESS_KEY_ID) $access_key
@@ -24,33 +24,60 @@ proc qc::aws_region_set { region } {
     return true
 }
 
-proc qc::s3_url { {bucket ""} } {
-    lappend bucket "s3.amazonaws.com"
-    return [join $bucket "."]
+# Private S3 procs
+proc qc::_s3_endpoint { args } {
+    #| Return an s3 endpoint
+    #| Usage:
+    #| qc::_s3_endpoint bucket object_key
+    #| qc::_s3_endpoint s3_uri
+    
+    if { [llength $args] == 1 } {
+        if { [qc::is s3_uri [lindex $args 0]] } {
+            lassign [qc::s3 uri_bucket_object_key [lindex $args 0]] bucket object_key
+            if { $object_key eq "" } {
+                unset object_key
+            }
+        } else {
+            set bucket [lindex $args 0]
+        }
+    } elseif { [llength $args] == 2 } {
+        lassign $args bucket object_key
+    } else {
+        error "Invalid number of arguments: Usage: \"qc::_s3_endpoint bucket object_key\" or \"qc::_s3_endpoint s3_uri\"."
+    } 
+
+    set endpoint "s3.amazonaws.com"
+    if { $bucket ne "" } {
+        set endpoint [join [list $bucket $endpoint] .]
+    }
+    if { [info exists object_key] } {
+        append endpoint / $object_key
+    }
+    return $endpoint
 }
 
-proc qc::s3_auth_headers { args } {
+proc qc::_s3_auth_headers { args } {
     #| Constructs the required s3 authentication header for the request type in question.
     #| See: http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
-    qc::args $args -amz_headers "" -content_type "" -content_md5 "" -- verb path bucket 
-    # eg s3_auth_headers -content_type image/jpeg -content_md5 xxxxxx PUT /pics/image.jpg mybucket
+    qc::args $args -amz_headers "" -content_type "" -content_md5 "" -- verb object_key bucket
+    # eg _s3_auth_headers -content_type image/jpeg -content_md5 xxxxxx PUT pics/image.jpg mybucket
 
     # check for security token
     if { [info exists ::env(AWS_SESSION_TOKEN)] && $::env(AWS_SESSION_TOKEN) ne "" } {
         # We're using temporary security credentials - add token header
         lappend amz_headers x-amz-security-token $::env(AWS_SESSION_TOKEN)
-    }    
+    }
 
     set date [qc::format_timestamp_http now]
-   
+    
     if { $bucket ne "" } {
         # Is there a subresource specified?
         set subresources [list "acl" "lifecycle" "location" "logging" "notification" "partNumber" "policy" "requestPayment" "torrent" "uploadId" "uploads" "versionId" "versioning" "versions" "website" "restore"]
-        if { [regexp {^[^\?]+\?([A-Za-z]+).*$} $path -> resource] && [qc::in $subresources $resource] } {
-            set canonicalized_resource "/${bucket}${path}"
+        if { [regexp {^[^\?]+\?([A-Za-z]+).*$} $object_key -> resource] && [qc::in $subresources $resource] } {
+            set canonicalized_resource "/${bucket}/${object_key}"
         } else {
             # otherwise, drop the query part
-            set canonicalized_resource "/$bucket[qc::url_path $path]"
+            set canonicalized_resource "/${bucket}/[qc::url_path $object_key]"
         }
     } else {
         set canonicalized_resource "/"
@@ -84,7 +111,7 @@ proc qc::s3_auth_headers { args } {
     set signature [::base64::encode [::sha1::hmac -bin ${::env(AWS_SECRET_ACCESS_KEY)} $string_to_sign]]
     set authorization "AWS ${::env(AWS_ACCESS_KEY_ID)}:$signature"
 
-    set return_headers [list Host [s3_url $bucket] Date $date Authorization $authorization]
+    set return_headers [list Host [qc::_s3_endpoint $bucket] Date $date Authorization $authorization]
 
     if { [dict exists $amz_headers "x-amz-security-token"] } {
         lappend return_headers "x-amz-security-token" [dict get $amz_headers "x-amz-security-token"]
@@ -93,74 +120,74 @@ proc qc::s3_auth_headers { args } {
     return $return_headers
 }
 
-proc qc::s3_get { bucket path } {
+proc qc::_s3_get { bucket object_key } {
     #| Construct the http GET request to S3 including auth headers
-    set headers [s3_auth_headers GET $path $bucket] 
-    set result [qc::http_get -headers $headers [s3_url $bucket]$path]
+    set headers [_s3_auth_headers GET $object_key $bucket] 
+    set result [qc::http_get -headers $headers [qc::_s3_endpoint $bucket $object_key]]
     return $result
 }
 
-proc qc::s3_head { bucket path } {
+proc qc::_s3_head { bucket object_key } {
     #| Construct the http HEAD request to S3 including auth headers
-    set headers [s3_auth_headers HEAD $path $bucket] 
-    set result [qc::http_head -headers $headers [s3_url $bucket]$path]
+    set headers [_s3_auth_headers HEAD $object_key $bucket] 
+    set result [qc::http_head -headers $headers [qc::_s3_endpoint $bucket $object_key]]
     return $result
 }
 
-proc qc::s3_post { args } {
-    qc::args $args -amz_headers "" -content_type {application/xml} -- bucket path {data ""}
+proc qc::_s3_post { args } {
+    qc::args $args -amz_headers "" -content_type {application/xml} -- bucket object_key {data ""}
     #| Construct the http POST request to S3 including auth headers
     if { $data ne "" } {
         # Used for posting XML
-        set content_md5 [qc::s3_base64_md5 -data $data]
-        set headers [s3_auth_headers -content_type $content_type -content_md5 $content_md5 POST $path $bucket] 
+        set content_md5 [qc::_s3_base64_md5 -data $data]
+        set headers [_s3_auth_headers -content_type $content_type -content_md5 $content_md5 POST $object_key $bucket] 
         lappend headers Content-MD5 $content_md5
         lappend headers Content-Type $content_type
-        set result [qc::http_post -valid_response_codes {100 200 202} -headers $headers -data $data [s3_url $bucket]$path]
+        set result [qc::http_post -valid_response_codes {100 200 202} -headers $headers -data $data [_s3_endpoint $bucket $object_key]]
     } else {
         if { $amz_headers ne "" } {
-            set headers [s3_auth_headers -amz_headers $amz_headers -content_type $content_type POST $path $bucket] 
+            set headers [_s3_auth_headers -amz_headers $amz_headers -content_type $content_type POST $object_key $bucket] 
             lappend headers {*}$amz_headers
             lappend headers Content-Type $content_type
-            set result [qc::http_post -headers $headers [s3_url $bucket]$path]
+            set result [qc::http_post -headers $headers [_s3_endpoint $bucket $object_key]]
         } else {
-            set headers [s3_auth_headers -content_type $content_type POST $path $bucket] 
+            set headers [_s3_auth_headers -content_type $content_type POST $object_key $bucket] 
             lappend headers Content-Type $content_type
-            set result [qc::http_post -headers $headers [s3_url $bucket]$path]
+            set result [qc::http_post -headers $headers [_s3_endpoint $bucket $object_key]]
         }
     }
     return $result
 }
 
-proc qc::s3_delete { bucket path } {
+proc qc::_s3_delete { bucket object_key } {
     #| Construct the http DELETE request to S3 including auth headers
-    set headers [s3_auth_headers DELETE $path $bucket] 
-    set result [qc::http_delete -headers $headers [s3_url $bucket]$path]
+    set headers [_s3_auth_headers DELETE $object_key $bucket] 
+    set result [qc::http_delete -headers $headers [_s3_endpoint $bucket $object_key]]
     return $result
 }
 
-proc qc::s3_save { args } {
+proc qc::_s3_save { args } {
     #| Construct the http SAVE request to S3 including auth headers
-    qc::args $args -timeout 60 -- bucket path filename
-    set headers [s3_auth_headers GET $path $bucket] 
-    return [qc::http_save -timeout  $timeout -headers $headers [s3_url $bucket]$path $filename]
+    qc::args $args -timeout 60 -- bucket object_key filename
+    set headers [_s3_auth_headers GET $object_key $bucket] 
+    return [qc::http_save -timeout  $timeout -headers $headers [_s3_endpoint $bucket $object_key] $filename]
 }
 
-proc qc::s3_put { args } {
+proc qc::_s3_put { args } {
     #| Construct the http PUT request to S3 including auth headers
-    # s3_put ?-header 0 ?-infile ? ?-s3_copy ?bucket path 
-    qc::args $args -nochecksum -header 0 -s3_copy ? -infile ? bucket path
+    # _s3_put ?-header 0 ?-infile ? ?-s3_copy ?bucket object_key
+    qc::args $args -nochecksum -header 0 -s3_copy ? -infile ? bucket object_key
     if { [info exists infile]} {
         set content_type [qc::mime_type_guess $infile]
-        set content_md5 [qc::s3_base64_md5 -file $infile]
+        set content_md5 [qc::_s3_base64_md5 -file $infile]
         set data_size [file size $infile]
         if { [info exists nochecksum] } {
             # Dont send metadata for upload parts
-            set headers [s3_auth_headers -content_type $content_type -content_md5 $content_md5 PUT $path $bucket] 
+            set headers [_s3_auth_headers -content_type $content_type -content_md5 $content_md5 PUT $object_key $bucket] 
         } else {
             # content_md5 header allows AWS to return an error if the file received has a different md5
             # Authentication value needs to use content_* values for hmac signing
-            set headers [s3_auth_headers -amz_headers [list "x-amz-meta-content-md5" $content_md5] -content_type $content_type -content_md5 $content_md5 PUT $path $bucket] 
+            set headers [_s3_auth_headers -amz_headers [list "x-amz-meta-content-md5" $content_md5] -content_type $content_type -content_md5 $content_md5 PUT $object_key $bucket] 
             lappend headers x-amz-meta-content-md5 $content_md5
         }
         lappend headers Content-Length $data_size
@@ -172,24 +199,25 @@ proc qc::s3_put { args } {
         # Have timeout values roughly in proportion to the filesize
         # In this case allowing 10 KB/s
         set timeout [expr {$data_size/10240}]
-        return [qc::http_put -header $header -headers $headers -timeout $timeout -infile $infile [s3_url $bucket]$path]
+        return [qc::http_put -header $header -headers $headers -timeout $timeout -infile $infile [_s3_endpoint $bucket $object_key]]
     } elseif { [info exists s3_copy] } {
+        # s3_copy must be in the format "bucket/object_key"
         # we're copying a S3 file - skip the data processing and send the PUT request with x-amz-copy-source header
-        set headers [s3_auth_headers -content_type {} -amz_headers [list "x-amz-copy-source" $s3_copy] PUT $path $bucket]
+        set headers [_s3_auth_headers -content_type {} -amz_headers [list "x-amz-copy-source" $s3_copy] PUT $object_key $bucket]
         lappend headers x-amz-copy-source $s3_copy
         lappend headers Content-Type {}
-        return [qc::http_put -header $header -headers $headers -data {} [s3_url $bucket]$path]
+        return [qc::http_put -header $header -headers $headers -data {} [_s3_endpoint $bucket $object_key]]
     } else {
-        error "qc::s3_put: 1 of -infile or -s3_copy must be specified"
+        error "qc::_s3_put: 1 of -infile or -s3_copy must be specified"
     }
 
 }
 
-proc qc::s3_base64_md5 { args } {
+proc qc::_s3_base64_md5 { args } {
     qc::args $args -file ? -data ? -- 
     #| Returns the base64 encoded binary md5 digest of a file or data
     if { [info exists file] && [info exists data] } {
-        error "qc::s3_base64_md5: specify only 1 of -file or -data"
+        error "qc::_s3_base64_md5: specify only 1 of -file or -data"
     }
     if { [info exists data] } {
         # Just use ::md5 since we don't process chunks of data large enough to cause problems
@@ -203,15 +231,17 @@ proc qc::s3_base64_md5 { args } {
             return [exec $openssl dgst -md5 -binary $file | $openssl enc -base64]
         }
     } else {
-        error "qc::s3_base64_md5: 1 of -file or -data must be specified"
+        error "qc::_s3_base64_md5: 1 of -file or -data must be specified"
     }
 }
 
+# Public S3 procs
 proc qc::s3 { args } {
     #| Access Amazon S3 buckets via REST API
     # Usage: s3 subcommand {args}
 
-    if { ![info exists ::env(AWS_ACCESS_KEY_ID)] || ![info exists ::env(AWS_SECRET_ACCESS_KEY)] } {
+    if { (![info exists ::env(AWS_ACCESS_KEY_ID)] || ![info exists ::env(AWS_SECRET_ACCESS_KEY)]) &&
+         [lindex $args 0] ni [list "md5" "uri" "uri_bucket_object_key"] } {
         error "No AWS credentials set."
     }
 
@@ -220,11 +250,11 @@ proc qc::s3 { args } {
             #| Just print the base64 md5 of a local file for reference
             # usage: s3 md5 filename
             lassign $args -> filename 
-            return [qc::s3_base64_md5 -file $filename]
+            return [qc::_s3_base64_md5 -file $filename]
         }
         ls {
             # usage: s3 ls 
-            set nodes [qc::s3_xml_select [qc::s3_get "" /] {/ns:ListAllMyBucketsResult/ns:Buckets/ns:Bucket}]
+            set nodes [qc::s3_xml_select [qc::_s3_get "" ""] {/ns:ListAllMyBucketsResult/ns:Buckets/ns:Bucket}]
             return [qc::lapply qc::s3_xml_node2dict $nodes]
         }
         lsbucket {
@@ -234,39 +264,42 @@ proc qc::s3 { args } {
                 error "Missing argument. Usage: qc::s3 lsbucket mybucket {prefix}"
             } elseif { [llength $args] == 3 }  {
                 # prefix is specified
-                set xmlDoc [qc::s3_get [lindex $args 1] "/?prefix=[lindex $args 2]"]
+                set xmlDoc [qc::_s3_get [lindex $args 1] "?prefix=[lindex $args 2]"]
             } else {
-                set xmlDoc [qc::s3_get [lindex $args 1] /]
+                set xmlDoc [qc::_s3_get [lindex $args 1] ""]
             }
 	    return [qc::lapply qc::s3_xml_node2dict [qc::s3_xml_select $xmlDoc {/ns:ListBucketResult/ns:Contents}]]
         }
         get {
             # usage:
             # qc::s3 get bucket remote_filename {local_filename}
-            # qc::s3 get s3_url local_filename
+            # qc::s3 get s3_uri local_filename
             if { [llength $args] < 3 || [llength $args] > 4 } {
-                error "Wrong number of arguments. Usage: qc::s3 get mybucket remote_filename {local_filename}"
+                error "Wrong number of arguments. Usage: \"qc::s3 get mybucket remote_filename ?local_filename?\" or \"qc::s3 get s3_uri local_filename\"."
             } elseif { [llength $args] == 3 } {
-                # Test if args are $bucket and $remote_filename or $s3_url and $local_filename
+                # Test if args are $bucket and $remote_filename or $s3_uil and $local_filename
                 lassign $args -> arg0 arg1
-                if { [qc::is s3_url $arg0] } {
-                    set s3_url $arg0
-                    lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                    set remote_filename "/${object_key}"
+                if { [qc::is s3_uri $arg0] } {
+                    set s3_uri $arg0
+                    lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     set local_filename $arg1
                 } else {
                     set bucket $arg0
-                    set remote_filename $arg1
+                    # Strip the starting "/" from the remote_filename
+                    set object_key [string range $arg1 1 end]
+                    set s3_uri [qc::s3 uri $bucket $object_key]
                     # No local filename, assume same as remote_filename
                     set local_filename "./[file tail $remote_filename]"
                 }
             } else {
                 lassign $args -> bucket remote_filename local_filename
+                set object_key [string range $remote_filename 1 end]
+                set s3_uri [qc::s3 uri $bucket $object_key]
             }
             if { [file exists $local_filename] } {
                 error "File $local_filename already exists."
             }
-            set head_dict [qc::s3 head $bucket $remote_filename]
+            set head_dict [qc::s3 head $s3_uri]
             if { [dict exists $head_dict x-amz-meta-content-md5] } {
                 set base64_md5 [dict get $head_dict x-amz-meta-content-md5]
             }
@@ -274,10 +307,10 @@ proc qc::s3 { args } {
             # set timeout - allow 1Mb/s
             set timeout_secs [expr {max( (${file_size}*8)/1000000 , 60)} ]
             log Debug "Timeout set at $timeout_secs seconds"
-            qc::s3_save -timeout $timeout_secs $bucket $remote_filename $local_filename
+            qc::_s3_save -timeout $timeout_secs $bucket $object_key $local_filename
             if { [info exists base64_md5] } {
                 # Check the base64 md5 of the downloaded file matches what we put in the x-amz-meta-content-md5 metadata on upload
-                if { [set local_md5 [qc::s3_base64_md5 -file $local_filename]] ne $base64_md5 } {
+                if { [set local_md5 [qc::_s3_base64_md5 -file $local_filename]] ne $base64_md5 } {
                     error "qc::s3 get: md5 of downloaded file $local_filename ($local_md5) does not match x-amz-meta-content-md5 ($base64_md5)."
                 }
             }
@@ -285,188 +318,189 @@ proc qc::s3 { args } {
         head {
             # usage:
             # qc::s3 head bucket remote_path
-            # qc::s3 head s3_url
+            # qc::s3 head s3_uri
 
             if { [llength $args] == 3 } {
                 lassign $args -> bucket remote_path
+                set object_key [string range $remote_path 1 end]
             } elseif { [llength $args] == 2 } {
-                set s3_url [qc::cast s3_url [lindex $args 1]]
-                lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                set remote_path "/${object_key}"
+                set s3_uri [qc::cast s3_uri [lindex $args 1]]
+                lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
             } else {
-                error "qc::s3 head: Wrong number of args. Usage \"qc::s3 head bucket remote_path\" or \"qc::s3 head s3_url\"."
+                error "qc::s3 head: Wrong number of args. Usage \"qc::s3 head bucket remote_path\" or \"qc::s3 head s3_uri\"."
             }
 
-           qc::s3_head $bucket $remote_path
+            qc::_s3_head $bucket $object_key
         }       
         copy {
             # usage:
-            # qc::s3 copy bucket remote_filename_to_copy_with_bucket remote_filename_copy
-            # E.G. qc::s3 copy "my-bucket" "my-bucket/file_to_copy" "file_copy"
-            # qc::s3 copy s3_url_to_copy s3_url_copy
+            # qc::s3 copy bucket remote_filename_to_copy remote_filename_copy
+            # E.G. qc::s3 copy "my-bucket" "file_to_copy" "file_copy"
+            # qc::s3 copy s3_uri_to_copy s3_uri_copy
 
             if {[llength $args] == 4} {
                 lassign $args -> bucket remote_filename remote_filename_copy
+                set file_to_copy "${bucket}${remote_filename}"
+                set object_key_copy [string range $remote_filename_copy 1 end]
             } elseif {[llength $args] == 3} {
-                lassign $args -> s3_url_to_copy s3_url_copy
-                lassign [qc::s3_url_bucket_object_key $s3_url_to_copy] bucket object_key
-                set remote_filename "${bucket}/${object_key}"
-                lassign [qc::s3_url_bucket_object_key $s3_url_copy] bucket_to object_key
-                set remote_filename_copy "/${object_key}"
+                lassign $args -> s3_uri_to_copy s3_uri_copy
+                lassign [qc::s3 uri_bucket_object_key $s3_uri_to_copy] bucket object_key
+                set file_to_copy "${bucket}/${object_key}"
+                lassign [qc::s3 uri_bucket_object_key $s3_uri_copy] bucket_to object_key_copy
                 if { $bucket ne $bucket_to } {
-                    error "qc::s3 copy: The s3_url to copy to must be in the same bucket as the s3_url to copy from."
+                    error "qc::s3 copy: The s3_uri to copy to must be in the same bucket as the s3_uri to copy from."
                 }
             } else {
-                error "qc::s3 copy: Wrong number of args. Usage \"qc::s3 copy bucket remote_filename_to_copy remote_filename_copy\" or \"qc::s3 copy s3_url_to_copy s3_url_copy\"."
+                error "qc::s3 copy: Wrong number of args. Usage \"qc::s3 copy bucket remote_filename_to_copy remote_filename_copy\" or \"qc::s3 copy s3_uri_to_copy s3_uri_copy\"."
             }
-            
-            qc::s3_put -s3_copy $remote_filename $bucket $remote_filename_copy
+
+            qc::_s3_put -s3_copy $file_to_copy $bucket $object_key_copy
         }
         put {
             # usage:
-            # qc::s3 put bucket local_path {remote_filename}
-            # qc::s3 put s3_url local_filename
+            # qc::s3 put bucket local_path ?remote_filename?
+            # qc::s3 put s3_uri local_filename
             # 5MB limit
             if { [llength $args] < 3 || [llength $args] > 4 } {
-                error "Wrong number of arguments. Usage: qc::s3 put mybucket local_filename {remote_filename}"
+                error "Wrong number of arguments. Usage: \"qc::s3 put mybucket local_filename ?remote_filename?\" or \"qc::s3 put s3_uri local_filename\"."
             } elseif { [llength $args] == 3 } {
-                # Test if args are $bucket and $remote_filename or $s3_url and $local_filename
+                # Test if args are $bucket and $remote_filename or $s3_uri and $local_filename
                 lassign $args -> arg0 arg1
-                if { [qc::is s3_url $arg0] } {
-                    set s3_url $arg0
-                    lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                    set remote_filename "/${object_key}"
+                if { [qc::is s3_uri $arg0] } {
+                    set s3_uri $arg0
+                    lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     set local_filename $arg1
                 } else {
                     set bucket $arg0
                     set local_filename $arg1
                     # No remote filename, assume same as local_filename
-                    set remote_filename "./[file tail $local_filename]"
+                    set object_key [file tail $local_filename]
                 }
             } else {
                 lassign $args -> bucket local_filename remote_filename
+                set object_key [string range $remote_filename 1 end]
             }
 
             if { [file size $local_filename] > [expr {1024*1024*5}]} { 
                 # Use multipart upload
-                qc::s3 upload $bucket $local_filename $remote_filename
+                qc::s3 upload $bucket $local_filename $object_key
             } else {
-                qc::s3_put -infile $local_filename $bucket $remote_filename
+                qc::_s3_put -infile $local_filename $bucket $object_key
             }
         }
         restore {
             # usage:
             # qc::s3 restore bucket remote_path days
-            # qc::s3 restore s3_url Days
+            # qc::s3 restore s3_uri Days
             # Requests restore of object from Glacier storage to S3 storage for $days days
             lassign $args -> bucket remote_path Days
             if { [llength $args] == 4  } {
                 lassign $args -> bucket remote_path Days
+                set object_key [string range $remote_path 1 end]
             } elseif { [llength $args] == 3 } {
-                lassign $args -> s3_url Days
-                lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                set remote_filename "/${object_key}"
+                lassign $args -> s3_uri Days
+                lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
             } else {
-                error "Invalid number of arguments. Usage: \"qc::s3 restore bucket remote_path days\" or \"qc::s3 restore s3_url days\"."
+                error "Invalid number of arguments. Usage: \"qc::s3 restore bucket remote_path days\" or \"qc::s3 restore s3_uri days\"."
             }
             set data "<RestoreRequest>[qc::xml_from Days]</RestoreRequest>"
-            qc::s3_post $bucket ${remote_path}?restore $data
+            qc::_s3_post $bucket "${object_key}?restore" $data
         }
         upload {
             switch [lindex $args 1] {
                 init {
                     # Usage:
                     # qc::s3 upload init bucket local_file remote_file {content_type}
-                    # qc::s3 upload init s3_url local_file {content_type}
+                    # qc::s3 upload init s3_uri local_file {content_type}
 
                     set content_type ""
                     if { [llength $args] == 6 } {
                         lassign $args -> -> bucket local_file remote_file content_type
+                        set object_key [string range $remote_file 1 end]
                     } elseif { [llength $args] == 5 } {
                         lassign $args -> -> arg0 local_file arg1
-                        if { [qc::is s3_url $arg0] } {
-                            set s3_url $arg0
-                            lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                            set remote_file "/${object_key}"
+                        if { [qc::is s3_uri $arg0] } {
+                            set s3_uri $arg0
+                            lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                             set content_type $arg1
                         } else {
                             set bucket $arg0
                             set remote_file $arg1
+                            set object_key [string range $remote_file 1 end]
                         }
                     } elseif { [llength $args] == 4 } {
-                        lassign $args -> -> s3_url local_file
-                        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                        set remote_file "/${object_key}"
+                        lassign $args -> -> s3_uri local_file
+                        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     } else {
-                        error "Invalid number of arguments. Usage: \"qc::s3 upload init bucket local_file remote_file {content_type}\" or \"qc::s3 upload init s3_url local_file {content_type}\"."
+                        error "Invalid number of arguments. Usage: \"qc::s3 upload init bucket local_file remote_file {content_type}\" or \"qc::s3 upload init s3_uri local_file {content_type}\"."
                     }
                     
-                    set content_md5 [qc::s3_base64_md5 -file $local_file]
+                    set content_md5 [qc::_s3_base64_md5 -file $local_file]
                     if {$content_type eq ""} {
                         set content_type [qc::mime_type_guess $local_file]
                     }
-                    set upload_dict [qc::s3_xml_node2dict [qc::s3_xml_select [qc::s3_post -content_type $content_type -amz_headers [list x-amz-meta-content-md5 $content_md5] $bucket ${remote_file}?uploads] {/ns:InitiateMultipartUploadResult}]]
+                    set upload_dict [qc::s3_xml_node2dict [qc::s3_xml_select [qc::_s3_post -content_type $content_type -amz_headers [list x-amz-meta-content-md5 $content_md5] $bucket "${object_key}?uploads"] {/ns:InitiateMultipartUploadResult}]]
                     set upload_id [dict get $upload_dict UploadId]
-                    log Debug "Upload init for $remote_file to $bucket."
+                    log Debug "Upload init for $object_key to $bucket."
                     log Debug "Upload_id: $upload_id"
                     return $upload_id
                 }
                 abort {
                     # Usage:
                     # qc::s3 upload abort bucket remote_path upload_id
-                    # qc::s3 upload abort s3_url upload_id
+                    # qc::s3 upload abort s3_uri upload_id
                     if {[llength $args] == 5 } {
                         lassign $args -> -> bucket remote_path upload_id
+                        set object_key [string range $remote_path 1 end]
                     } elseif {[llength $args] == 4 } {
-                        lassign $args -> -> s3_url upload_id
-                        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                        set remote_path "/${object_key}"
+                        lassign $args -> -> s3_uri upload_id
+                        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     } else {
-                        error "Invalid number of arguments. Usage: \"qc::s3 upload abort bucket remote_path upload_id\" or \"qc::s3 upload abort s3_url upload_id\"."
+                        error "Invalid number of arguments. Usage: \"qc::s3 upload abort bucket remote_path upload_id\" or \"qc::s3 upload abort s3_uri upload_id\"."
                     }
-                    return [s3_delete $bucket ${remote_path}?uploadId=$upload_id]
+                    return [_s3_delete $bucket "${object_key}?uploadId=$upload_id"]
                 }
                 ls {
                     # usage: s3 upload ls bucket 
                     lassign $args -> -> bucket
-                    return [qc::lapply qc::s3_xml_node2dict [qc::s3_xml_select [qc::s3_get $bucket /?uploads] {/ns:ListMultipartUploadsResult/ns:Upload}]]
+                    return [qc::lapply qc::s3_xml_node2dict [qc::s3_xml_select [qc::_s3_get $bucket "?uploads"] {/ns:ListMultipartUploadsResult/ns:Upload}]]
                 }
                 lsparts {
                     # usage:
                     # qc::s3 upload lsparts bucket remote_path upload_id
-                    # qc::s3 upload lsparts s3_url upload_id
+                    # qc::s3 upload lsparts s3_uri upload_id
                     if {[llength $args] == 5 } {
                         lassign $args -> -> bucket remote_path upload_id
+                        set object_key [string range $remote_path 1 end]
                     } elseif {[llength $args] == 4 } {
-                        lassign $args -> -> s3_url upload_id
-                        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                        set remote_path "/${object_key}"
+                        lassign $args -> -> s3_uri upload_id
+                        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     } else {
-                        error "Invalid number of arguments. Usage: \"qc::s3 upload lsparts bucket remote_path upload_id\" or \"qc::s3 upload lsparts s3_url upload_id\"."
+                        error "Invalid number of arguments. Usage: \"qc::s3 upload lsparts bucket remote_path upload_id\" or \"qc::s3 upload lsparts s3_uri upload_id\"."
                     }
                     
-                    return [qc::lapply qc::s3_xml_node2dict [qc::s3_xml_select [qc::s3_get $bucket ${remote_path}?uploadId=$upload_id] {/ns:ListPartsResult/ns:Part}]]
+                    return [qc::lapply qc::s3_xml_node2dict [qc::s3_xml_select [qc::_s3_get $bucket "${object_key}?uploadId=$upload_id"] {/ns:ListPartsResult/ns:Part}]]
                 }
                 cleanup {
                     # usage: s3 upload cleanup bucket 
                     # aborts any unfinished uploads for bucket
                     lassign $args -> -> bucket 
                     foreach dict [qc::s3 upload ls $bucket] {
-                        qc::s3 upload abort $bucket "/[dict get $dict Key]" [dict get $dict UploadId]
+                        qc::s3 upload abort $bucket "[dict get $dict Key]" [dict get $dict UploadId]
                     }
                 }
                 complete {
                     # usage:
                     # qc::s3 upload complete bucket remote_path upload_id etag_dict
-                    # qc::s3 upload complete s3_url upload_id etag_dict
+                    # qc::s3 upload complete s3_uri upload_id etag_dict
                     if {[llength $args] == 6} {
                         lassign $args -> -> bucket remote_path upload_id etag_dict
+                        set object_key [string range $remote_path 1 end]
                     } elseif {[llength $args] == 5} {
-                        lassign $args -> -> s3_url upload_id etag_dict
-                        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                        set remote_path "/${object_key}"
+                        lassign $args -> -> s3_uri upload_id etag_dict
+                        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     } else {
-                        error "Invalid number of arguments. Usage: \"qc::s3 upload complete bucket remote_path upload_id etag_dict\" or \"qc::s3 upload complete s3_url upload_id etag_dict\"."
+                        error "Invalid number of arguments. Usage: \"qc::s3 upload complete bucket remote_path upload_id etag_dict\" or \"qc::s3 upload complete s3_uri upload_id etag_dict\"."
                     }
                     set xml {<CompleteMultipartUpload>}
                     foreach PartNumber [dict keys $etag_dict] {
@@ -475,21 +509,21 @@ proc qc::s3 { args } {
                     }
                     lappend xml {</CompleteMultipartUpload>}
                     log Debug "Completing Upload to $remote_path in $bucket."
-                    return [qc::s3_post $bucket ${remote_path}?uploadId=$upload_id [join $xml \n]]
+                    return [qc::_s3_post $bucket "${object_key}?uploadId=$upload_id" [join $xml \n]]
                 }
                 send {
                     # Perform upload
                     # usage:
                     # qc::s3 upload send bucket local_path remote_path upload_id
-                    # qc::s3 upload send s3_url local_path upload_id
+                    # qc::s3 upload send s3_uri local_path upload_id
                     if {[llength $args] == 6} {
                         lassign $args -> -> bucket local_path remote_path upload_id
+                        set object_key [string range $remote_path 1 end]
                     } elseif {[llength $args] == 5} {
-                        lassign $args -> -> s3_url local_path upload_id
-                        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                        set remote_path "/${object_key}"
+                        lassign $args -> -> s3_uri local_path upload_id
+                        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     } else {
-                        error "Invalid number of arguments. Usage: \"qc::s3 upload send bucket local_path remote_path upload_id\" or \"qc::s3 upload send s3_url local_path upload_id\"."
+                        error "Invalid number of arguments. Usage: \"qc::s3 upload send bucket local_path remote_path upload_id\" or \"qc::s3 upload send s3_uri local_path upload_id\"."
                     }
                     
                     # bytes
@@ -522,7 +556,7 @@ proc qc::s3 { args } {
                         set attempt 1
                         while { !$s3_timeout($upload_id) && $attempt<=$max_attempt && !$success } {
                             try {
-                                set response [qc::s3_put -header 1 -nochecksum -infile $tempfile $bucket ${remote_path}?partNumber=${part_index}&uploadId=$upload_id]
+                                set response [qc::_s3_put -header 1 -nochecksum -infile $tempfile $bucket "${object_key}?partNumber=${part_index}&uploadId=$upload_id"]
                                 set success true
                             } {
                                 log Debug "Failed - retrying part $part_index of ${num_parts}... "
@@ -533,7 +567,7 @@ proc qc::s3 { args } {
                         if { $s3_timeout($upload_id) || $attempt>$max_attempt } {
                             #TODO should we abort or leave for potential recovery later?
                             ::try {
-                                qc::s3 upload abort $bucket $remote_path $upload_id
+                                qc::s3 upload abort $bucket $object_key $upload_id
                             } on error [list error_message options] {
                                 # error when attempting to abort upload; do nothing
                             }
@@ -551,7 +585,7 @@ proc qc::s3 { args } {
                             error $message
                         }
                         regexp -line -- {^ETag: "(\S+)"\s*$} $response match etag
-                      
+                        
                         dict set etag_dict $part_index $etag
                         file delete $tempfile
                         incr part_index
@@ -566,51 +600,71 @@ proc qc::s3 { args } {
                     # Top level multipart upload
                     # usage:
                     # qc::s3 upload bucket local_file remote_file {content_type}
-                    # qc::s3 upload s3_url local_file {content_type}
+                    # qc::s3 upload s3_uri local_file {content_type}
                     # TODO could be extended to retry upload part failures
                     set content_type ""
                     if {[llength $args] == 5} {
                         lassign $args -> bucket local_file remote_file content_type
+                        set object_key [string range $remote_file 1 end]
                     } elseif {[llength $args] == 4} {
                         lassign $args -> arg0 local_file arg1
-                        if { [qc::is s3_url $arg0] } {
-                            set s3_url $arg0
-                            lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                            set remote_file "/${object_key}"
+                        if { [qc::is s3_uri $arg0] } {
+                            set s3_uri $arg0
+                            lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                             set content_type $arg1
                         } else {
                             set bucket $arg0
-                            set remote_filename $arg1
+                            set remote_file $arg1
+                            set object_key [string range $remote_file 1 end]
                         }
                     } elseif {[llength $args] == 3} {
-                        lassign $args -> s3_url local_file
-                        lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                        set remote_file "/${object_key}"
+                        lassign $args -> s3_uri local_file
+                        lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
                     } else {
-                        error "Invalid number of arguments. Usage: \"qc::s3 upload bucket local_file remote_file {content_type}\" or \"qc::s3 upload s3_url local_file {content_type}\"."
+                        error "Invalid number of arguments. Usage: \"qc::s3 upload bucket local_file remote_file {content_type}\" or \"qc::s3 upload s3_uri local_file {content_type}\"."
                     }
                     
-                    set upload_id [qc::s3 upload init $bucket $local_file $remote_file $content_type]
-                    set etag_dict [qc::s3 upload send $bucket $local_file $remote_file $upload_id]
-                    qc::s3 upload complete $bucket $remote_file $upload_id $etag_dict
+                    set upload_id [qc::s3 upload init $bucket $local_file $object_key $content_type]
+                    set etag_dict [qc::s3 upload send $bucket $local_file $object_key $upload_id]
+                    qc::s3 upload complete $bucket $object_key $upload_id $etag_dict
                 }
             }
         }
         delete {
             # usage:
-            # qc::s3 delete bucket remote_filename
-            # qc::s3 delete s3_url
+            # qc::s3 delete bucket remote_file
+            # qc::s3 delete s3_uri
             if {[llength $args] == 3} {
-                lassign $args -> bucket remote_filename
+                lassign $args -> bucket remote_file
+                set object_key [string range $remote_file 1 end]
             } elseif {[llength $args] == 2} {
-                lassign $args -> s3_url
-                lassign [qc::s3_url_bucket_object_key $s3_url] bucket object_key
-                set remote_filename "/${object_key}"
+                lassign $args -> s3_uri
+                lassign [qc::s3 uri_bucket_object_key $s3_uri] bucket object_key
             } else {
-                error "Invalid number of arguments. Usage: \"qc::s3 delete bucket remote_filename\" or \"qc::s3 delete s3_url\"."
+                error "Invalid number of arguments. Usage: \"qc::s3 delete bucket remote_filename\" or \"qc::s3 delete s3_uri\"."
             }
             
-            qc::s3_delete $bucket $remote_filename
+            qc::_s3_delete $bucket $object_key
+        }
+        uri {
+            #| Return an s3_uri in the format s3://bucket/object_key
+            # Usage:
+            # qc::s3 uri bucket ?object_key?
+            if {[llength $args] < 2 || [llength $args] > 3} {
+                error "Invalid number of arguments. Usage: \"qc::s3 uri bucket ?object_key?\"."
+            }
+            lassign $args -> bucket object_key
+            return [qc::cast s3_uri "${bucket}/${object_key}"]
+        }
+        uri_bucket_object_key {
+            #| Return a list of the bucket and object key for the given s3_uri
+            #| Usage:
+            #| qc::s3 uri_bucket_object_key s3_uri
+            if {[llength $args] != 2} {
+                error "Invalid number of arguments. Usage: \"qc::s3 uri_bucket_object_key s3_uri\"."
+            }
+            regexp {^(?:[sS]3://|/)?([^/]+)/?(.*)} [lindex $args 1] -> bucket object_key
+            return [list $bucket $object_key]
         }
         default {
             error "Unknown s3 command."
@@ -618,53 +672,7 @@ proc qc::s3 { args } {
     }
 }
 
-proc qc::s3_url_bucket_object_key_v2 {s3_url} {
-    #| Return a list of the bucket and object key for the given s3_url
-
-    # Original solution
-    
-    # Strip a leading "s3://" or "/"
-    if {[regexp {^[sS]3://(.*)$} $s3_url -> temp]} {
-        set s3_url $temp
-    } elseif {[regexp {^/(.*)$} $s3_url -> temp]} {
-        set s3_url $temp
-    }
-
-    set separator_index [string first / $s3_url]
-    if { $separator_index == -1 } {
-        set bucket $s3_url
-        set object_key ""
-    } else {
-        set bucket [string range $s3_url 0 $separator_index-1]
-        set object_key [string range $s3_url $separator_index+1 end]
-    }
-
-    return [list $bucket $object_key]
-}
-
-proc qc::s3_url_bucket_object_key { s3_url } {
-    #| Return a list of the bucket and object key for the given s3_url
-    regexp {^(?:[sS]3://|/)?([^/]+)/?(.*)} $s3_url -> bucket object_key
-    return [list $bucket $object_key]
-}
-
-proc qc::s3_url_bucket_object_key_v3 {s3_url} {
-    #| Return a list of the bucket and object key for the given s3_url
-
-    # Regexp free solution
-    if { [string first "s3://" [lower $s3_url]] == 0 } {
-        set s3_url [string range $s3_url 5 end]
-    } elseif { [string first "/" $s3_url] == 0 } {
-        set s3_url [string range $s3_url 1 end]
-    }
-
-    set uri_split [split $s3_url "/"]
-    set bucket [qc::lshift uri_split]
-    set object_key [join $uri_split "/"]
-
-    return [list $bucket $object_key]
-}
-
+# Public S3 XML procs
 proc qc::s3_xml_select { xmlDoc xpath} {
     #| Returns xml nodes specified by the supplied xpath.
     # any namespace specified in the xmlns attribute is mapped to "ns" for use in the xpath query.
@@ -683,8 +691,8 @@ proc qc::s3_xml_node2dict { node } {
     set nodes [$node childNodes]
     foreach node $nodes {
         if { [llength [$node childNodes]] > 1 \
-           || ([llength [$node childNodes]] == 1 \
-              && [ne [[$node firstChild] nodeType] TEXT_NODE] ) } {
+                 || ([llength [$node childNodes]] == 1 \
+                         && [ne [[$node firstChild] nodeType] TEXT_NODE] ) } {
             lappend dict [$node nodeName] [qc::s3_xml_node2dict $node]
         }  elseif { [llength [$node childNodes]] == 0 } {
             # empty node

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -487,7 +487,7 @@ proc qc::s3 { args } {
                     # aborts any unfinished uploads for bucket
                     lassign $args -> -> bucket 
                     foreach dict [qc::s3 upload ls $bucket] {
-                        qc::s3 upload abort $bucket "[dict get $dict Key]" [dict get $dict UploadId]
+                        qc::s3 upload abort $bucket "/[dict get $dict Key]" [dict get $dict UploadId]
                     }
                 }
                 complete {

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -598,7 +598,7 @@ proc qc::s3 { args } {
     }
 }
 
-proc qc::s3_url_bucket_object_key_v1 {s3_url} {
+proc qc::s3_url_bucket_object_key {s3_url} {
     #| Return a list of the bucket and object key for the given s3_url
 
     # Original solution

--- a/tcl/s3_tools.tcl
+++ b/tcl/s3_tools.tcl
@@ -246,14 +246,14 @@ proc qc::s3 { args } {
                 error "Wrong number of arguments. Usage: qc::s3 get mybucket remote_filename {local_filename}"
             } elseif { [llength $args] == 3 } {
                 # Test if args are $bucket and $remote_filename or $s3_url and $local_filename
-                lassign $args -> temp0 temp1
-                if { [qc::is s3_url $temp0] } {
-                    set s3_url $temp0
+                lassign $args -> arg0 arg1
+                if { [qc::is s3_url $arg0] } {
+                    set s3_url $arg0
                     lassign [qc::s3_url_bucket_object_key $s3_url] bucket remote_filename
-                    set local_filename $temp1
+                    set local_filename $arg1
                 } else {
-                    set bucket $temp0
-                    set remote_filename $temp1
+                    set bucket $arg0
+                    set remote_filename $arg1
                     # No local filename, assume same as remote_filename
                     set local_filename "./[file tail $remote_filename]"
                 }
@@ -322,14 +322,14 @@ proc qc::s3 { args } {
                 error "Wrong number of arguments. Usage: qc::s3 put mybucket local_filename {remote_filename}"
             } elseif { [llength $args] == 3 } {
                 # Test if args are $bucket and $remote_filename or $s3_url and $local_filename
-                lassign $args -> temp0 temp1
-                if { [qc::castable s3_url $temp0] } {
-                    set s3_url [qc::cast s3_url $temp0]
+                lassign $args -> arg0 arg1
+                if { [qc::castable s3_url $arg0] } {
+                    set s3_url [qc::cast s3_url $arg0]
                     lassign [qc::s3_url_bucket_object_key $s3_url] bucket remote_filename
-                    set local_filename $temp1
+                    set local_filename $arg1
                 } else {
-                    set bucket $temp0
-                    set local_filename $temp1
+                    set bucket $arg0
+                    set local_filename $arg1
                     # No remote filename, assume same as local_filename
                     set remote_filename "./[file tail $local_filename]"
                 }
@@ -372,14 +372,14 @@ proc qc::s3 { args } {
                     if { [llength $args] == 6 } {
                         lassign $args -> -> bucket local_file remote_file content_type
                     } elseif { [llength $args] == 5 } {
-                        lassign $args -> -> temp0 local_file temp1
-                        if { [qc::is s3_url $temp0] } {
-                            set s3_url $temp0
+                        lassign $args -> -> arg0 local_file arg1
+                        if { [qc::is s3_url $arg0] } {
+                            set s3_url $arg0
                             lassign [qc::s3_url_bucket_object_key $s3_url] bucket remote_file
-                            set content_type $temp1
+                            set content_type $arg1
                         } else {
-                            set bucket $temp0
-                            set remote_file $temp1
+                            set bucket $arg0
+                            set remote_file $arg1
                         }
                     } elseif { [llength $args] == 4 } {
                         lassign $args -> -> s3_url local_file
@@ -555,14 +555,14 @@ proc qc::s3 { args } {
                     if {[llength $args] == 5} {
                         lassign $args -> bucket local_file remote_file content_type
                     } elseif {[llength $args] == 4} {
-                        lassign $args -> temp0 local_file temp1
-                        if { [qc::is s3_url $temp0] } {
-                            set s3_url $temp0
+                        lassign $args -> arg0 local_file arg1
+                        if { [qc::is s3_url $arg0] } {
+                            set s3_url $arg0
                             lassign [qc::s3_url_bucket_object_key $s3_url] bucket remote_file
-                            set content_type $temp1
+                            set content_type $arg1
                         } else {
-                            set bucket $temp0
-                            set remote_filename $temp1
+                            set bucket $arg0
+                            set remote_filename $arg1
                         }
                     } elseif {[llength $args] == 3} {
                         lassign $args -> s3_url local_file

--- a/test/cast.test
+++ b/test/cast.test
@@ -159,6 +159,14 @@ namespace eval ::qcode::test {
         qc::cast interval "year"
     } -returnCodes error -result "Could not cast year to an interval"
 
+    test cast-s3_url-1.0 {qc::cast s3_url: Missing Protocol 1}  {qc::cast s3_url "bucket/object_key"}      {s3://bucket/object_key}
+    test cast-s3_url-1.1 {qc::cast s3_url: Missing Protocol 2}  {qc::cast s3_url "/bucket/object_key"}     {s3://bucket/object_key}
+    test cast-s3_url-1.2 {qc::cast s3_url: Upper Case Protocol} {qc::cast s3_url "S3://bucket/object_key"} {s3://bucket/object_key}
+    test cast-s3_url-1.3 {qc::cast s3_url: No object_key}       {qc::cast s3_url "bucket"}                 {s3://bucket/}
+    test cast-s3_url-1.4 {qc::cast s3_url: Invalid bucket}     -body {qc::cast s3_url "%%%%%%%%/object_key"} -returnCodes error -result {Could not cast "%%%%%%%%/object_key" to an s3_url}
+    test cast-s3_url-1.5 {qc::cast s3_url: Invalid object_key} -body {qc::cast s3_url "bucket/invalid."}     -returnCodes error -result {Could not cast "bucket/invalid." to an s3_url}
+    
+        
     cleanupTests
 }
 namespace delete ::qcode::test

--- a/test/cast.test
+++ b/test/cast.test
@@ -159,12 +159,12 @@ namespace eval ::qcode::test {
         qc::cast interval "year"
     } -returnCodes error -result "Could not cast year to an interval"
 
-    test cast-s3_url-1.0 {qc::cast s3_url: Missing Protocol 1}  {qc::cast s3_url "bucket/object_key"}      {s3://bucket/object_key}
-    test cast-s3_url-1.1 {qc::cast s3_url: Missing Protocol 2}  {qc::cast s3_url "/bucket/object_key"}     {s3://bucket/object_key}
-    test cast-s3_url-1.2 {qc::cast s3_url: Upper Case Protocol} {qc::cast s3_url "S3://bucket/object_key"} {s3://bucket/object_key}
-    test cast-s3_url-1.3 {qc::cast s3_url: No object_key}       {qc::cast s3_url "bucket"}                 {s3://bucket/}
-    test cast-s3_url-1.4 {qc::cast s3_url: Invalid bucket}     -body {qc::cast s3_url "%%%%%%%%/object_key"} -returnCodes error -result {Could not cast "%%%%%%%%/object_key" to an s3_url}
-    test cast-s3_url-1.5 {qc::cast s3_url: Invalid object_key} -body {qc::cast s3_url "bucket/invalid."}     -returnCodes error -result {Could not cast "bucket/invalid." to an s3_url}
+    test cast-s3_uri-1.0 {qc::cast s3_uri: Missing Protocol 1}  {qc::cast s3_uri "bucket/object_key"}      {s3://bucket/object_key}
+    test cast-s3_uri-1.1 {qc::cast s3_uri: Missing Protocol 2}  {qc::cast s3_uri "/bucket/object_key"}     {s3://bucket/object_key}
+    test cast-s3_uri-1.2 {qc::cast s3_uri: Upper Case Protocol} {qc::cast s3_uri "S3://bucket/object_key"} {s3://bucket/object_key}
+    test cast-s3_uri-1.3 {qc::cast s3_uri: No object_key}       {qc::cast s3_uri "bucket"}                 {s3://bucket/}
+    test cast-s3_uri-1.4 {qc::cast s3_uri: Invalid bucket}     -body {qc::cast s3_uri "%%%%%%%%/object_key"} -returnCodes error -result {Could not cast "%%%%%%%%/object_key" to an s3_uri}
+    test cast-s3_uri-1.5 {qc::cast s3_uri: Invalid object_key} -body {qc::cast s3_uri "bucket/invalid."}     -returnCodes error -result {Could not cast "bucket/invalid." to an s3_uri}
     
         
     cleanupTests

--- a/test/castable.test
+++ b/test/castable.test
@@ -400,7 +400,37 @@ namespace eval ::qcode::test {
         qc::castable interval "year"
     } -result false
 
-    
+    test castable-s3_uri-1.0 {qc::castable s3_uri "bucket"} -body {
+        qc::castable s3_uri "bucket"
+    } -result true
+
+    test castable-s3_uri-1.1 {qc::castable s3_uri "bucket"} -body {
+        qc::castable s3_uri "bucket"
+    } -result true
+
+    test castable-s3_uri-1.2 {qc::castable s3_uri "bucket/key"} -body {
+        qc::castable s3_uri "bucket/key"
+    } -result true
+
+    test castable-s3_uri-1.3 {qc::castable s3_uri "Invalid@Bucket/key"} -body {
+        qc::castable s3_uri "invalid@bucket/key"
+    } -result false
+
+    test castable-s3_uri-1.4 {qc::castable s3_uri "bucket/invalid_key."} -body {
+        qc::castable s3_uri "bucket/invalid_key."
+    } -result false
+
+    test castable-s3_uri-1.5 {qc::castable s3_uri "/leading/slash"} -body {
+        qc::castable s3_uri "/leading/slash"
+    } -result true
+
+    test castable-s3_uri-1.6 {qc::castable s3_uri "s3://lower-case/protocol"} -body {
+        qc::castable s3_uri "s3://lower-case/protocol"
+    } -result true
+
+    test castable-s3_uri-1.7 {qc::castable s3_uri "S3://upper-case/protocol"} -body {
+        qc::castable s3_uri "S3://upper-case/protocol"
+    } -result true
     
     cleanupTests
 }

--- a/test/castable.test
+++ b/test/castable.test
@@ -399,6 +399,8 @@ namespace eval ::qcode::test {
     test castable-interval-1.5 {qc::castable interval "year"} -body {
         qc::castable interval "year"
     } -result false
+
+    
     
     cleanupTests
 }

--- a/test/is.test
+++ b/test/is.test
@@ -3033,11 +3033,10 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
     test is-s3_bucket-1.7     {qc::is s3_bucket: Invalid end character}       {qc::is s3_bucket "my-bucket."}             0
     test is-s3_bucket-1.8     {qc::is s3_bucket: IP Address}                  {qc::is s3_bucket "1.2.3.4"}                0
 
-    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 1}    {qc::is s3_object_key "/my/file&name"}       0
-    test is-s3_object_key-1.1 {qc::is s3_object_key: Invalid characters 2}    {qc::is s3_object_key "/file name"}          0
-    test is-s3_object_key-1.2 {qc::is s3_object_key: Valid key}               {qc::is s3_object_key "/obj/k!_t/Y*f).png"}  1
-    test is-s3_object_key-1.3 {qc::is s3_object_key: Ending in "."}           {qc::is s3_object_key "/name."}              0
-    test is-s3_object_key-1.4 {qc::is s3_object_key: Not starting with "/"}   {qc::is s3_object_key "test"}                0
+    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 1}    {qc::is s3_object_key "my/file&name"}       0
+    test is-s3_object_key-1.1 {qc::is s3_object_key: Invalid characters 2}    {qc::is s3_object_key "file name"}          0
+    test is-s3_object_key-1.2 {qc::is s3_object_key: Valid key}               {qc::is s3_object_key "/obj/k!_t/Y*f).png"} 1
+    test is-s3_object_key-1.3 {qc::is s3_object_key: Ending in "."}           {qc::is s3_object_key "name."}              0
     
     cleanupTests
 }

--- a/test/is.test
+++ b/test/is.test
@@ -3014,6 +3014,30 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
     test is-interval-1.5 {qc::is interval "year"} -body {
         qc::is interval "year"
     } -result 0
+
+    # S3 URL, Bucket, Object Key
+    # Test                    Description                                     Code                                        Result
+    test is-s3_url-1.0        {qc::is s3_url: S3 URL}                         {qc::is s3_url "s3://string/st34.235"}      1
+    test is-s3_url-1.1        {qc::is s3_url: S3 URL without object key}      {qc::is s3_url "S3://bucket"}               1
+    test is-s3_url-1.2        {qc::is s3_url: S3 URL with inferred hierarchy} {qc::is s3_url "s3://bucket/2/3/4/5"}       1
+    test is-s3_url-1.3        {qc::is s3_url: Invalid S3 URL}                 {qc::is s3_url "invalid s3 url"}            0
+    test is-s3_url-1.4        {qc::is s3_url: Missing protocol}               {qc::is s3_url "/bucket/file"}              0         
+
+    test is-s3_bucket-1.0     {qc::is s3_bucket: Valid 1}                     {qc::is s3_bucket "test-name"}              1
+    test is-s3_bucket-1.1     {qc::is s3_bucket: Valid 2}                     {qc::is s3_bucket "1.test-name.6"}          1
+    test is-s3_bucket-1.2     {qc::is s3_bucket: Too few characters}          {qc::is s3_bucket "aa"}                     0
+    test is-s3_bucket-1.3     {qc::is s3_bucket: Too many characters}         {qc::is s3_bucket [join [lrepeat 70 a] ""]} 0
+    test is-s3_bucket-1.4     {qc::is s3_bucket: Invalid characters 1}        {qc::is s3_bucket "bucket_name"}            0
+    test is-s3_bucket-1.5     {qc::is s3_bucket: Invalid characters 2}        {qc::is s3_bucket "aaaAaaa"}                0
+    test is-s3_bucket-1.6     {qc::is s3_bucket: Invalid start character}     {qc::is s3_bucket "-bucket"}                0
+    test is-s3_bucket-1.7     {qc::is s3_bucket: Invalid end character}       {qc::is s3_bucket "my-bucket."}             0
+    test is-s3_bucket-1.8     {qc::is s3_bucket: IP Address}                  {qc::is s3_bucket "1.2.3.4"}                0
+
+    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 1}    {qc::is s3_object_key "my/file&name"}       0
+    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 2}    {qc::is s3_object_key "file name"}          0
+    test is-s3_object_key-1.0 {qc::is s3_object_key: Valid key}               {qc::is s3_object_key "obj/k!_t/Y*f).png"}  1
+    test is-s3_object_key-1.0 {qc::is s3_object_key: Ending in "."}           {qc::is s3_object_key "name."}              0
+
     
     cleanupTests
 }

--- a/test/is.test
+++ b/test/is.test
@@ -3033,11 +3033,11 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
     test is-s3_bucket-1.7     {qc::is s3_bucket: Invalid end character}       {qc::is s3_bucket "my-bucket."}             0
     test is-s3_bucket-1.8     {qc::is s3_bucket: IP Address}                  {qc::is s3_bucket "1.2.3.4"}                0
 
-    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 1}    {qc::is s3_object_key "my/file&name"}       0
-    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 2}    {qc::is s3_object_key "file name"}          0
-    test is-s3_object_key-1.0 {qc::is s3_object_key: Valid key}               {qc::is s3_object_key "obj/k!_t/Y*f).png"}  1
-    test is-s3_object_key-1.0 {qc::is s3_object_key: Ending in "."}           {qc::is s3_object_key "name."}              0
-
+    test is-s3_object_key-1.0 {qc::is s3_object_key: Invalid characters 1}    {qc::is s3_object_key "/my/file&name"}       0
+    test is-s3_object_key-1.1 {qc::is s3_object_key: Invalid characters 2}    {qc::is s3_object_key "/file name"}          0
+    test is-s3_object_key-1.2 {qc::is s3_object_key: Valid key}               {qc::is s3_object_key "/obj/k!_t/Y*f).png"}  1
+    test is-s3_object_key-1.3 {qc::is s3_object_key: Ending in "."}           {qc::is s3_object_key "/name."}              0
+    test is-s3_object_key-1.4 {qc::is s3_object_key: Not starting with "/"}   {qc::is s3_object_key "test"}                0
     
     cleanupTests
 }

--- a/test/is.test
+++ b/test/is.test
@@ -3017,11 +3017,11 @@ bmZvIDEgMCBSCi9Sb290IDEzNiAwIFIKPj4Kc3RhcnR4cmVmCjExODgxMQolJUVPRgo=}
 
     # S3 URL, Bucket, Object Key
     # Test                    Description                                     Code                                        Result
-    test is-s3_url-1.0        {qc::is s3_url: S3 URL}                         {qc::is s3_url "s3://string/st34.235"}      1
-    test is-s3_url-1.1        {qc::is s3_url: S3 URL without object key}      {qc::is s3_url "S3://bucket"}               1
-    test is-s3_url-1.2        {qc::is s3_url: S3 URL with inferred hierarchy} {qc::is s3_url "s3://bucket/2/3/4/5"}       1
-    test is-s3_url-1.3        {qc::is s3_url: Invalid S3 URL}                 {qc::is s3_url "invalid s3 url"}            0
-    test is-s3_url-1.4        {qc::is s3_url: Missing protocol}               {qc::is s3_url "/bucket/file"}              0         
+    test is-s3_uri-1.0        {qc::is s3_uri: S3 URI}                         {qc::is s3_uri "s3://string/st34.235"}      1
+    test is-s3_uri-1.1        {qc::is s3_uri: S3 URI without object key}      {qc::is s3_uri "S3://bucket"}               1
+    test is-s3_uri-1.2        {qc::is s3_uri: S3 URI with inferred hierarchy} {qc::is s3_uri "s3://bucket/2/3/4/5"}       1
+    test is-s3_uri-1.3        {qc::is s3_uri: Invalid S3 URI}                 {qc::is s3_uri "invalid s3 url"}            0
+    test is-s3_uri-1.4        {qc::is s3_uri: Missing protocol}               {qc::is s3_uri "/bucket/file"}              0         
 
     test is-s3_bucket-1.0     {qc::is s3_bucket: Valid 1}                     {qc::is s3_bucket "test-name"}              1
     test is-s3_bucket-1.1     {qc::is s3_bucket: Valid 2}                     {qc::is s3_bucket "1.test-name.6"}          1

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -67,6 +67,15 @@ namespace eval ::qcode::test {
         qc::s3 uri_bucket_object_key "/abcdef/acb/123/xyz.png"
     } -result {abcdef acb/123/xyz.png}
 
+    # uri - create an S3 URI from a bucket and object_key
+    test s3-uri-1.0 {qc::s3 uri: bucket and key} -body {
+        qc::s3 uri "bucket" "key"
+    } -result {s3://bucket/key}
+
+    test s3-uri-1.1 {qc::s3 uri: bucket only} -body {
+        qc::s3 uri "bucket"
+    }  -result {s3://bucket/}
+
     # md5 - Get MD5 of a local file
     test s3-md5-1.0 {qc::s3 md5: Test} -body {
         set filepath [qc::file_temp "123456789"]

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -22,6 +22,10 @@ namespace eval ::qcode::test {
     testConstraint requires_s3_put false
     # Set true once `qc::s3 delete` passes its test
     testConstraint requires_s3_delete false
+    # Set true once `qc::s3 upload abort` passes its test
+    testConstraint requires_s3_upload_abort false
+    # Set true once `qc::s3 upload lsparts` passes its test
+    testConstraint requires_s3_upload_lsparts false
     
     set role_name [qc::aws_metadata iam/security-credentials/]
     if { $role_name ne "" } {
@@ -375,16 +379,161 @@ namespace eval ::qcode::test {
         return 0
     } -result {1}
     
-    # upload
-    test s3-upload-1.0 {qc::s3 upload: Using separate bucket and remote_filename} -constraints {
+    # upload - Multipart uploads
+    test s3-upload-1.0 {qc::s3 upload: Testing `init`, `send`, and `complete` v1} -constraints {
         requires_s3
         requires_test_bucket
+        requires_s3_lsbucket
     } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.0-test"
+        ::try {
+            qc::s3 upload $bucket $local_filename "/${object_key}"
+        } finally {
+            file delete $local_filename
+        }
+
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            return 1
+        }
+        return 0
+    } -result {1}
+    
+    test s3-upload-1.1 {qc::s3 upload: Testing `init`, `send`, and `complete` v2} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.0-test"
+        set s3_uri [qc::s3 uri $bucket $object_key]
+        ::try {
+            qc::s3 upload $s3_uri $local_filename
+        } finally {
+            file delete $local_filename
+        }
+
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            return 1
+        }
+        return 0
+    } -result {1}
+
+    test s3-upload-1.2 {qc::s3 upload: Testing `abort` v1} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.2-test"
+        set s3_uri [qc::s3 uri $bucket $object_key]
+        ::try {
+            set upload_id [qc::s3 upload init $s3_uri $local_filename]
+        } finally {
+            file delete $local_filename
+        }
+
+        qc::s3 upload abort $s3_uri $upload_id
+        
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            return 0
+        }
         return 1
     } -result {1}
 
+    test s3-upload-1.3 {qc::s3 upload: Testing `abort` v2} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.3-test"
+        ::try {
+            set upload_id [qc::s3 upload init $bucket $local_filename "/${object_key}"]
+        } finally {
+            file delete $local_filename
+        }
+
+        qc::s3 upload abort $bucket "/${object_key}" $upload_id
+        
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            return 0
+        }
+        testConstraint requires_s3_upload_abort true
+        return 1
+    } -result {1}
+
+    test s3-upload-1.4 {qc::s3 upload: Testing `ls`} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_upload_abort
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.4-test"
+        ::try {
+            set upload_id [qc::s3 upload init $bucket $local_filename "/${object_key}"]
+            set result [qc::s3 upload ls $bucket]
+        } finally {
+            file delete $local_filename
+            qc::s3 upload abort $bucket "/${object_key}" $upload_id
+        }
+
+        return $result
+    } -result {1}
     
-    
+    test s3-upload-1.5 {qc::s3 upload: Testing `lsparts`} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_upload_abort
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.5-test"
+        ::try {
+            set upload_id [qc::s3 upload init $bucket $local_filename "/${object_key}"]
+            set etag_dict [qc::s3 upload send $bucket $local_filename "/${object_key}" $upload_id]
+            set result [qc::s3 upload lsparts $bucket "/${object_key}" $upload_id]
+        } finally {
+            file delete $local_filename
+            qc::s3 upload abort $bucket "/${object_key}" $upload_id
+        }
+
+        if { "\"[dict get $etag_dict 1]\"" in [ldict_values result ETag] } {
+            testConstraint requires_s3_upload_lsparts true
+            return 1
+        }
+        return 0
+    } -result {1}
+
+    test s3-upload-1.6 {qc::s3 upload: Testing `cleanup`} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_upload_abort
+        requires_s3_upload_lsparts
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-upload-1.6-test"
+        ::try {
+            set upload_id [qc::s3 upload init $bucket $local_filename "/${object_key}"]
+            set etag_dict [qc::s3 upload send $bucket $local_filename "/${object_key}" $upload_id]
+
+            qc::s3 upload cleanup $bucket
+
+            set result [qc::s3 upload lsparts $bucket "/${object_key}" $upload_id]
+        } finally {
+            file delete $local_filename
+        }
+
+        if { [llength $result] == 0 } {
+            return 1
+        }
+        
+        return 0
+    } -result {1}
+
     # Cleanup
     test s3-cleanup {Remove files from S3 uploaded by the s3_tools tests} -constraints {
         requires_s3

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -11,9 +11,18 @@ namespace eval ::qcode::test {
 
     # Bucket to runs tests against
     set bucket "qcodetcl-tcltest-s3"
-    
+
     # Set true once s3 credentials and region are set
     testConstraint requires_s3 false
+    # Set true once $bucket is confirmed as available by `qc::s3 ls`
+    testConstraint requires_test_bucket false
+    # Set true once `qc::s3 lsbucket` passes its test
+    testConstraint requires_s3_lsbucket false
+    # Set true once `qc::s3 put` passes its test
+    testConstraint requires_s3_put false
+    # Set true once `qc::s3 delete` passes its test
+    testConstraint requires_s3_delete false
+    
     set role_name [qc::aws_metadata iam/security-credentials/]
     if { $role_name ne "" } {
         qc::aws_region_set "eu-west-1"
@@ -26,34 +35,340 @@ namespace eval ::qcode::test {
         testConstraint requires_s3 true
     }
 
-    set result [qc::s3 lsbucket $bucket]
+    # Some tests require other s3 procs to be working
+    # Tests are ordered so if a test fails, other test dependent on the failing proc will be skipped
 
-    # md5
+    # s3_url_bucket_object_key
+    test s3_url_bucket_object_key-1.0 {qc::s3_url_bucket_object_key: Protocol 1} -body {
+        qc::s3_url_bucket_object_key "S3://bucket/object_key"
+    } -result {bucket object_key}
+
+    test s3_url_bucket_object_key-1.1 {qc::s3_url_bucket_object_key: Protocol 2} -body {
+        qc::s3_url_bucket_object_key "s3://bucket/object_key"
+    } -result {bucket object_key}
+
+    test s3_url_bucket_object_key-1.2 {qc::s3_url_bucket_object_key: Protocol 3} -body {
+        qc::s3_url_bucket_object_key "/bucket/object_key"
+    } -result {bucket object_key}
+
+    test s3_url_bucket_object_key-1.3 {qc::s3_url_bucket_object_key: Protocol 4} -body {
+        qc::s3_url_bucket_object_key "bucket/object_key"
+    } -result {bucket object_key}
+    
+    test s3_url_bucket_object_key-1.4 {qc::s3_url_bucket_object_key: No object key 1} -body {
+        qc::s3_url_bucket_object_key "abcd:1234 £A12 ab1 a"
+    } -result {{abcd:1234 £A12 ab1 a} {}}
+
+    test s3_url_bucket_object_key-1.5 {qc::s3_url_bucket_object_key: No object key 2} -body {
+        qc::s3_url_bucket_object_key "/abcdef/"
+    } -result {abcdef {}}
+
+    test s3_url_bucket_object_key-1.6 {qc::s3_url_bucket_object_key: Long object key} -body {
+        qc::s3_url_bucket_object_key "/abcdef/acb/123/xyz.png"
+    } -result {abcdef acb/123/xyz.png}
+    
+    # md5 - Get MD5 of a local file
     test s3-md5-1.0 {qc::s3 md5: Test} -body {
+        set filepath [qc::file_temp "123456789"]
         ::try {
-            set filepath [qc::temp_file "123456789"]
             set md5 [qc::s3 md5 $filepath]
         } finally {
             file delete $filepath
         }
         return $md5
-    } -result {test}
+    } -result {JfnnlDI7RTiF9RgfG2JNCw==}
 
-    # Some tests require other s3 procs to be working
-    # Tests are ordered so if a test fails, other test dependent on the failing proc will be skipped
+    # ls - List all available buckets
+    test s3-ls-1.0 {qc::s3 ls: List available buckets} -constraints {
+        requires_s3
+    } -body {
+        set results [qc::s3 ls]
+        if { $bucket in [ldict_values results Name] } {
+            testConstraint requires_test_bucket true
+        }
+        return 1
+    } -result {1}
+        
+    # lsbucket - List all objects in a bucket
+    test s3-lsbucket-1.0 {qc::s3 lsbucket: List files in a bucket} -constraints {
+        requires_s3
+        requires_test_bucket
+    } -body {
+        qc::s3 lsbucket $bucket
+        return 1
+    } -result {1}
+
+    test s3-lsbucket-1.1 {qc::s3 lsbucket: List files in a bucket with prefix} -constraints {
+        requires_s3
+        requires_test_bucket
+    } -body {
+        qc::s3 lsbucket $bucket "test"
+        testConstraint requires_s3_lsbucket true
+        return 1
+    } -result {1}
+
+    # put - Upload a file to s3
+    test s3-put-1.0 {qc::s3 put: bucket local_path remote_filename} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+    } -body {
+        set object_key "s3-put-1.0-test"
+        set remote_filename "/${object_key}"
+        set local_filepath [qc::file_temp "1234"]
+        ::try {
+            qc::s3 put $bucket $local_filepath $remote_filename
+        } finally {
+            file delete  $local_filepath
+        }
+
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            # Put was successful
+            return 1
+        }
+        return 0
+    } -result {1}
+
+    test s3-put-1.1 {qc::s3 put: s3_url local_filename } -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+    } -body {
+        set object_key "s3-put-1.1-test"
+        set s3_url "s3://${bucket}/${object_key}"
+        
+        set local_filepath [qc::file_temp "1234"]
+        ::try {
+            qc::s3 put $s3_url $local_filepath
+        } finally {
+            file delete $local_filepath
+        }
+
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            # Put was successful
+            testConstraint requires_s3_put true
+            return 1
+        }
+        return 0
+    } -result {1}
+
+    # delete - Delete an object from s3
+    test s3-delete-1.0 {qc::s3 delete: bucket remote_filename} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+        requires_s3_put
+    } -body {
+        set object_key "s3-delete-1.0-test"
+        set remote_filename "/${object_key}"
+        set local_filename [qc::file_temp "1234"]
+        ::try {
+            qc::s3 put $bucket $local_filename $remote_filename 
+        } finally {
+            file delete $local_filename
+        }
+        
+        # Delete
+        qc::s3 delete $bucket $remote_filename
+
+        # Confirm deleted
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            return 0
+        }
+
+        return 1
+    } -result {1}
+
+    test s3-delete-1.1 {qc::s3 delete: s3_url} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+        requires_s3_put
+    } -body {
+        set s3_url "s3://${bucket}/s3-delete-1.1-test"
+        set local_filename [qc::file_temp "1234"]
+        ::try {
+            qc::s3 put $s3_url $local_filename
+        } finally {
+            file delete $local_filename
+        }
+
+        # Delete
+        qc::s3 delete $s3_url
+
+        # Confirm deleted
+        lassign [qc::s3_url_bucket_object_key $s3_url] . object_key
+        set results [qc::s3 lsbucket $bucket $object_key]
+        if { $object_key in [ldict_values results Key] } {
+            return 0
+        }
+
+        return 1
+    } -result {1}
     
-    # ls
-    # lsbucket
-    # get
-    # head
+    # get - Get an object from s3
+    test s3-get-1.0 {qc::s3 get: bucket remote_filename local_filename} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_put
+    } -body {
+        set file_string "Test file contents"
+        set local_filename [qc::file_temp $file_string]
+        set remote_filename "/s3-get-1.0-test"
+        ::try {
+            qc::s3 put $bucket $local_filename $remote_filename
+        } finally {
+            file delete $local_filename
+        }
+
+        # Get file
+        set local_filename [join [list "/tmp/" [uuid::uuid generate]] ""]
+        set get_file_string ""
+        ::try {
+            qc::s3 get $bucket $remote_filename $local_filename
+            set get_file_string [qc::cat $local_filename]
+        } finally {
+            file delete $local_filename
+        }
+        
+        if { $file_string ne $get_file_string } {
+            return 0
+        }
+        return 1
+    } -result {1}
+
+    test s3-get-1.1 {qc::s3 get: s3_url local_filename} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_put
+    } -body {
+        set file_string "Test file contents"
+        set local_filename [qc::file_temp $file_string]
+        set s3_url "s3://${bucket}/s3-get-1.0-test"
+        ::try {
+            qc::s3 put $s3_url $local_filename
+        } finally {
+            file delete $local_filename
+        }
+
+        # Get file
+        set local_filename [join [list "/tmp/" [uuid::uuid generate]] ""]
+        set get_file_string ""
+        ::try {
+            qc::s3 get $s3_url $local_filename
+            set get_file_string [qc::cat $local_filename]
+        } finally {
+            file delete $local_filename
+        }
+        
+        if { $file_string ne $get_file_string } {
+            return 0
+        }
+        return 1
+    } -result {1}
+    
+    # head - Get 
+    test s3-head-1.0 {qc::s3 head: bucket remote_path} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_put
+    } -body {
+        set local_filename [qc::file_temp "1234"]
+        set remote_path "/s3-head-1.0-test"
+        
+        ::try {
+            qc::s3 put $bucket $local_filename $remote_path
+        } finally {
+            file delete $local_filename
+        }
+
+        # qc::head
+        set result [qc::s3 head $bucket $remote_path]
+        return [regexp {200 OK$} [dict get $result http]]
+    } -result {1}
+
+    test s3-head-1.1 {qc::s3 head: s3_url} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_put
+    } -body {
+        set local_filename [qc::file_temp "1234"]
+        set s3_url "s3://${bucket}/s3-head-1.1-test"
+        ::try {
+            qc::s3 put $s3_url $local_filename
+        } finally {
+            file delete $local_filename
+        }
+
+        # qc::s3 head
+        set result [qc::s3 head $s3_url]
+        return [regexp {200 OK$} [dict get $result http]]
+    } -result {1}
+    
     # copy
-    # put
-    # restore
-    # upload
-    # delete
-    
-    #test s3-put-1.0 {qc::s3 put: }
+    test s3-copy-1.0 {qc::s3 copy: bucket remote_filename_to_copy_with_bucket remote_filename_copy} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_put
+        requires_s3_lsbucket
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3-copy-1.0-test"
+        set s3_url "s3://${bucket}/${object_key}"
+        ::try {
+            qc::s3 put $s3_url $local_filename
+        } finally {
+            file delete $local_filename
+        }
 
+        # qc::s3 copy
+        set object_to_copy "${bucket}/${object_key}"
+        set object_copy "${object_key}_copy"
+        qc::s3 copy $bucket $object_to_copy "/${object_copy}"
+
+        # Check result
+        set results [qc::s3 lsbucket $bucket $object_copy]
+        if { $object_copy in [ldict_values results Key] } {
+            return 1
+        }
+        return 0
+    } -result {1}
+
+    test s3-copy-1.1 {qc::s3 copy: s3_url_to_copy s3_url_copy} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_put
+        requires_s3_lsbucket
+    } -body {
+        set local_filename [qc::file_temp "abcdefg"]
+        set s3_url "s3://${bucket}/${object_key}"
+        ::try {
+            qc::s3 put $s3_url $local_filename
+        } finally {
+            file delete $local_filename
+        }
+
+        # qc::s3 copy
+        set s3_url_to_copy $s3_url
+        set s3_url_copy "${s3_url}_copy"
+        qc::s3 copy $s3_url_to_copy $s3_url_copy
+
+        # Check result
+        lassign [qc::s3_url_bucket_object_key $s3_url_copy] . object_key
+        set results [qc::s3 lsbucket $bucket $object_copy]
+        if { $object_copy in [ldict_values results Key] } {
+            return 1
+        }
+        return 0
+    } -result {1}
+    
+    # restore
+    
+    
+    # upload
     
     cleanupTests
 }

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -365,10 +365,13 @@ namespace eval ::qcode::test {
         return 0
     } -result {1}
     
-    # restore
-    
-    
     # upload
+    test s3-upload-1.0 {qc::s3 upload: Using separate bucket and remote_filename} -constraints {
+        requires_s3
+        requires_test_bucket
+    } -body {
+        return 1
+    } -result {1}
     
     cleanupTests
 }

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -71,6 +71,31 @@ namespace eval ::qcode::test {
         qc::s3 uri_bucket_object_key "/abcdef/acb/123/xyz.png"
     } -result {abcdef acb/123/xyz.png}
 
+    # _s3_endpoint - test for the private proc qc::_s3_endpoint
+    test s3-endpoint-1.0 {qc::_s3_endpoint: bucket} -body {
+        qc::_s3_endpoint bucket
+    } -result {bucket.s3.amazonaws.com}
+
+    test s3-endpoint-1.1 {qc::_s3_endpoint: bucket and key 1} -body {
+        qc::_s3_endpoint bucket ""
+    } -result {bucket.s3.amazonaws.com/}
+
+    test s3-endpoint-1.2 {qc::_s3_endpoint: bucket and key 2} -body {
+        qc::_s3_endpoint bucket key
+    } -result {bucket.s3.amazonaws.com/key}
+    
+    test s3-endpoint-1.3 {qc::_s3_endpoint: s3_uri 1} -body {
+        qc::_s3_endpoint "s3://bucket"
+    } -result {bucket.s3.amazonaws.com/}
+
+    test s3-endpoint-1.4 {qc::_s3_endpoint: s3_uri 2} -body {
+        qc::_s3_endpoint "s3://bucket/"
+    } -result {bucket.s3.amazonaws.com/}
+
+    test s3-endpoint-1.5 {qc::_s3_endpoint: s3_uri 3} -body {
+        qc::_s3_endpoint "s3://bucket/key"
+    } -result {bucket.s3.amazonaws.com/key}
+    
     # uri - create an S3 URI from a bucket and object_key
     test s3-uri-1.0 {qc::s3 uri: bucket and key} -body {
         qc::s3 uri "bucket" "key"

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -1,0 +1,61 @@
+package require tcltest
+eval ::tcltest::configure $argv
+# Ensure package is loaded from ./package rather than /usr/lib/tcltk
+set auto_path [linsert $auto_path 0 ./package]
+package require -exact qcode $::env(VERSION)
+package require json
+
+namespace eval ::qcode::test {
+    namespace import ::tcltest::*
+    namespace path ::qc
+
+    # Bucket to runs tests against
+    set bucket "qcodetcl-tcltest-s3"
+    
+    # Set true once s3 credentials and region are set
+    testConstraint requires_s3 false
+    set role_name [qc::aws_metadata iam/security-credentials/]
+    if { $role_name ne "" } {
+        qc::aws_region_set "eu-west-1"
+        set role_credentials [::json::json2dict [qc::aws_metadata iam/security-credentials/${role_name}]]
+        set access_key [dict get $role_credentials AccessKeyId]
+        set secret_key [dict get $role_credentials SecretAccessKey]
+        set token [dict get $role_credentials Token]
+        qc::aws_credentials_set $access_key $secret_key $token
+
+        testConstraint requires_s3 true
+    }
+
+    set result [qc::s3 lsbucket $bucket]
+
+    # md5
+    test s3-md5-1.0 {qc::s3 md5: Test} -body {
+        ::try {
+            set filepath [qc::temp_file "123456789"]
+            set md5 [qc::s3 md5 $filepath]
+        } finally {
+            file delete $filepath
+        }
+        return $md5
+    } -result {test}
+
+    # Some tests require other s3 procs to be working
+    # Tests are ordered so if a test fails, other test dependent on the failing proc will be skipped
+    
+    # ls
+    # lsbucket
+    # get
+    # head
+    # copy
+    # put
+    # restore
+    # upload
+    # delete
+    
+    #test s3-put-1.0 {qc::s3 put: }
+
+    
+    cleanupTests
+}
+namespace delete ::qcode::test
+

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -38,33 +38,33 @@ namespace eval ::qcode::test {
     # Some tests require other s3 procs to be working
     # Tests are ordered so if a test fails, other test dependent on the failing proc will be skipped
 
-    # s3_url_bucket_object_key
-    test s3_url_bucket_object_key-1.0 {qc::s3_url_bucket_object_key: Protocol 1} -body {
-        qc::s3_url_bucket_object_key "S3://bucket/object_key"
+    # s3_uri_bucket_object_key
+    test s3-uri_bucket_object_key-1.0 {qc::s3 uri_bucket_object_key: Protocol 1} -body {
+        qc::s3 uri_bucket_object_key "S3://bucket/object_key"
     } -result {bucket object_key}
 
-    test s3_url_bucket_object_key-1.1 {qc::s3_url_bucket_object_key: Protocol 2} -body {
-        qc::s3_url_bucket_object_key "s3://bucket/object_key"
+    test s3-uri_bucket_object_key-1.1 {qc::s3 uri_bucket_object_key: Protocol 2} -body {
+        qc::s3 uri_bucket_object_key "s3://bucket/object_key"
     } -result {bucket object_key}
 
-    test s3_url_bucket_object_key-1.2 {qc::s3_url_bucket_object_key: Protocol 3} -body {
-        qc::s3_url_bucket_object_key "/bucket/object_key"
+    test s3-uri_bucket_object_key-1.2 {qc::s3 uri_bucket_object_key: Protocol 3} -body {
+        qc::s3 uri_bucket_object_key "/bucket/object_key"
     } -result {bucket object_key}
 
-    test s3_url_bucket_object_key-1.3 {qc::s3_url_bucket_object_key: Protocol 4} -body {
-        qc::s3_url_bucket_object_key "bucket/object_key"
+    test s3-uri_bucket_object_key-1.3 {qc::s3 uri_bucket_object_key: Protocol 4} -body {
+        qc::s3 uri_bucket_object_key "bucket/object_key"
     } -result {bucket object_key}
     
-    test s3_url_bucket_object_key-1.4 {qc::s3_url_bucket_object_key: No object key 1} -body {
-        qc::s3_url_bucket_object_key "abcd:1234 £A12 ab1 a"
+    test s3-uri_bucket_object_key-1.4 {qc::s3 uri_bucket_object_key: No object key 1} -body {
+        qc::s3 uri_bucket_object_key "abcd:1234 £A12 ab1 a"
     } -result {{abcd:1234 £A12 ab1 a} {}}
 
-    test s3_url_bucket_object_key-1.5 {qc::s3_url_bucket_object_key: No object key 2} -body {
-        qc::s3_url_bucket_object_key "/abcdef/"
+    test s3-uri_bucket_object_key-1.5 {qc::s3 uri_bucket_object_key: No object key 2} -body {
+        qc::s3 uri_bucket_object_key "/abcdef/"
     } -result {abcdef {}}
 
-    test s3_url_bucket_object_key-1.6 {qc::s3_url_bucket_object_key: Long object key} -body {
-        qc::s3_url_bucket_object_key "/abcdef/acb/123/xyz.png"
+    test s3-uri_bucket_object_key-1.6 {qc::s3 uri_bucket_object_key: Long object key} -body {
+        qc::s3 uri_bucket_object_key "/abcdef/acb/123/xyz.png"
     } -result {abcdef acb/123/xyz.png}
     
     # md5 - Get MD5 of a local file
@@ -200,7 +200,7 @@ namespace eval ::qcode::test {
         qc::s3 delete $s3_url
 
         # Confirm deleted
-        lassign [qc::s3_url_bucket_object_key $s3_url] . object_key
+        lassign [qc::s3 uri_bucket_object_key $s3_url] . object_key
         set results [qc::s3 lsbucket $bucket $object_key]
         if { $object_key in [ldict_values results Key] } {
             return 0
@@ -325,9 +325,8 @@ namespace eval ::qcode::test {
         }
 
         # qc::s3 copy
-        set object_to_copy "${bucket}/${object_key}"
         set object_copy "${object_key}_copy"
-        qc::s3 copy $bucket $object_to_copy "/${object_copy}"
+        qc::s3 copy $bucket "/${object_key}" "/${object_copy}"
 
         # Check result
         set results [qc::s3 lsbucket $bucket $object_copy]
@@ -357,7 +356,7 @@ namespace eval ::qcode::test {
         qc::s3 copy $s3_url_to_copy $s3_url_copy
 
         # Check result
-        lassign [qc::s3_url_bucket_object_key $s3_url_copy] . object_key
+        lassign [qc::s3 uri_bucket_object_key $s3_url_copy] . object_key
         set results [qc::s3 lsbucket $bucket $object_copy]
         if { $object_copy in [ldict_values results Key] } {
             return 1

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -522,7 +522,7 @@ namespace eval ::qcode::test {
         set object_key "s3_tools_test-upload-1.6-test"
         ::try {
             set upload_id [qc::s3 upload init $bucket $local_filename "/${object_key}"]
-            set etag_dict [qc::s3 upload send $bucket $local_filename "/${object_key}" $upload_id]
+            #set etag_dict [qc::s3 upload send $bucket $local_filename "/${object_key}" $upload_id]
 
             qc::s3 upload cleanup $bucket
 

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -482,7 +482,11 @@ namespace eval ::qcode::test {
             qc::s3 upload abort $bucket "/${object_key}" $upload_id
         }
 
-        return $result
+        # Confirm `qc::s3 upload ls` found the partially uploaded object
+        if { $object_key in [ldict_values result Key] } {
+            return 1
+        }
+        return 0
     } -result {1}
     
     test s3-upload-1.5 {qc::s3 upload: Testing `lsparts`} -constraints {

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -383,6 +383,8 @@ namespace eval ::qcode::test {
         return 1
     } -result {1}
 
+    
+    
     # Cleanup
     test s3-cleanup {Remove files from S3 uploaded by the s3_tools tests} -constraints {
         requires_s3

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -66,7 +66,7 @@ namespace eval ::qcode::test {
     test s3-uri_bucket_object_key-1.6 {qc::s3 uri_bucket_object_key: Long object key} -body {
         qc::s3 uri_bucket_object_key "/abcdef/acb/123/xyz.png"
     } -result {abcdef acb/123/xyz.png}
-    
+
     # md5 - Get MD5 of a local file
     test s3-md5-1.0 {qc::s3 md5: Test} -body {
         set filepath [qc::file_temp "123456789"]
@@ -113,7 +113,7 @@ namespace eval ::qcode::test {
         requires_test_bucket
         requires_s3_lsbucket
     } -body {
-        set object_key "s3-put-1.0-test"
+        set object_key "s3_tools_test-put-1.0-test"
         set remote_filename "/${object_key}"
         set local_filepath [qc::file_temp "1234"]
         ::try {
@@ -135,7 +135,7 @@ namespace eval ::qcode::test {
         requires_test_bucket
         requires_s3_lsbucket
     } -body {
-        set object_key "s3-put-1.1-test"
+        set object_key "s3_tools_test-put-1.1-test"
         set s3_url "s3://${bucket}/${object_key}"
         
         set local_filepath [qc::file_temp "1234"]
@@ -161,7 +161,7 @@ namespace eval ::qcode::test {
         requires_s3_lsbucket
         requires_s3_put
     } -body {
-        set object_key "s3-delete-1.0-test"
+        set object_key "s3_tools_test-delete-1.0-test"
         set remote_filename "/${object_key}"
         set local_filename [qc::file_temp "1234"]
         ::try {
@@ -188,7 +188,7 @@ namespace eval ::qcode::test {
         requires_s3_lsbucket
         requires_s3_put
     } -body {
-        set s3_url "s3://${bucket}/s3-delete-1.1-test"
+        set s3_url "s3://${bucket}/s3_tools_test-delete-1.1-test"
         set local_filename [qc::file_temp "1234"]
         ::try {
             qc::s3 put $s3_url $local_filename
@@ -206,6 +206,7 @@ namespace eval ::qcode::test {
             return 0
         }
 
+        testConstraint requires_s3_delete true
         return 1
     } -result {1}
     
@@ -217,7 +218,7 @@ namespace eval ::qcode::test {
     } -body {
         set file_string "Test file contents"
         set local_filename [qc::file_temp $file_string]
-        set remote_filename "/s3-get-1.0-test"
+        set remote_filename "/s3_tools_test-get-1.0-test"
         ::try {
             qc::s3 put $bucket $local_filename $remote_filename
         } finally {
@@ -247,7 +248,7 @@ namespace eval ::qcode::test {
     } -body {
         set file_string "Test file contents"
         set local_filename [qc::file_temp $file_string]
-        set s3_url "s3://${bucket}/s3-get-1.0-test"
+        set s3_url "s3://${bucket}/s3_tools_test-get-1.0-test"
         ::try {
             qc::s3 put $s3_url $local_filename
         } finally {
@@ -277,7 +278,7 @@ namespace eval ::qcode::test {
         requires_s3_put
     } -body {
         set local_filename [qc::file_temp "1234"]
-        set remote_path "/s3-head-1.0-test"
+        set remote_path "/s3_tools_test-head-1.0-test"
         
         ::try {
             qc::s3 put $bucket $local_filename $remote_path
@@ -296,7 +297,7 @@ namespace eval ::qcode::test {
         requires_s3_put
     } -body {
         set local_filename [qc::file_temp "1234"]
-        set s3_url "s3://${bucket}/s3-head-1.1-test"
+        set s3_url "s3://${bucket}/s3_tools_test-head-1.1-test"
         ::try {
             qc::s3 put $s3_url $local_filename
         } finally {
@@ -316,7 +317,7 @@ namespace eval ::qcode::test {
         requires_s3_lsbucket
     } -body {
         set local_filename [qc::file_temp "abcdefg"]
-        set object_key "s3-copy-1.0-test"
+        set object_key "s3_tools_test-copy-1.0-test"
         set s3_url "s3://${bucket}/${object_key}"
         ::try {
             qc::s3 put $s3_url $local_filename
@@ -343,6 +344,7 @@ namespace eval ::qcode::test {
         requires_s3_lsbucket
     } -body {
         set local_filename [qc::file_temp "abcdefg"]
+        set object_key "s3_tools_test-copy-1.1-test"
         set s3_url "s3://${bucket}/${object_key}"
         ::try {
             qc::s3 put $s3_url $local_filename
@@ -369,6 +371,20 @@ namespace eval ::qcode::test {
         requires_s3
         requires_test_bucket
     } -body {
+        return 1
+    } -result {1}
+
+    # Cleanup
+    test s3-cleanup {Remove files from S3 uploaded by the s3_tools tests} -constraints {
+        requires_s3
+        requires_test_bucket
+        requires_s3_lsbucket
+        requires_s3_delete
+    } -body {
+        set result [qc::s3 lsbucket $bucket "s3_tools_test-"]
+        foreach object_key [ldict_values result Key] {
+            qc::s3 delete $bucket $object_key
+        }
         return 1
     } -result {1}
     

--- a/test/s3_tools.test
+++ b/test/s3_tools.test
@@ -24,8 +24,8 @@ namespace eval ::qcode::test {
     testConstraint requires_s3_delete false
     # Set true once `qc::s3 upload abort` passes its test
     testConstraint requires_s3_upload_abort false
-    # Set true once `qc::s3 upload lsparts` passes its test
-    testConstraint requires_s3_upload_lsparts false
+    # Set true once `qc::s3 upload ls` passes its test
+    testConstraint requires_s3_upload_ls false
     
     set role_name [qc::aws_metadata iam/security-credentials/]
     if { $role_name ne "" } {
@@ -484,6 +484,7 @@ namespace eval ::qcode::test {
 
         # Confirm `qc::s3 upload ls` found the partially uploaded object
         if { $object_key in [ldict_values result Key] } {
+            testConstraint requires_s3_upload_ls true
             return 1
         }
         return 0
@@ -506,7 +507,6 @@ namespace eval ::qcode::test {
         }
 
         if { "\"[dict get $etag_dict 1]\"" in [ldict_values result ETag] } {
-            testConstraint requires_s3_upload_lsparts true
             return 1
         }
         return 0
@@ -516,7 +516,7 @@ namespace eval ::qcode::test {
         requires_s3
         requires_test_bucket
         requires_s3_upload_abort
-        requires_s3_upload_lsparts
+        requires_s3_upload_ls
     } -body {
         set local_filename [qc::file_temp "abcdefg"]
         set object_key "s3_tools_test-upload-1.6-test"
@@ -526,7 +526,7 @@ namespace eval ::qcode::test {
 
             qc::s3 upload cleanup $bucket
 
-            set result [qc::s3 upload lsparts $bucket "/${object_key}" $upload_id]
+            set result [qc::s3 upload ls $bucket]
         } finally {
             file delete $local_filename
         }


### PR DESCRIPTION
## Changes
S3 subcommands have been updated to optionally use s3_url in place of bucket and remote_file (object_key)

### New Procs
qc::s3_url_bucket_object_key

qc::is s3_bucket
qc::is s3_object_key
qc::is s3_url

qc::cast s3_url
qc::castable s3_url

## Tests
Testing of s3_tools procs in progress
is.test updated with is proc tests