### PR TITLE
Conn location

### DIFF
--- a/test/conn_host.test
+++ b/test/conn_host.test
@@ -1,0 +1,71 @@
+package require tcltest
+package require mock_ns
+namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
+
+# Load all .tcl files
+set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+foreach file $files {
+    source $file
+}
+namespace import ::qc::*
+
+set setup {
+    ns_conn _set headers [ns_set create headers]
+}
+
+set cleanup {
+    mock_ns::_reset
+}
+
+test conn_host1.0 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                             ]
+        return [qc::conn_host]
+    } \
+    -result {www.qcode.co.uk}
+
+test conn_host1.1 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk:8443" \
+                             ]
+        return [qc::conn_host]
+    } \
+    -result {www.qcode.co.uk:8443}
+
+
+test conn_host1.2 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set location "https://www.fallback.co.uk"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "" \
+                             ]
+        return [qc::conn_host]
+    } \
+    -result {www.fallback.co.uk}
+
+test conn_host1.3 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set location "https://www.fallback.co.uk:8443"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "" \
+                             ]
+        return [qc::conn_host]
+    } \
+    -result {www.fallback.co.uk:8443}
+
+cleanupTests

--- a/test/conn_location.test
+++ b/test/conn_location.test
@@ -1,5 +1,6 @@
 package require tcltest
-namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
+package require mock_ns
+namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
 set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
@@ -9,93 +10,104 @@ foreach file $files {
 namespace import ::qc::*
 
 set setup {
-    # overload ns_conn
-    proc ns_conn { subcmd } {
-        switch -exact $subcmd {
-            "location" {
-                return "https://www.fallback.co.uk"
-            }
-            default {
-                error "ns_conn: $subcmd not implemented in test suite"
-            }
-        }
-    }
+    ns_conn _set headers [ns_set create headers]
+}
+
+set cleanup {
+    mock_ns::_reset
 }
 
 test conn_location1.0 \
     {conn_location 443} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.qcode.co.uk
-        set port        ""
-        set protocol    https
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol --
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {https://www.qcode.co.uk}
 
 test conn_location1.1 \
     {conn_location 80} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.qcode.co.uk
-        set port        ""
-        set protocol    http
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol --
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {http://www.qcode.co.uk}
 
 test conn_location1.2 \
     {conn_location 8443} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.qcode.co.uk:8443
-        set port        ""
-        set protocol    https
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol --
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk:8443" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {https://www.qcode.co.uk:8443}
 
 test conn_location1.3 \
     {conn_location legacy 443} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.qcode.co.uk
-        set port        443
-        set protocol    https
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                                "Port" "443" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {https://www.qcode.co.uk}
 
 test conn_location1.4 \
     {conn_location legacy 80} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.qcode.co.uk
-        set port        80
-        set protocol    http
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                                "Port" "80" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {http://www.qcode.co.uk}
 
 test conn_location1.5 \
     {conn_location legacy 8443} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.qcode.co.uk
-        set port        8443
-        set protocol    https
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                                "Port" "8443" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {https://www.qcode.co.uk:8443}
 
 test conn_location1.6 \
     {conn_location invalid host} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        www.:qcode:.co.uk
-        set port        ""
-        set protocol    https
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.:qcode:.co.uk" \
+                             ]
+        return [qc::conn_location]
     } \
     -returnCodes error \
     -result {conn_location: cannot construct location string}
@@ -103,12 +115,30 @@ test conn_location1.6 \
 test conn_location1.7 \
     {conn_location fallback} \
     -setup $setup \
+    -cleanup $cleanup \
     -body {
-        set host        ""
-        set port        ""
-        set protocol    https
-        qc::conn_location -conn_host $host -conn_port $port -conn_protocol $protocol
+        ns_conn _set protocol "https"
+        ns_conn _set location "https://www.fallback.co.uk"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "" \
+                             ]
+        return [qc::conn_location]
     } \
     -result {https://www.fallback.co.uk}
+
+test conn_location1.8 \
+    {conn_location fallback} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "https"
+        ns_conn _set location "https://www.fallback.co.uk:8443"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "" \
+                             ]
+        return [qc::conn_location]
+    } \
+    -result {https://www.fallback.co.uk:8443}
+
 
 cleanupTests

--- a/test/conn_port.test
+++ b/test/conn_port.test
@@ -1,0 +1,87 @@
+package require tcltest
+package require mock_ns
+namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
+
+# Load all .tcl files
+set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+foreach file $files {
+    source $file
+}
+namespace import ::qc::*
+
+set setup {
+    ns_conn _set headers [ns_set create headers]
+}
+
+set cleanup {
+    mock_ns::_reset
+}
+
+test conn_port1.0 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                             ]
+        return [qc::conn_port]
+    } \
+    -result {443}
+
+test conn_port1.1 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk" \
+                             ]
+        return [qc::conn_port]
+    } \
+    -result {80}
+
+test conn_port1.2 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "Host" "www.qcode.co.uk:8443" \
+                             ]
+        return [qc::conn_port]
+    } \
+    -result {8443}
+
+test conn_port1.3 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "Host"             "www.qcode.co.uk" \
+                                "X-Forwarded-Port" 8443 \
+                             ]
+        return [qc::conn_port]
+    } \
+    -result {8443}
+
+test conn_port1.4 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "Host"             "www.qcode.co.uk" \
+                                "Port"             8443 \
+                             ]
+        return [qc::conn_port]
+    } \
+    -result {8443}
+
+cleanupTests

--- a/test/conn_port.test
+++ b/test/conn_port.test
@@ -84,4 +84,18 @@ test conn_port1.4 \
     } \
     -result {8443}
 
+test conn_port1.5 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "Host"             "www.qcode.co.uk" \
+                                "X-Forwarded-Port" "notaport" \
+                             ]
+        return [qc::conn_port]
+    } \
+    -result {80}
+
 cleanupTests

--- a/test/conn_protocol.test
+++ b/test/conn_protocol.test
@@ -1,0 +1,79 @@
+package require tcltest
+package require mock_ns
+namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
+
+# Load all .tcl files
+set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+foreach file $files {
+    source $file
+}
+namespace import ::qc::*
+
+set setup {
+    ns_conn _set headers [ns_set create headers]
+}
+
+set cleanup {
+    mock_ns::_reset
+}
+
+test conn_protocol1.0 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "http"
+        return [qc::conn_protocol]
+    } \
+    -result {http}
+
+test conn_protocol1.1 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "https"
+        return [qc::conn_protocol]
+    } \
+    -result {https}
+
+test conn_protocol1.2 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "http"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-Proto" "https" \
+                             ]
+        return [qc::conn_protocol]
+    } \
+    -result {https}
+
+test conn_protocol1.3 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-Proto" "http" \
+                             ]
+        return [qc::conn_protocol]
+    } \
+    -result {http}
+
+test conn_protocol1.4 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set protocol "https"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-Proto" "none" \
+                             ]
+        return [qc::conn_protocol]
+    } \
+    -result {https}
+
+cleanupTests


### PR DESCRIPTION
* Integrate mock-ns package into tests
* Add tests for conn_port conn_host and conn_protocol
* ```conn_protocol``` returns connection protocol unless ```X-Forwarded-Proto``` is set
* ```conn_port``` returns in the following precedence:
  *  ```X-Forwarded-Port``` if set and numeric
  * Legacy ```Port``` header if present
  * Port portion of the ```Host``` header
  * Default port 80 or 443 based on protocol
* ```conn_host``` returns Host header unless not present whereupon (legacy) it returns the host portion of ```ns_conn location```
* ```conn_location``` uses the above 3 procs to build location (exception to handle legacy cases where port will not be in ```Host``` header)