### PR TITLE
Image Data & Image Resize Task Updates

### DIFF
--- a/tcl/db.tcl
+++ b/tcl/db.tcl
@@ -637,3 +637,16 @@ proc qc::db_disconnect {} {
     pg_disconnect $_db
     unset _db
 }
+
+proc qc::db_advisory_trans_lock {class object} {
+    #| Obtain exclusive transaction level advisory lock on an application-defined resource.
+    #  class: identifies the class of resource to be locked
+    #  object: identifies the individual resource to be locked
+
+    # convert class and object identifiers to a 32 bit signed integers
+    set class_id [expr {[crc::crc32 $class] -  (4294967295 + 1)/2}]
+    set object_id [expr {[crc::crc32 $object] -  (4294967295 + 1)/2}]
+
+    # obtain advisory lock
+    db_1row {select pg_advisory_xact_lock(:class_id,:object_id)}
+}

--- a/tcl/db.tcl
+++ b/tcl/db.tcl
@@ -1,3 +1,5 @@
+package require crc32
+
 namespace eval qc {
     namespace export db_*
 }

--- a/tcl/image_cache.tcl
+++ b/tcl/image_cache.tcl
@@ -25,12 +25,24 @@ proc qc::image_data {args} {
     if { ! [qc::image_cache_exists {*}$caller_args] } {
         # Queue the image to be cached and return a placeholder.
 
-        qc::image_resize_task_add \
-            $file_id \
-            $cache_dir \
-            $max_width \
-            $max_height \
-            $autocrop
+        if { $autocrop } {
+            qc::image_resize_task_add \
+                -autocrop \
+                -mime_type $mime_type \
+                -cache_dir $cache_dir \
+                -- \
+                $file_id \
+                $max_width \
+                $max_height
+        } else {
+            qc::image_resize_task_add \
+                -mime_type $mime_type \
+                -cache_dir $cache_dir \
+                -- \
+                $file_id \
+                $max_width \
+                $max_height
+        }
 
         set filename "${max_width}x${max_height}.png"
         set url [qc::url "https://via.placeholder.com/:filename" \

--- a/tcl/image_resize_task.tcl
+++ b/tcl/image_resize_task.tcl
@@ -4,14 +4,39 @@ namespace eval qc {
         image_resize_task_process
 }
 
-proc qc::image_resize_task_add {
-    file_id
-    cache_dir
-    width
-    height
-    {autocrop false}
-} {
+proc qc::image_resize_task_add {args} {
     #| Add a new resize task for an image in the database.
+
+    qc::args $args {*}{
+        -autocrop
+        -mime_type "*/*"
+        -cache_dir ""
+        --
+        file_id
+        width
+        height
+    }
+
+    default autocrop false
+
+    if { $cache_dir eq "" } {
+        set cache_dir [ns_pagepath]/image
+    }
+
+    if { $mime_type eq "*/*" } {
+        db_1row {
+            select
+            mime_type
+
+            from
+            file
+
+            where
+            file_id=:file_id
+        }
+    }
+
+    # obtain an advisory lock
 
     db_0or1row {
         select
@@ -25,6 +50,7 @@ proc qc::image_resize_task_add {
         and cache_dir=:cache_dir
         and autocrop=:autocrop
         and task_state = 'QUEUED'
+        and mime_type=:mime_type
         and (
              (
               width=:width
@@ -53,86 +79,10 @@ proc qc::image_resize_task_add {
                 date_added
                 task_state
                 autocrop
+                mime_type
             }]
         "
     }
 
     return $row_id
-}
-
-proc qc::image_resize_task_process { row_id } {
-    #| Resize and cache the image from the task queue.
-
-    db_trans {
-        db_0or1row {
-            select
-            i.file_id,
-            i.cache_dir,
-            i.height,
-            i.width,
-            i.autocrop,
-            f.mime_type
-
-            from
-            image_resize_task i
-            join file f using (file_id)
-
-            where
-            i.row_id=:row_id
-            and i.task_state = 'QUEUED'
-
-            for update
-        } {
-            error "No queued image resize task exists for row ${row_id}."
-        }
-
-        set date_processed [qc::cast timestamptz "now"]
-
-        ::try {
-            set task_state "PROCESSED"
-
-            if { ! [qc::_image_cache_original_exists $cache_dir $file_id] } {
-                # Cache the original image.
-                qc::_image_cache_original_create $cache_dir $file_id
-            }
-
-            if { $mime_type eq "*/*" } {
-                set mime_type [qc::mime_type_guess \
-                                   [qc::_image_cache_original_file \
-                                        $cache_dir $file_id]]
-            }
-
-            if { $mime_type ne "image/svg+xml" } {
-                qc::_image_cache_create \
-                    $cache_dir \
-                    $file_id \
-                    $mime_type \
-                    $width \
-                    $height \
-                    $autocrop
-            }
-
-        } on error [list message options] {
-            set task_state "ERROR"
-
-            error \
-                $message \
-                [dict get $options -errorinfo] \
-                [dict get $options -errorcode]
-        } finally {
-            db_dml "
-                update
-                image_resize_task
-
-                set
-                [qc::sql_set {*}{
-                    task_state
-                    date_processed
-                }]
-
-                where
-                row_id=:row_id
-            "
-        }
-    }
 }

--- a/tcl/image_resize_task.tcl
+++ b/tcl/image_resize_task.tcl
@@ -1,9 +1,6 @@
-package require crc32
-
 namespace eval qc {
     namespace export \
-        image_resize_task_add \
-        image_resize_task_process
+        image_resize_task_add
 }
 
 proc qc::image_resize_task_add {args} {

--- a/test/db.test
+++ b/test/db.test
@@ -153,4 +153,29 @@ test db_col_varchar_length-1.0 {db_col_varchar_length} -setup $setup -cleanup $c
     db_col_varchar_length courses title
 } -result 40
 
+# db_advisory_trans_lock
+test db_advisory_trans_lock-1.0 \
+    {Check the advisory transaction level lock works.} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        db_trans {
+            qc::db_advisory_trans_lock students test
+
+            db_1row {
+                select
+                firstname
+
+                from
+                students
+
+                where
+                student_id = 012345
+            }
+        }
+
+        return $firstname
+    } \
+    -result "John"
+
 cleanupTests

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -74,7 +74,8 @@ set db_setup_qry {
         autocrop boolean not null,
         date_added timestamptz not null,
         date_processed timestamptz,
-        task_state image_resize_task_state not null
+        task_state image_resize_task_state not null,
+        mime_type text not null
     );
 
     create sequence if not exists file_id_seq;
@@ -233,6 +234,8 @@ test image_data-1.0 \
     -cleanup $cleanup \
     -body {
         set data [qc::image_data \
+                      -mime_type $mime_type \
+                      -- \
                       $cache_dir \
                       $file_id \
                       $new_width \
@@ -250,6 +253,7 @@ test image_data-1.0 \
             and width=:new_width
             and height=:new_height
             and cache_dir=:cache_dir
+            and mime_type=:mime_type
             and not autocrop
             and task_state = 'QUEUED'
         } {
@@ -270,18 +274,37 @@ test image_data-1.0 \
     -result true
 
 test image_data-1.1 \
-    {Check that the image is queued to be autocropped, cached, and a placeholder
-     is returned.} \
+    {Check that the image is queued to be autocropped and a placeholder is returned.} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
         set data [qc::image_data \
                       -autocrop \
+                      -mime_type $mime_type \
                       -- \
                       $cache_dir \
                       $file_id \
                       $new_width \
                       $new_height]
+
+        qc::db_0or1row {
+            select
+            true as queued
+
+            from
+            image_resize_task
+
+            where
+            file_id=:file_id
+            and width=:new_width
+            and height=:new_height
+            and cache_dir=:cache_dir
+            and mime_type=:mime_type
+            and autocrop
+            and task_state = 'QUEUED'
+        } {
+            return false
+        }
 
         set filename "${new_width}x${new_height}.png"
         set url [qc::url "https://via.placeholder.com/:filename" \
@@ -301,15 +324,17 @@ test image_data-1.2 \
     -setup $setup \
     -cleanup $cleanup \
     -body {
-        set row_id [qc::image_resize_task_add \
-                        $file_id \
-                        $cache_dir \
-                        $new_width \
-                        $new_height]
-
-        qc::image_resize_task_process $row_id
+        qc::_image_cache_create \
+            $cache_dir \
+            $file_id \
+            $mime_type \
+            $new_width \
+            $new_height \
+            false
 
         set data [qc::image_data \
+                      -mime_type $mime_type \
+                      -- \
                       $cache_dir \
                       $file_id \
                       $new_width \

--- a/test/image_resize_task.test
+++ b/test/image_resize_task.test
@@ -74,7 +74,8 @@ set db_setup_qry {
         autocrop boolean not null,
         date_added timestamptz not null,
         date_processed timestamptz,
-        task_state image_resize_task_state not null
+        task_state image_resize_task_state not null,
+        mime_type text not null
     );
 
     create sequence if not exists file_id_seq;
@@ -144,6 +145,8 @@ set data_setup {
     set mime_type "image/png"
     set width 420
     set height 120
+    set new_width 210
+    set new_height 60
     set id [open "./images/${filename}" r]
     fconfigure $id -translation binary
     set data [base64::encode [read $id]]
@@ -167,12 +170,6 @@ set data_setup {
     }
 
     set cache_dir "/tmp/image-cache-test"
-    set dir_created false
-
-    if { ![file exists $cache_dir] } {
-        file mkdir $cache_dir
-        set dir_created true
-    }
 
     db_dml "
         insert into image
@@ -182,35 +179,11 @@ set data_setup {
             width
         }]
     "
-
-    set original_width $width
-    set original_height $height
-    set new_width 210
-    set new_height 60
 }
 
 set data_cleanup {
     qc::db_trans_abort
     qc::auth_logout
-
-    if { $dir_created } {
-        file delete -force $cache_dir
-    } else {
-        set img_dir_original "${file_id}-${original_width}x${original_height}"
-        set cache_dir_original "${cache_dir}/${img_dir_original}"
-        set img_dir_resize "${file_id}-${new_width}x${new_height}"
-        set cache_dir_resize "${cache_dir}/${img_dir_resize}"
-        set cache_dir_autocrop "${cache_dir}/${file_id}"
-        set img_link "${cache_dir}/${file_id}.png"
-
-        file delete \
-            -force \
-            -- \
-            $cache_dir_original \
-            $cache_dir_resize \
-            $cache_dir_autocrop \
-            $img_link
-    }
 }
 
 if { [info commands ns_db] eq "ns_db" } {
@@ -232,7 +205,13 @@ test image_resize_task_add-1.0 \
     -setup $setup \
     -cleanup $cleanup \
     -body {
-        set row_id [qc::image_resize_task_add $file_id $cache_dir $new_width $new_height]
+        set row_id [qc::image_resize_task_add \
+                        -mime_type $mime_type \
+                        -cache_dir $cache_dir \
+                        -- \
+                        $file_id \
+                        $new_width \
+                        $new_height]
         set task_state "QUEUED"
         set expected [qc::dict_from {*}{
             file_id
@@ -240,6 +219,7 @@ test image_resize_task_add-1.0 \
             new_height
             new_width
             task_state
+            mime_type
         }]
         set task [lindex [qc::db_select_ldict {
             select
@@ -247,7 +227,8 @@ test image_resize_task_add-1.0 \
             cache_dir,
             height as new_height,
             width as new_width,
-            task_state
+            task_state,
+            mime_type
 
             from
             image_resize_task
@@ -259,87 +240,5 @@ test image_resize_task_add-1.0 \
         return [qc::dicts_equal $expected $task]
     } \
     -result true
-
-test image_resize_task_process-1.0 \
-    {Check that an image resize task can be processed.} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        set row_id [qc::image_resize_task_add $file_id $cache_dir $new_width $new_height]
-
-        qc::image_resize_task_process $row_id
-
-        set expected "PROCESSED"
-
-        qc::db_1row {
-            select
-            i.task_state,
-            f.mime_type
-
-            from
-            image_resize_task i
-            join file f using (file_id)
-
-            where
-            i.row_id=:row_id
-        }
-
-        return [expr {
-                      $expected eq $task_state
-                      && [qc::_image_cache_original_exists $cache_dir $file_id]
-                      && [qc::image_cache_exists \
-                              -mime_type $mime_type \
-                              -- \
-                              $cache_dir \
-                              $file_id \
-                              $width \
-                              $height]
-                  }]
-    } \
-    -result 1
-
-test image_resize_task_process-1.1 \
-    {Check that an autocrop image resize task can be processed.} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        set row_id [qc::image_resize_task_add \
-                        $file_id \
-                        $cache_dir \
-                        $new_width \
-                        $new_height \
-                        true]
-
-        qc::image_resize_task_process $row_id
-
-        set expected "PROCESSED"
-
-        qc::db_1row {
-            select
-            i.task_state,
-            f.mime_type
-
-            from
-            image_resize_task i
-            join file f using (file_id)
-
-            where
-            i.row_id=:row_id
-        }
-
-        return [expr {
-                      $expected eq $task_state
-                      && [qc::_image_cache_original_exists $cache_dir $file_id]
-                      && [qc::image_cache_exists \
-                              -autocrop \
-                              -mime_type $mime_type \
-                              -- \
-                              $cache_dir \
-                              $file_id \
-                              210 \
-                              58]
-                  }]
-    } \
-    -result 1
 
 cleanupTests


### PR DESCRIPTION
Tcl
----
- [x] Does each proc have a #| comment to describe what it does?
- [x] Are there comments throughout the code?
- [x] Is each proc unit testable?
- [x] Are the proc names well chosen ?
- [x] Are families of procs named with a prefix and stored in the same file?
- [x] Are variable names well chosen?
- [x] Are line lengths all about 80 to 90 characters?
- [x] Security: Is user input sanitised?
- [x] Security: Is substitution protected from injection attacks?


SQL
------
- [x] Are long sql queries formatted well ?

Testing
---
```
tclsh image_resize_task.test
image_resize_task.test:	Total	1	Passed	1	Skipped	0	Failed	0
```
```
tclsh image_cache.test
image_cache.test:	Total	3	Passed	3	Skipped	0	Failed	0
```
```
tclsh all.tcl
Tests running in interp:  /usr/bin/tclsh
Tests located in:  /home/nick/qcode-tcl/test
Tests running in:  /home/nick/qcode-tcl/test
Temporary files stored in /home/nick/qcode-tcl/test
Test files run in separate interpreters
Running tests that match:  *
Skipping test files that match:  l.*.test
Only running test files that match:  *.test
Tests began at Fri Feb 12 13:59:17 GMT 2021
_s3.test
args.test
auth.test
binary_convert.test
cast.test
castable.test
check.test
conn.test
conn_location.test
cookie.test
crypt.test
css_selector2xpath.test
csv.test
date.test
db.test
db_file.test
db_trans.test
dict.test
dict_intersect.test
dict_is_subset.test
email.test
file.test
form_layout.test
format.test
format_date.test
format_timestamp.test
html.test
html_options.test
html_table.test
html_table_doc.test
html_table_scroll.test
http.test
image_cache.test
image_resize_task.test
is.test
ldict.test
ll.test
math.test
multimap.test
my.test
password.test
perl.test
perm.test
pgpass.test
response.test
response_login.test
response_redirect.test
return_next.test
s3.test
===========================================================================================
===== Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file =======
===========================================================================================
Test file error: Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file
    while executing
"error "Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file""
    invoked from within
"if { ![info exists ::env(aws_s3_test_bucket)] } {
    puts "==========================================================================================..."
    (file "/home/nick/qcode-tcl/test/s3.test" line 17)
s3_uri.test
soap.test
sort.test
sql.test
sql_where.test
sql_where_in.test
style.test
table.test
tabular_text.test
tson.test
upset.test
url.test
user_agent.test
util.test
util_list.test
util_string.test
widget.test
xml.test

Tests ended at Fri Feb 12 13:59:38 GMT 2021
all.tcl:	Total	1647	Passed	1634	Skipped	13	Failed	0
Sourced 67 Test Files.
Number of tests skipped for each constraint:
	1	earlier_than_8.5
	12	knownBug

Test files exiting with errors:  

  s3.test

```