### PR TITLE
fix tcltest

### DIFF
--- a/tcl/util_list.tcl
+++ b/tcl/util_list.tcl
@@ -79,8 +79,13 @@ proc qc::lunion { a b } {
 proc qc::ldelete {listVar index} {
     #| Deletes item at $index of list
     upvar 1 $listVar list
-    # Replace a deletion with null, much faster
-    set list [lreplace [K $list [set list {}]] $index $index]
+
+    if { $index < [llength $list] } {
+        # Replace a deletion with null, much faster
+        set list [lreplace [K $list [set list {}]] $index $index]
+    }
+
+    return $list
 }
 
 proc qc::lmove {list from to} {

--- a/test/_s3.test
+++ b/test/_s3.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/_s3.test
+++ b/test/_s3.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/all.tcl
+++ b/test/all.tcl
@@ -1,5 +1,6 @@
 package require tcltest
-namespace import ::tcltest::runAllTests
+namespace import ::tcltest::configure ::tcltest::runAllTests
+configure -testdir [file dirname [file normalize [info script]]]
 
 proc tcltest::cleanupTestsHook {} {
     variable numTests

--- a/test/args.test
+++ b/test/args.test
@@ -2,7 +2,8 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/args.test
+++ b/test/args.test
@@ -2,7 +2,6 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file

--- a/test/auth.test
+++ b/test/auth.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/auth.test
+++ b/test/auth.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/binary_convert.test
+++ b/test/binary_convert.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/binary_convert.test
+++ b/test/binary_convert.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/cast.test
+++ b/test/cast.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/cast.test
+++ b/test/cast.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/castable.test
+++ b/test/castable.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/castable.test
+++ b/test/castable.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/check.test
+++ b/test/check.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/check.test
+++ b/test/check.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/conn.test
+++ b/test/conn.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/conn.test
+++ b/test/conn.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/conn_host.test
+++ b/test/conn_host.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/conn_host.test
+++ b/test/conn_host.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/conn_location.test
+++ b/test/conn_location.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/conn_location.test
+++ b/test/conn_location.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/conn_port.test
+++ b/test/conn_port.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/conn_port.test
+++ b/test/conn_port.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/conn_protocol.test
+++ b/test/conn_protocol.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/conn_protocol.test
+++ b/test/conn_protocol.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/cookie.test
+++ b/test/cookie.test
@@ -3,7 +3,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/cookie.test
+++ b/test/cookie.test
@@ -3,7 +3,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/crypt.test
+++ b/test/crypt.test
@@ -1,7 +1,7 @@
 package require tcltest
 package require Pgtcl
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
-source [file join [file dirname [file normalize [info script]]] "crypt_setup.tcl"]
+source "~/qcode-tcl/test/crypt_setup.tcl"
 
 # pkcs_padding_append
 test pkcs_padding_append-1.0 {pkcs_padding_append - 1 byte unicode} -setup $setup -cleanup $cleanup -constraints {} -body {

--- a/test/crypt.test
+++ b/test/crypt.test
@@ -1,7 +1,7 @@
 package require tcltest
 package require Pgtcl
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
-source ./crypt_setup.tcl
+source [file join [file dirname [file normalize [info script]]] "crypt_setup.tcl"]
 
 # pkcs_padding_append
 test pkcs_padding_append-1.0 {pkcs_padding_append - 1 byte unicode} -setup $setup -cleanup $cleanup -constraints {} -body {

--- a/test/crypt_setup.tcl
+++ b/test/crypt_setup.tcl
@@ -2,7 +2,7 @@
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
     foreach file $files {
         source $file
     }

--- a/test/crypt_setup.tcl
+++ b/test/crypt_setup.tcl
@@ -2,7 +2,7 @@
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
     foreach file $files {
         source $file
     }

--- a/test/css_selector2xpath.test
+++ b/test/css_selector2xpath.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/css_selector2xpath.test
+++ b/test/css_selector2xpath.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/csv.test
+++ b/test/csv.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/csv.test
+++ b/test/csv.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/date.test
+++ b/test/date.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/date.test
+++ b/test/date.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/db.test
+++ b/test/db.test
@@ -3,7 +3,7 @@ package require Pgtcl
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load common definitions of setup and cleanup
-source ./db_setup.tcl
+source ~/qcode-tcl/test/db_setup.tcl
 
 ################################################################################
 ###   TESTS

--- a/test/db_file.test
+++ b/test/db_file.test
@@ -3,7 +3,7 @@ package require Pgtcl
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load common definitions of setup and cleanup
-source ./db_file_setup.tcl
+source ~/qcode-tcl/test/db_file_setup.tcl
 
 
 

--- a/test/db_file_setup.tcl
+++ b/test/db_file_setup.tcl
@@ -1,6 +1,6 @@
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
     foreach file $files {
         source $file
     }

--- a/test/db_file_setup.tcl
+++ b/test/db_file_setup.tcl
@@ -1,6 +1,6 @@
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
     foreach file $files {
         source $file
     }
@@ -48,35 +48,6 @@ set setup_qry {
 }
 
 set cleanup_qry {
-    drop table if exists param cascade;
-    drop domain if exists plain_text cascade;
-    drop domain if exists plain_string cascade;
-    drop domain if exists url cascade;
-    drop domain if exists url_path cascade;
-    drop type if exists user_state cascade;
-    drop type if exists perm_method cascade;
-    drop sequence if exists user_id_seq cascade; 
-    drop sequence if exists file_id_seq cascade;
-    drop sequence if exists perm_category_id_seq cascade;
-    drop sequence if exists perm_class_id_seq cascade;
-    drop sequence if exists perm_id_seq cascade;
-    drop extension if exists pgcrypto cascade;
-    drop function if exists sha1 cascade;
-    drop table if exists users cascade;
-    drop table if exists file cascade;
-    drop table if exists image cascade;
-    drop table if exists validation_messages cascade;
-    drop table if exists session cascade;
-    drop table if exists schema cascade;
-    drop table if exists perm_category cascade;
-    drop table if exists perm_class cascade;
-    drop table if exists perm cascade;
-    drop table if exists user_perm cascade;
-    drop table if exists sticky cascade;
-    drop table if exists file_alias_path cascade;
-    drop table if exists form cascade;
-    drop table if exists required cascade;
-    drop table if exists optional cascade;
 } 
 
 set setup {
@@ -98,7 +69,21 @@ set setup {
     
     # Establish a connection the qc::db way
     qc::db_connect {*}[array get ::conn_info_test]
-    qc::param_set s3_file_bucket mla-dev-files
+
+    # Local config
+    if { [file exists ~/.qcode-tcl] } {
+        source ~/.qcode-tcl
+    }
+    
+    # Bucket to runs tests against
+    if { ![info exists ::env(aws_s3_test_bucket)] } {
+        puts "==========================================================================================="
+        puts "===== Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file ======="
+        puts "==========================================================================================="
+        error "Please specify the S3 test bucket to use in your ~/.qcode-tcl Tcl config file"
+    }
+    
+    qc::param_set s3_file_bucket $::env(aws_s3_test_bucket)
     db_dml {
         insert into
         users(user_id,firstname,surname,email,password_hash,user_state)

--- a/test/db_file_setup.tcl
+++ b/test/db_file_setup.tcl
@@ -60,6 +60,7 @@ set setup {
     db_dml {SET client_min_messages = WARNING}    
     qc::db_init
     db_dml {
+        drop user if exists test_user;
         CREATE USER test_user WITH PASSWORD 'test_password';
         GRANT ALL PRIVILEGES ON DATABASE test_database TO test_user;
         GRANT ALL PRIVILEGES ON ALL TABLES in SCHEMA public TO test_user;

--- a/test/db_setup.tcl
+++ b/test/db_setup.tcl
@@ -80,6 +80,8 @@ set setup_outside_naviserver {
     set conn_superuser [pg_connect -connlist [array get ::conn_info_superuser]]
     pg_execute $conn_superuser {CREATE DATABASE test_database}
     pg_execute $conn_superuser {
+        SET client_min_messages TO WARNING;
+        drop user if exists test_user;
         CREATE USER test_user WITH PASSWORD 'test_password';
         GRANT ALL PRIVILEGES ON DATABASE test_database TO test_user;
     }

--- a/test/db_setup.tcl
+++ b/test/db_setup.tcl
@@ -2,7 +2,7 @@
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
     foreach file $files {
         source $file
     }

--- a/test/db_setup.tcl
+++ b/test/db_setup.tcl
@@ -2,7 +2,7 @@
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
     foreach file $files {
         source $file
     }

--- a/test/db_trans.test
+++ b/test/db_trans.test
@@ -3,7 +3,7 @@ package require Pgtcl
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load common definitions of setup and cleanup
-source ./db_setup.tcl
+source ~/qcode-tcl/test/db_setup.tcl
 
 ################################################################################
 ###   TESTS

--- a/test/dict.test
+++ b/test/dict.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/dict.test
+++ b/test/dict.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/dict_intersect.test
+++ b/test/dict_intersect.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/dict_intersect.test
+++ b/test/dict_intersect.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/dict_is_subset.test
+++ b/test/dict_is_subset.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/dict_is_subset.test
+++ b/test/dict_is_subset.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/email.test
+++ b/test/email.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/email.test
+++ b/test/email.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/file.test
+++ b/test/file.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/file.test
+++ b/test/file.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/form_layout.test
+++ b/test/form_layout.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/form_layout.test
+++ b/test/form_layout.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/format.test
+++ b/test/format.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/format.test
+++ b/test/format.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/format_date.test
+++ b/test/format_date.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/format_date.test
+++ b/test/format_date.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/format_timestamp.test
+++ b/test/format_timestamp.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/format_timestamp.test
+++ b/test/format_timestamp.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/html.test
+++ b/test/html.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/html.test
+++ b/test/html.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/html_options.test
+++ b/test/html_options.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/html_options.test
+++ b/test/html_options.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/html_table.test
+++ b/test/html_table.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/html_table.test
+++ b/test/html_table.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/html_table_doc.test
+++ b/test/html_table_doc.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/html_table_doc.test
+++ b/test/html_table_doc.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/html_table_scroll.test
+++ b/test/html_table_scroll.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/html_table_scroll.test
+++ b/test/html_table_scroll.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/http.test
+++ b/test/http.test
@@ -3,7 +3,7 @@ package require json
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/http.test
+++ b/test/http.test
@@ -3,7 +3,7 @@ package require json
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -4,7 +4,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
     foreach file $files {
         source $file
     }
@@ -100,6 +100,8 @@ set setup_outside_naviserver {
     set conn_superuser [pg_connect -connlist [array get ::conn_info_superuser]]
     pg_execute $conn_superuser {create database test_database}
     pg_execute $conn_superuser {
+        SET client_min_messages TO WARNING;
+        drop user if exists test_user;
         create user test_user with password 'test_password';
         grant all privileges on database test_database to test_user;
     }
@@ -145,7 +147,7 @@ set data_setup {
     set mime_type "image/png"
     set width 420
     set height 120
-    set id [open "./images/${filename}" r]
+    set id [open "~/qcode-tcl/test/images/${filename}" r]
     fconfigure $id -translation binary
     set data [base64::encode [read $id]]
     close $id

--- a/test/image_cache.test
+++ b/test/image_cache.test
@@ -4,7 +4,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
     foreach file $files {
         source $file
     }

--- a/test/image_resize_task.test
+++ b/test/image_resize_task.test
@@ -100,6 +100,8 @@ set setup_outside_naviserver {
     set conn_superuser [pg_connect -connlist [array get ::conn_info_superuser]]
     pg_execute $conn_superuser {create database test_database}
     pg_execute $conn_superuser {
+        SET client_min_messages TO WARNING;
+        drop user if exists test_user;
         create user test_user with password 'test_password';
         grant all privileges on database test_database to test_user;
     }

--- a/test/image_resize_task.test
+++ b/test/image_resize_task.test
@@ -4,7 +4,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
     foreach file $files {
         source $file
     }
@@ -147,7 +147,7 @@ set data_setup {
     set height 120
     set new_width 210
     set new_height 60
-    set id [open "./images/${filename}" r]
+    set id [open "~/qcode-tcl/test/images/${filename}" r]
     fconfigure $id -translation binary
     set data [base64::encode [read $id]]
     close $id

--- a/test/image_resize_task.test
+++ b/test/image_resize_task.test
@@ -4,7 +4,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
     foreach file $files {
         source $file
     }

--- a/test/is.test
+++ b/test/is.test
@@ -3,7 +3,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 source ~/qcode-tcl/test/db_setup.tcl
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/is.test
+++ b/test/is.test
@@ -1,9 +1,9 @@
 package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
-source ./db_setup.tcl
+source ~/qcode-tcl/test/db_setup.tcl
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/ldict.test
+++ b/test/ldict.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/ldict.test
+++ b/test/ldict.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/ll.test
+++ b/test/ll.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/ll.test
+++ b/test/ll.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/math.test
+++ b/test/math.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/math.test
+++ b/test/math.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/mime.test
+++ b/test/mime.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/mime.test
+++ b/test/mime.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/multimap.test
+++ b/test/multimap.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/multimap.test
+++ b/test/multimap.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/my.test
+++ b/test/my.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/my.test
+++ b/test/my.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/password.test
+++ b/test/password.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/password.test
+++ b/test/password.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/perl.test
+++ b/test/perl.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/perl.test
+++ b/test/perl.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/perm.test
+++ b/test/perm.test
@@ -119,6 +119,8 @@ set setup_outside_naviserver {
     set conn_superuser [pg_connect -connlist [array get ::conn_info_superuser]]
     pg_execute $conn_superuser {CREATE DATABASE test_database}
     pg_execute $conn_superuser {
+        SET client_min_messages TO WARNING;
+        drop user if exists test_user;
         CREATE USER test_user WITH PASSWORD 'test_password';
         GRANT ALL PRIVILEGES ON DATABASE test_database TO test_user;
     }

--- a/test/perm.test
+++ b/test/perm.test
@@ -4,7 +4,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
     foreach file $files {
         source $file
     }

--- a/test/perm.test
+++ b/test/perm.test
@@ -4,7 +4,7 @@ namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstrai
 
 if { [info commands ns_db] ne "ns_db" } {
     # Load all .tcl files
-    set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+    set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
     foreach file $files {
         source $file
     }

--- a/test/pgpass.test
+++ b/test/pgpass.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/pgpass.test
+++ b/test/pgpass.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/response.test
+++ b/test/response.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/response.test
+++ b/test/response.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/response_login.test
+++ b/test/response_login.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/response_login.test
+++ b/test/response_login.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/response_redirect.test
+++ b/test/response_redirect.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/response_redirect.test
+++ b/test/response_redirect.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/return_next.test
+++ b/test/return_next.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/return_next.test
+++ b/test/return_next.test
@@ -3,7 +3,7 @@ package require mock_ns
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/s3.test
+++ b/test/s3.test
@@ -3,7 +3,7 @@ package require json
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/s3.test
+++ b/test/s3.test
@@ -3,7 +3,7 @@ package require json
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }
@@ -51,7 +51,6 @@ if { $role_name ne "" } {
 
 # Some tests require other s3 procs to be working
 # Tests are ordered so if a test fails, other test dependent on the failing proc will be skipped
-
 
 # md5 - Get MD5 of a local file
 test s3-md5-1.0 {qc::s3 md5: Test} -body {

--- a/test/s3_uri.test
+++ b/test/s3_uri.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/s3_uri.test
+++ b/test/s3_uri.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/soap.test
+++ b/test/soap.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/soap.test
+++ b/test/soap.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/sort.test
+++ b/test/sort.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/sort.test
+++ b/test/sort.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/sql.test
+++ b/test/sql.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/sql.test
+++ b/test/sql.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/sql_where.test
+++ b/test/sql_where.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/sql_where.test
+++ b/test/sql_where.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/sql_where_in.test
+++ b/test/sql_where_in.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/sql_where_in.test
+++ b/test/sql_where_in.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/style.test
+++ b/test/style.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/style.test
+++ b/test/style.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/table.test
+++ b/test/table.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/table.test
+++ b/test/table.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/tabular_text.test
+++ b/test/tabular_text.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/tabular_text.test
+++ b/test/tabular_text.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/tson.test
+++ b/test/tson.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/tson.test
+++ b/test/tson.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/upset.test
+++ b/test/upset.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/upset.test
+++ b/test/upset.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/url.test
+++ b/test/url.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/url.test
+++ b/test/url.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/user_agent.test
+++ b/test/user_agent.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/user_agent.test
+++ b/test/user_agent.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/util.test
+++ b/test/util.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/util.test
+++ b/test/util.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/util_list.test
+++ b/test/util_list.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/util_list.test
+++ b/test/util_list.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/util_string.test
+++ b/test/util_string.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/util_string.test
+++ b/test/util_string.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/widget.test
+++ b/test/widget.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/widget.test
+++ b/test/widget.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }

--- a/test/xml.test
+++ b/test/xml.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
 foreach file $files {
     source $file
 }

--- a/test/xml.test
+++ b/test/xml.test
@@ -2,7 +2,7 @@ package require tcltest
 namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint
 
 # Load all .tcl files
-set files [lsort [glob -nocomplain [file join "../tcl" *.tcl]]]
+set files [lsort [glob -nocomplain [file join [file dirname [file normalize [info script]]] "../tcl" *.tcl]]]
 foreach file $files {
     source $file
 }


### PR DESCRIPTION
* preserve qc::ldelete behaviour of preventing errors when attempting to delete a index that is greater than the max list index
* update relative file paths to be anchored by user's home directory
* drop test db user if exists before attempting to create it