### PR TITLE
Option To Check Image Resize Queue When Calling qc::image_data

### DIFF
--- a/tcl/image_cache.tcl
+++ b/tcl/image_cache.tcl
@@ -52,11 +52,16 @@ proc qc::image_data {args} {
         }
 
         if { $count > 0 } {
-            # TODO return placeholder image
+            set filename "${max_width}x${max_height}.png"
+            set url [qc::url "https://via.placeholder.com/:filename" \
+                         filename $filename \
+                         text "queued for processing" \
+                        ]
+
             return [dict create \
-                        width ? \
-                        height ? \
-                        url ? \
+                        width $max_width \
+                        height $max_height \
+                        url $url \
                        ]
         }
     }

--- a/tcl/image_cache.tcl
+++ b/tcl/image_cache.tcl
@@ -7,7 +7,7 @@ namespace eval qc {
 
 proc qc::image_data {args} {
     #| Return dict of width, height, & url of an image. Usage:
-    #| ?-autocrop? ?-mime_type */*? ?-check_queue? -- cache_dir file_id max_width max_height
+    #| ?-autocrop? ?-mime_type */*? -- cache_dir file_id max_width max_height
     set caller_args $args
     qc::args $args {*}{
         -autocrop

--- a/tcl/image_resize_task.tcl
+++ b/tcl/image_resize_task.tcl
@@ -9,6 +9,7 @@ proc qc::image_resize_task_add {
     cache_dir
     width
     height
+    {autocrop false}
 } {
     #| Add a new resize task for an image in the database.
 
@@ -27,6 +28,7 @@ proc qc::image_resize_task_add {
             width
             date_added
             task_state
+            autocrop
         }]
     "
 
@@ -42,7 +44,8 @@ proc qc::image_resize_task_process { row_id } {
             file_id,
             cache_dir,
             height,
-            width
+            width,
+            autocrop
 
             from
             image_resize_task
@@ -61,11 +64,23 @@ proc qc::image_resize_task_process { row_id } {
         ::try {
             set task_state "PROCESSED"
 
-            return [qc::image_data \
+            if { $autocrop } {
+                return [qc::image_data \
+                        -autocrop \
+                        -- \
                         $cache_dir \
                         $file_id \
                         $width \
                         $height]
+            } else {
+                return [qc::image_data \
+                        $cache_dir \
+                        $file_id \
+                        $width \
+                        $height]
+            }
+
+            
         } on error [list message options] {
             set task_state "ERROR"
 

--- a/tcl/image_resize_task.tcl
+++ b/tcl/image_resize_task.tcl
@@ -13,24 +13,49 @@ proc qc::image_resize_task_add {
 } {
     #| Add a new resize task for an image in the database.
 
-    set row_id [qc::db_seq "row_id_seq"]
-    set task_state "QUEUED"
-    set date_added [qc::cast timestamptz "now"]
+    db_0or1row {
+        select
+        row_id
 
-    db_dml "
-        insert into
+        from
         image_resize_task
-        [qc::sql_insert {*}{
-            row_id
-            file_id
-            cache_dir
-            height
-            width
-            date_added
-            task_state
-            autocrop
-        }]
-    "
+
+        where
+        file_id=:file_id
+        and cache_dir=:cache_dir
+        and autocrop=:autocrop
+        and task_state = 'QUEUED'
+        and (
+             (
+              width=:width
+              and height<=:height
+             )
+             or (
+                 width<=:width
+                 and height=:height
+             )
+        )
+    } {
+        # Image hasn't been queued at this height and width for the cache directory.
+        set row_id [qc::db_seq "row_id_seq"]
+        set task_state "QUEUED"
+        set date_added [qc::cast timestamptz "now"]
+
+        db_dml "
+            insert into
+            image_resize_task
+            [qc::sql_insert {*}{
+                row_id
+                file_id
+                cache_dir
+                height
+                width
+                date_added
+                task_state
+                autocrop
+            }]
+        "
+    }
 
     return $row_id
 }
@@ -41,18 +66,20 @@ proc qc::image_resize_task_process { row_id } {
     db_trans {
         db_0or1row {
             select
-            file_id,
-            cache_dir,
-            height,
-            width,
-            autocrop
+            i.file_id,
+            i.cache_dir,
+            i.height,
+            i.width,
+            i.autocrop,
+            f.mime_type
 
             from
-            image_resize_task
+            image_resize_task i
+            join file f using (file_id)
 
             where
-            row_id=:row_id
-            and task_state = 'QUEUED'
+            i.row_id=:row_id
+            and i.task_state = 'QUEUED'
 
             for update
         } {
@@ -64,23 +91,27 @@ proc qc::image_resize_task_process { row_id } {
         ::try {
             set task_state "PROCESSED"
 
-            if { $autocrop } {
-                return [qc::image_data \
-                        -autocrop \
-                        -- \
-                        $cache_dir \
-                        $file_id \
-                        $width \
-                        $height]
-            } else {
-                return [qc::image_data \
-                        $cache_dir \
-                        $file_id \
-                        $width \
-                        $height]
+            if { ! [qc::_image_cache_original_exists $cache_dir $file_id] } {
+                # Cache the original image.
+                qc::_image_cache_original_create $cache_dir $file_id
             }
 
-            
+            if { $mime_type eq "*/*" } {
+                set mime_type [qc::mime_type_guess \
+                                   [qc::_image_cache_original_file \
+                                        $cache_dir $file_id]]
+            }
+
+            if { $mime_type ne "image/svg+xml" } {
+                qc::_image_cache_create \
+                    $cache_dir \
+                    $file_id \
+                    $mime_type \
+                    $width \
+                    $height \
+                    $autocrop
+            }
+
         } on error [list message options] {
             set task_state "ERROR"
 

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -256,6 +256,7 @@ test image_data-1.1 \
     -cleanup $cleanup \
     -body {
         qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
+
         set data [qc::image_data \
                       -check_queue \
                       -- \
@@ -263,10 +264,20 @@ test image_data-1.1 \
                       $file_id \
                       $new_width \
                       $new_height]
+        set filename "${new_width}x${new_height}.png"
+        set url [qc::url "https://via.placeholder.com/:filename" \
+                     filename $filename \
+                     text "queued for processing" \
+                    ]
+        set expected [dict create \
+                          width $new_width \
+                          height $new_height \
+                          url $url \
+                         ]
 
-        return $data
+        return [qc::dicts_equal $expected $data]
     } \
-    -result {width ? height ? url ?}
+    -result true
 
 test image_data-1.2 \
     {Check that a placeholder image is returned when the image is queued to be
@@ -290,10 +301,20 @@ test image_data-1.2 \
                       $file_id \
                       $new_width \
                       $new_height]
+        set filename "${new_width}x${new_height}.png"
+        set url [qc::url "https://via.placeholder.com/:filename" \
+                     filename $filename \
+                     text "queued for processing" \
+                    ]
+        set expected [dict create \
+                          width $new_width \
+                          height $new_height \
+                          url $url \
+                         ]
 
-        return $data
+        return [qc::dicts_equal $expected $data]
     } \
-    -result {width ? height ? url ?}
+    -result true
 
 test image_data-1.3 \
     {Check that the image is cached at the requested dimensions immediately

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -1,0 +1,251 @@
+package require tcltest
+package require Pgtcl
+namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
+
+if { [info commands ns_db] ne "ns_db" } {
+    # Load all .tcl files
+    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    foreach file $files {
+        source $file
+    }
+    namespace import ::qc::*
+
+    # Superuser credentials
+    set pgpass_filename $::env(HOME)/.pgpass
+    if { [pgpass_credentials_exist $pgpass_filename template1] } {
+        dict2vars [pgpass_credentials $pgpass_filename template1] {*}{
+            hostname
+            database
+            port
+            username
+            password
+        }
+    } else {
+        error "Missing pgpass entry for db template1"
+    }
+    set ::conn_info_superuser(host) $hostname
+    set ::conn_info_superuser(dbname) $database
+    set ::conn_info_superuser(port) $port
+    set ::conn_info_superuser(user) $username
+    set ::conn_info_superuser(password) $password
+
+    # initialise db credentials
+
+    set ::conn_info_test(host) $hostname
+    set ::conn_info_test(port) $port
+    array set ::conn_info_test {
+        dbname test_database
+        user test_user
+        password test_password
+    }
+}
+
+set db_setup_qry {
+    create type image_resize_task_state as enum (
+        'QUEUED',
+        'PROCESSED',
+        'ERROR'
+    );
+
+    create table if not exists file (
+        file_id int primary key,
+        user_id int not null,
+        filename text not null,
+        data bytea,
+        upload_date timestamp without time zone default now(),
+        mime_type text not null,
+        s3_location text
+    );
+
+    create table if not exists image (
+        file_id int primary key references file(file_id) on delete cascade,
+        width int,
+        height int,
+        autocrop_width int,
+        autocrop_height int
+    );
+
+    create table if not exists image_resize_task (
+        row_id int primary key,
+        file_id int not null references image(file_id) on delete cascade,
+        cache_dir text not null,
+        height int not null,
+        width int not null,
+        date_added timestamptz not null,
+        date_processed timestamptz,
+        task_state image_resize_task_state not null
+    );
+
+    create sequence if not exists file_id_seq;
+    create sequence if not exists row_id_seq;
+}
+
+set db_cleanup_qry {
+    drop table image_resize_task;
+    drop table image;
+    drop table file;
+    drop type image_resize_task_state;
+    drop sequence file_id_seq;
+    drop sequence row_id_seq;
+}
+
+set setup_inside_naviserver {
+    set db [qc::db_get_handle]
+    ns_db dml $db $db_setup_qry
+}
+
+set setup_outside_naviserver {
+    set conn_superuser [pg_connect -connlist [array get ::conn_info_superuser]]
+    pg_execute $conn_superuser {create database test_database}
+    pg_execute $conn_superuser {
+        create user test_user with password 'test_password';
+        grant all privileges on database test_database to test_user;
+    }
+    pg_disconnect $conn_superuser
+
+    set conn [qc::db_connect {*}[array get ::conn_info_test]]
+    pg_execute $conn $db_setup_qry
+}
+
+set cleanup_inside_naviserver {
+    # Cleanup the qc::db connection
+    set db [qc::db_get_handle]
+    ns_db dml $db $db_cleanup_qry
+}
+
+set cleanup_outside_naviserver {
+    set conn [qc::db_connect {*}[array get ::conn_info_test]]
+    pg_execute $conn $db_cleanup_qry
+    qc::db_disconnect
+
+    set conn_superuser [pg_connect -connlist [array get ::conn_info_superuser]]
+    pg_execute $conn_superuser {
+        drop database if exists test_database
+    }
+    pg_execute $conn_superuser {
+        drop role if exists test_user;
+    }
+    pg_disconnect $conn_superuser
+}
+
+set data_setup {
+    proc ns_pagepath {} {
+        return ""
+    }
+
+    set user_id 0
+
+    qc::auth_as_user $user_id
+
+    qc::db_trans_start
+
+    set filename "logo_qcode_420x120.png"
+    set mime_type "image/png"
+    set width 420
+    set height 120
+    set id [open "./images/${filename}" r]
+    fconfigure $id -translation binary
+    set data [base64::encode [read $id]]
+    close $id
+    set file_id [qc::db_seq "file_id_seq"]
+
+    db_dml {
+        insert into file (
+            file_id,
+            user_id,
+            filename,
+            data,
+            mime_type
+        ) values (
+            :file_id,
+            :user_id,
+            :filename,
+            decode(:data, 'base64'),
+            :mime_type
+        );
+    }
+
+    set cache_dir "/tmp/image-cache-test"
+    set dir_created false
+
+    if { ![file exists $cache_dir] } {
+        file mkdir $cache_dir
+        set dir_created true
+    }
+
+    db_dml "
+        insert into image
+        [qc::sql_insert {*}{
+            file_id
+            height
+            width
+        }]
+    "
+
+    set original_width $width
+    set original_height $height
+    set new_width 210
+    set new_height 60
+}
+
+set data_cleanup {
+    qc::db_trans_abort
+    qc::auth_logout
+
+    if { $dir_created } {
+        file delete -force $cache_dir
+    } else {
+        set filename "${file_id}.png"
+        set img_dir_original "${file_id}-${original_width}x${original_height}"
+        set cache_dir_original "${cache_dir}/${img_dir_original}"
+
+        if { [file exists "${cache_dir_original}/${filename}"] } {
+            file delete -force $cache_dir_original
+        }
+
+        set img_dir_resize "${file_id}-${new_width}x${new_height}"
+        set cache_dir_resize "${cache_dir}/${img_dir_resize}"
+
+        if { [file exists "${cache_dir_resize}/${filename}"] } {
+            file delete -force $cache_dir_resize
+        }
+    }
+}
+
+if { [info commands ns_db] eq "ns_db" } {
+    set setup $setup_inside_naviserver
+    append setup $data_setup
+
+    set cleanup $data_cleanup
+    append cleanup $cleanup_inside_naviserver
+} else {
+    set setup $setup_outside_naviserver
+    append setup $data_setup
+
+    set cleanup $data_cleanup
+    append cleanup $cleanup_outside_naviserver
+}
+
+test image_resize_task_process-1.0 \
+    {Check that an image resize task can be processed.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        # what to do if image isn't queued and isn't cached?
+        #   1. queue and return placeholder
+        #   2. attempt to process on the fly
+        # what to do about autocrop?
+        qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
+        set data [qc::image_data \
+                      -check_queue \
+                      -- \
+                      $cache_dir \
+                      $file_id \
+                      $new_width \
+                      $new_height]
+
+        return $data
+    } \
+    -result {width 100 height 100 url ?}
+
+cleanupTests

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -297,7 +297,7 @@ test image_data-1.2 \
 
 test image_data-1.3 \
     {Check that the image is cached at the requested dimensions immediately
-     despite it already being queued to be processed.} \
+     when it is queued to be processed but caller does not specify -check_queue.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -71,6 +71,7 @@ set db_setup_qry {
         cache_dir text not null,
         height int not null,
         width int not null,
+        autocrop boolean not null,
         date_added timestamptz not null,
         date_processed timestamptz,
         task_state image_resize_task_state not null
@@ -195,20 +196,20 @@ set data_cleanup {
     if { $dir_created } {
         file delete -force $cache_dir
     } else {
-        set filename "${file_id}.png"
         set img_dir_original "${file_id}-${original_width}x${original_height}"
         set cache_dir_original "${cache_dir}/${img_dir_original}"
-
-        if { [file exists "${cache_dir_original}/${filename}"] } {
-            file delete -force $cache_dir_original
-        }
-
         set img_dir_resize "${file_id}-${new_width}x${new_height}"
         set cache_dir_resize "${cache_dir}/${img_dir_resize}"
+        set cache_dir_autocrop "${cache_dir}/${file_id}"
+        set img_link "${cache_dir}/${file_id}.png"
 
-        if { [file exists "${cache_dir_resize}/${filename}"] } {
-            file delete -force $cache_dir_resize
-        }
+        file delete \
+            -force \
+            -- \
+            $cache_dir_original \
+            $cache_dir_resize \
+            $cache_dir_autocrop \
+            $img_link
     }
 }
 
@@ -226,15 +227,34 @@ if { [info commands ns_db] eq "ns_db" } {
     append cleanup $cleanup_outside_naviserver
 }
 
-test image_resize_task_process-1.0 \
-    {Check that an image resize task can be processed.} \
+test image_data-1.0 \
+    {Check that the image is cached at the width and height.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
-        # what to do if image isn't queued and isn't cached?
-        #   1. queue and return placeholder
-        #   2. attempt to process on the fly
-        # what to do about autocrop?
+        set data [qc::image_data \
+                      -- \
+                      $cache_dir \
+                      $file_id \
+                      $new_width \
+                      $new_height]
+        set file_url "${cache_dir}/${file_id}-${new_width}x${new_height}/${file_id}.png"
+        set expected [dict create \
+                          width $new_width \
+                          height $new_height \
+                          url $file_url \
+                         ]
+
+        return [qc::dicts_equal $expected $data]
+    } \
+    -result true
+
+test image_data-1.1 \
+    {Check that a placeholder image is returned when the image is queued to be
+     cached at requested dimensions and the caller uses the -check_queue option.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
         qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
         set data [qc::image_data \
                       -check_queue \
@@ -246,6 +266,117 @@ test image_resize_task_process-1.0 \
 
         return $data
     } \
-    -result {width 100 height 100 url ?}
+    -result {width ? height ? url ?}
+
+test image_data-1.2 \
+    {Check that a placeholder image is returned when the image is queued to be
+     cached at requested autocropped dimensions and the caller uses the
+     -check_queue option.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        qc::image_resize_task_add \
+            $file_id \
+            $cache_dir \
+            $new_width \
+            $new_height \
+            true
+
+        set data [qc::image_data \
+                      -autocrop \
+                      -check_queue \
+                      -- \
+                      $cache_dir \
+                      $file_id \
+                      $new_width \
+                      $new_height]
+
+        return $data
+    } \
+    -result {width ? height ? url ?}
+
+test image_data-1.3 \
+    {Check that the image is cached at the requested dimensions immediately
+     despite it already being queued to be processed.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
+
+        set data [qc::image_data \
+                      -- \
+                      $cache_dir \
+                      $file_id \
+                      $new_width \
+                      $new_height]
+        set file_url "${cache_dir}/${file_id}-${new_width}x${new_height}/${file_id}.png"
+        set expected [dict create \
+                          width $new_width \
+                          height $new_height \
+                          url $file_url \
+                         ]
+
+        return [qc::dicts_equal $expected $data]
+    } \
+    -result true
+
+test image_data-1.4 \
+    {Check that the image is autocropped and cached at the requested dimensions
+     immediately when it has been queued to be processed at the same dimensions
+     without autocropping.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
+
+        set data [qc::image_data \
+                      -autocrop \
+                      -- \
+                      $cache_dir \
+                      $file_id \
+                      $new_width \
+                      $new_height]
+        set file_url "${cache_dir}/${file_id}/autocrop/210x58/${file_id}.png"
+        set expected [dict create \
+                          width 210 \
+                          height 58 \
+                          url $file_url \
+                         ]
+
+        return [qc::dicts_equal $expected $data]
+    } \
+    -result true
+
+test image_data-1.5 \
+    {Check that the image is cached at the requested dimensions immediately when
+     it has been queued to be processed at the same dimensions with autocropping.
+     without autocropping.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        qc::image_resize_task_add \
+            $file_id \
+            $cache_dir \
+            $new_width \
+            $new_height \
+            true
+
+        set data [qc::image_data \
+                      -check_queue \
+                      -- \
+                      $cache_dir \
+                      $file_id \
+                      $new_width \
+                      $new_height]
+        set file_url "${cache_dir}/${file_id}-${new_width}x${new_height}/${file_id}.png"
+        set expected [dict create \
+                          width $new_width \
+                          height $new_height \
+                          url $file_url \
+                         ]
+
+        return [qc::dicts_equal $expected $data]
+    } \
+    -result true
 
 cleanupTests

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -228,104 +228,88 @@ if { [info commands ns_db] eq "ns_db" } {
 }
 
 test image_data-1.0 \
-    {Check that the image is cached at the width and height.} \
+    {Check that the image is queued to be cached and a placeholder is returned.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
         set data [qc::image_data \
-                      -- \
                       $cache_dir \
                       $file_id \
                       $new_width \
                       $new_height]
-        set file_url "${cache_dir}/${file_id}-${new_width}x${new_height}/${file_id}.png"
+
+        qc::db_0or1row {
+            select
+            true as queued
+
+            from
+            image_resize_task
+
+            where
+            file_id=:file_id
+            and width=:new_width
+            and height=:new_height
+            and cache_dir=:cache_dir
+            and not autocrop
+            and task_state = 'QUEUED'
+        } {
+            return false
+        }
+
+        set filename "${new_width}x${new_height}.png"
+        set url [qc::url "https://via.placeholder.com/:filename" \
+                     filename $filename \
+                     text "queued for processing"]
         set expected [dict create \
                           width $new_width \
                           height $new_height \
-                          url $file_url \
-                         ]
+                          url $url]
 
         return [qc::dicts_equal $expected $data]
     } \
     -result true
 
 test image_data-1.1 \
-    {Check that a placeholder image is returned when the image is queued to be
-     cached at requested dimensions and the caller uses the -check_queue option.} \
+    {Check that the image is queued to be autocropped, cached, and a placeholder
+     is returned.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
-        qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
-
         set data [qc::image_data \
-                      -check_queue \
+                      -autocrop \
                       -- \
                       $cache_dir \
                       $file_id \
                       $new_width \
                       $new_height]
+
         set filename "${new_width}x${new_height}.png"
         set url [qc::url "https://via.placeholder.com/:filename" \
                      filename $filename \
-                     text "queued for processing" \
-                    ]
+                     text "queued for processing"]
         set expected [dict create \
                           width $new_width \
                           height $new_height \
-                          url $url \
-                         ]
+                          url $url]
 
         return [qc::dicts_equal $expected $data]
     } \
     -result true
 
 test image_data-1.2 \
-    {Check that a placeholder image is returned when the image is queued to be
-     cached at requested autocropped dimensions and the caller uses the
-     -check_queue option.} \
+    {Check that the cached image data is returned.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
-        qc::image_resize_task_add \
-            $file_id \
-            $cache_dir \
-            $new_width \
-            $new_height \
-            true
+        set row_id [qc::image_resize_task_add \
+                        $file_id \
+                        $cache_dir \
+                        $new_width \
+                        $new_height]
+
+        qc::image_resize_task_process $row_id
 
         set data [qc::image_data \
-                      -autocrop \
-                      -check_queue \
-                      -- \
-                      $cache_dir \
-                      $file_id \
-                      $new_width \
-                      $new_height]
-        set filename "${new_width}x${new_height}.png"
-        set url [qc::url "https://via.placeholder.com/:filename" \
-                     filename $filename \
-                     text "queued for processing" \
-                    ]
-        set expected [dict create \
-                          width $new_width \
-                          height $new_height \
-                          url $url \
-                         ]
-
-        return [qc::dicts_equal $expected $data]
-    } \
-    -result true
-
-test image_data-1.3 \
-    {Check that the image is cached at the requested dimensions immediately
-     when it is queued to be processed but caller does not specify -check_queue.} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
-
-        set data [qc::image_data \
-                      -- \
                       $cache_dir \
                       $file_id \
                       $new_width \
@@ -334,67 +318,7 @@ test image_data-1.3 \
         set expected [dict create \
                           width $new_width \
                           height $new_height \
-                          url $file_url \
-                         ]
-
-        return [qc::dicts_equal $expected $data]
-    } \
-    -result true
-
-test image_data-1.4 \
-    {Check that the image is autocropped and cached at the requested dimensions
-     immediately when it has been queued to be processed at the same dimensions
-     without autocropping.} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        qc::image_resize_task_add $file_id $cache_dir $new_width $new_height
-
-        set data [qc::image_data \
-                      -autocrop \
-                      -- \
-                      $cache_dir \
-                      $file_id \
-                      $new_width \
-                      $new_height]
-        set file_url "${cache_dir}/${file_id}/autocrop/210x58/${file_id}.png"
-        set expected [dict create \
-                          width 210 \
-                          height 58 \
-                          url $file_url \
-                         ]
-
-        return [qc::dicts_equal $expected $data]
-    } \
-    -result true
-
-test image_data-1.5 \
-    {Check that the image is cached at the requested uncropped dimensions
-     immediately when it has been queued to be processed at the same dimensions
-     with autocropping.} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        qc::image_resize_task_add \
-            $file_id \
-            $cache_dir \
-            $new_width \
-            $new_height \
-            true
-
-        set data [qc::image_data \
-                      -check_queue \
-                      -- \
-                      $cache_dir \
-                      $file_id \
-                      $new_width \
-                      $new_height]
-        set file_url "${cache_dir}/${file_id}-${new_width}x${new_height}/${file_id}.png"
-        set expected [dict create \
-                          width $new_width \
-                          height $new_height \
-                          url $file_url \
-                         ]
+                          url $file_url]
 
         return [qc::dicts_equal $expected $data]
     } \

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -348,9 +348,9 @@ test image_data-1.4 \
     -result true
 
 test image_data-1.5 \
-    {Check that the image is cached at the requested dimensions immediately when
-     it has been queued to be processed at the same dimensions with autocropping.
-     without autocropping.} \
+    {Check that the image is cached at the requested uncropped dimensions
+     immediately when it has been queued to be processed at the same dimensions
+     with autocropping.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {

--- a/test/image_resize_task.test
+++ b/test/image_resize_task.test
@@ -71,6 +71,7 @@ set db_setup_qry {
         cache_dir text not null,
         height int not null,
         width int not null,
+        autocrop boolean not null,
         date_added timestamptz not null,
         date_processed timestamptz,
         task_state image_resize_task_state not null
@@ -195,20 +196,20 @@ set data_cleanup {
     if { $dir_created } {
         file delete -force $cache_dir
     } else {
-        set filename "${file_id}.png"
         set img_dir_original "${file_id}-${original_width}x${original_height}"
         set cache_dir_original "${cache_dir}/${img_dir_original}"
-
-        if { [file exists "${cache_dir_original}/${filename}"] } {
-            file delete -force $cache_dir_original
-        }
-
         set img_dir_resize "${file_id}-${new_width}x${new_height}"
         set cache_dir_resize "${cache_dir}/${img_dir_resize}"
+        set cache_dir_autocrop "${cache_dir}/${file_id}"
+        set img_link "${cache_dir}/${file_id}.png"
 
-        if { [file exists "${cache_dir_resize}/${filename}"] } {
-            file delete -force $cache_dir_resize
-        }
+        file delete \
+            -force \
+            -- \
+            $cache_dir_original \
+            $cache_dir_resize \
+            $cache_dir_autocrop \
+            $img_link
     }
 }
 
@@ -265,6 +266,37 @@ test image_resize_task_process-1.0 \
     -cleanup $cleanup \
     -body {
         set row_id [qc::image_resize_task_add $file_id $cache_dir $new_width $new_height]
+
+        qc::image_resize_task_process $row_id
+
+        set expected "PROCESSED"
+
+        qc::db_1row {
+            select
+            task_state
+
+            from
+            image_resize_task
+
+            where
+            row_id=:row_id
+        }
+
+        return [expr {$expected eq $task_state}]
+    } \
+    -result 1
+
+test image_resize_task_process-1.1 \
+    {Check that an autocrop image resize task can be processed.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        set row_id [qc::image_resize_task_add \
+                        $file_id \
+                        $cache_dir \
+                        $new_width \
+                        $new_height \
+                        true]
 
         qc::image_resize_task_process $row_id
 

--- a/test/image_resize_task.test
+++ b/test/image_resize_task.test
@@ -273,16 +273,28 @@ test image_resize_task_process-1.0 \
 
         qc::db_1row {
             select
-            task_state
+            i.task_state,
+            f.mime_type
 
             from
-            image_resize_task
+            image_resize_task i
+            join file f using (file_id)
 
             where
-            row_id=:row_id
+            i.row_id=:row_id
         }
 
-        return [expr {$expected eq $task_state}]
+        return [expr {
+                      $expected eq $task_state
+                      && [qc::_image_cache_original_exists $cache_dir $file_id]
+                      && [qc::image_cache_exists \
+                              -mime_type $mime_type \
+                              -- \
+                              $cache_dir \
+                              $file_id \
+                              $width \
+                              $height]
+                  }]
     } \
     -result 1
 
@@ -304,16 +316,29 @@ test image_resize_task_process-1.1 \
 
         qc::db_1row {
             select
-            task_state
+            i.task_state,
+            f.mime_type
 
             from
-            image_resize_task
+            image_resize_task i
+            join file f using (file_id)
 
             where
-            row_id=:row_id
+            i.row_id=:row_id
         }
 
-        return [expr {$expected eq $task_state}]
+        return [expr {
+                      $expected eq $task_state
+                      && [qc::_image_cache_original_exists $cache_dir $file_id]
+                      && [qc::image_cache_exists \
+                              -autocrop \
+                              -mime_type $mime_type \
+                              -- \
+                              $cache_dir \
+                              $file_id \
+                              210 \
+                              58]
+                  }]
     } \
     -result 1
 


### PR DESCRIPTION
Tcl
----
- [x] Does each proc have a #| comment to describe what it does?
- [x] Are there comments throughout the code?
- [x] Is each proc unit testable?
- [x] Are the proc names well chosen ?
- [x] Are families of procs named with a prefix and stored in the same file?
- [x] Are variable names well chosen?
- [x] Are line lengths all about 80 to 90 characters?
- [x] Security: Is user input sanitised?
- [x] Security: Is substitution protected from injection attacks?


SQL
------
- [x] Are long sql queries formatted well ?


Testing
---
#### New Unit Tests

```
tclsh image_cache.test
image_cache.test:	Total	6	Passed	6	Skipped	0	Failed	0
```
```
tclsh image_resize_task.test
image_resize_task.test:	Total	3	Passed	3	Skipped	0	Failed	0
```

#### All Tests
```
tclsh all.tcl
Tests running in interp:  /usr/bin/tclsh
Tests located in:  /home/nick/qcode-tcl/test
Tests running in:  /home/nick/qcode-tcl/test
Temporary files stored in /home/nick/qcode-tcl/test
Test files run in separate interpreters
Running tests that match:  *
Skipping test files that match:  l.*.test
Only running test files that match:  *.test
Tests began at Fri Feb 05 13:00:38 GMT 2021
_s3.test
args.test
auth.test
binary_convert.test
cast.test
castable.test
check.test
conn.test
conn_location.test
cookie.test
crypt.test
css_selector2xpath.test
csv.test
date.test
db.test
db_file.test
writing /tmp/aRfv9fkqcy ...
written
Timeout set at 60 seconds
writing /tmp/KFkrJALrly ...
written
Timeout set at 60 seconds
writing /tmp/T0RDuR12L4 ...
written
db_trans.test
dict.test
dict_intersect.test
dict_is_subset.test
email.test
file.test
writing /tmp/n6pgiELacF ...
written
writing /tmp/zsw39yXRTb ...
written
form_layout.test
format.test
format_date.test
format_timestamp.test
html.test
html_options.test
html_table.test
html_table_doc.test
html_table_scroll.test
http.test
image_cache.test
image_resize_task.test
is.test
ldict.test
ll.test
math.test
multimap.test
my.test
password.test
perl.test
perm.test
pgpass.test
response.test
response_login.test
response_redirect.test
return_next.test
s3.test
===========================================================================================
===== Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file =======
===========================================================================================
Test file error: Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file
    while executing
"error "Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file""
    invoked from within
"if { ![info exists ::env(aws_s3_test_bucket)] } {
    puts "==========================================================================================..."
    (file "/home/nick/qcode-tcl/test/s3.test" line 17)
s3_uri.test
soap.test
sort.test
sql.test
sql_where.test
sql_where_in.test
style.test
table.test
tabular_text.test
tson.test
upset.test
url.test
user_agent.test
util.test
util_list.test
util_string.test
widget.test
xml.test

Tests ended at Fri Feb 05 13:01:02 GMT 2021
all.tcl:	Total	1651	Passed	1638	Skipped	13	Failed	0
Sourced 67 Test Files.
Number of tests skipped for each constraint:
	1	earlier_than_8.5
	12	knownBug

Test files exiting with errors:  

  s3.test
```