### PR TITLE
Fix for the final separator being merged into the penultimate one

### DIFF
--- a/tcl/tabular_text.tcl
+++ b/tcl/tabular_text.tcl
@@ -58,8 +58,8 @@ proc qc::tabular_text_parse  {args} {
             set vertical_whitespaces [qc::lintersect $vertical_whitespaces [regexp -all -inline -indices {\s} $line]]
         }
     }
-    
-    # conbine consecutive vertical whitespace indices 
+
+    # Combine consecutive vertical whitespace indices 
     set column_separators {}
     set i 0
     set group_start 0
@@ -73,19 +73,21 @@ proc qc::tabular_text_parse  {args} {
             set group_start $start
             set group_end $end
         }
-        
-        if { $i == [llength $vertical_whitespaces] } {
-            # last vertical whitespace - close current group then add as column separator
-            set group_end $end
-            lappend column_separators [list $group_start $group_end]
-        } elseif { $start - $group_end > 1 } {
+
+        if { $start - $group_end > 1 } {
             # non-consequetive vertical whitespace - add column separator and start new group
             lappend column_separators [list $group_start $group_end]
             set group_start $start
             set group_end $end
         } else {
-            # consecutive vertical  whitespace - extend current group
+            # consecutive vertical whitespace - extend current group
             set group_end $end
+        }
+
+        if { $i == [llength $vertical_whitespaces] } {
+            # last vertical whitespace - close current group then add as column separator
+            set group_end $end
+            lappend column_separators [list $group_start $group_end]
         }
     }
     

--- a/test/tabular_text.test
+++ b/test/tabular_text.test
@@ -157,4 +157,21 @@ test tabular_text_parse-10.0 {tabular_text_parse - casting} \
     } \
     -result {{line_num value} {1 1234.22} {2 {Not a number}}}
 
+test tabular_text_parse-11.0 {tabular_text_parse - Single column white-spaces} -setup {
+} -body {
+    set lines [list]
+    lappend lines {a    b c d e}
+    lappend lines {1    2 3 4 5}
+    set text [join $lines \n]
+
+    set conf [list]
+    lappend conf [list label a var_name a]
+    lappend conf [list label b var_name b]
+    lappend conf [list label c var_name c]
+    lappend conf [list label d var_name d]
+    lappend conf [list label e var_name e]
+
+    return [qc::tabular_text_parse $text $conf]
+} -cleanup {} -result {{a b c d e} {1 2 3 4 5}}
+
 cleanupTests


### PR DESCRIPTION
## Changes
When merging consecutive white-spaces the final whitespace is always merged into the penultimate one.
This fixes that behaviour so that this only happens if the final whitespace is actually consecutive 

## Testing
Added test and ran exiting tests
### Before code changes
![image](https://user-images.githubusercontent.com/42375871/123453849-ced9d780-d5d7-11eb-9792-615599b5e250.png)

### After code changes
![image](https://user-images.githubusercontent.com/42375871/123453859-d26d5e80-d5d7-11eb-830b-493bc615704b.png)
