### PR TITLE
Allow auth_check to use global session_id

### DIFF
--- a/tcl/auth.tcl
+++ b/tcl/auth.tcl
@@ -37,8 +37,9 @@ proc qc::auth_check {} {
     #| Check if we can authenticate the user
     #| Return true or false
     # session based auth
-    if { [qc::cookie_exists session_id]} {
-	set session_id [cookie_get session_id]
+    global current_user_id session_id
+    if { [qc::cookie_exists session_id] || [info exists session_id] } {
+	set session_id [qc::session_id]
 	if { [qc::session_exists $session_id] } {
 	    return true
 	}

--- a/tcl/auth.tcl
+++ b/tcl/auth.tcl
@@ -38,6 +38,9 @@ proc qc::auth_check {} {
     #| Return true or false
     # session based auth
     global current_user_id session_id
+    if { [info exists current_user_id] } {
+        return true
+    }
     if { [qc::cookie_exists session_id] || [info exists session_id] } {
 	set session_id [qc::session_id]
 	if { [qc::session_exists $session_id] } {


### PR DESCRIPTION
Testing:
Performed local make-install, restarted erp, deleted browser cookies, navigated to login page, logged in.