### PR TITLE
param_get failing in Naviserver cp - add case

### DIFF
--- a/tcl/param.tcl
+++ b/tcl/param.tcl
@@ -10,7 +10,7 @@ proc qc::param_get { args } {
     if { [llength $args] > 0 } {
         return [dict get [qc::param_get $param_name] {*}$args]
     } else {
-        if { [qc::db_connected] } {
+        if { [qc::db_connected] || [info commands ns_db] eq "ns_db" } {
             # DB param
             set qry {select param_value from param where param_name=:param_name}
             db_cache_0or1row -ttl $ttl $qry {


### PR DESCRIPTION
param_get fails when called from the control port due to the ```is_dbconnected``` command returning false.
The ```_db``` global variable isn't set until the db has been accessed in that context

```
Welcome to erp running at /usr/lib/naviserver/bin/nsd (pid 3565)
NaviServer/4.99.19 for linux built on Jul  6 2020 at 16:06:38
Tag: tar-4.99.19
1> qc::db_connected
false
2> qc::param_get test
Don't know where your home directory is
3> db_1row {select * from users limit 1}

4> qc::db_connected
true
5> qc::param_get test
1
```