### PR TITLE
Drop attempts to build trust in X-Forwarded-For and accept it shouldn…

### DIFF
--- a/tcl/conn.tcl
+++ b/tcl/conn.tcl
@@ -4,17 +4,9 @@ namespace eval qc {
 
 proc qc::conn_remote_ip {} {
     #| Try to return the remote IP address of the current connection
-    #| Trust that a reverse proxy like nginx is setup to pass an X-Forwarded-For header.
     set headers [ns_conn headers]
-    if { \
-        [ns_set ifind $headers X-Forwarded-For]!=-1 \
-        && ( \
-               [ns_conn peeraddr] eq "127.0.0.1" \
-            || [string match  192.168* [ns_conn peeraddr]] \
-            || [ns_conn peeraddr] eq [ns_info address] \
-            ) \
-        } {
-	# Proxied so trust X-Forwarded-For
+    if { [ns_set ifind $headers X-Forwarded-For]!=-1 } {
+	# Proxied so use X-Forwarded-For
         # X-Forwarded-For can be a list of IPs. The client IP is always leftmost.
 	set forwarded [split [ns_set iget $headers X-Forwarded-For] ,]
         set ip [string trim [lindex $forwarded 0]]

--- a/test/conn_remote_ip.test
+++ b/test/conn_remote_ip.test
@@ -1,0 +1,101 @@
+package require tcltest
+package require mock_ns
+namespace import ::tcltest::test ::tcltest::cleanupTests ::tcltest::testConstraint mock_ns::*
+
+# Load all .tcl files
+set files [lsort [glob -nocomplain "~/qcode-tcl/tcl/*.tcl"]]
+foreach file $files {
+    source $file
+}
+namespace import ::qc::*
+
+set setup {
+    ns_conn _set headers [ns_set create headers]
+}
+
+set cleanup {
+    mock_ns::_reset
+}
+
+# Standard case where X-Forwarded-For overrides internal peeraddr
+test conn_remote_ip1.0 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set peeraddr "192.168.1.12"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-For" "10.10.10.10" \
+                             ]
+        return [qc::conn_remote_ip]
+    } \
+    -result {10.10.10.10}
+
+# Standard case where X-Forwarded-For overrides peeraddr
+test conn_remote_ip1.1 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set peeraddr "30.30.30.30"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-For" "10.10.10.10" \
+                             ]
+        return [qc::conn_remote_ip]
+    } \
+    -result {10.10.10.10}
+
+# X-Forwarded-For not present so return peeraddr
+test conn_remote_ip1.2 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set peeraddr "30.30.30.30"
+        return [qc::conn_remote_ip]
+    } \
+    -result {30.30.30.30}
+
+# X-Forwarded-For is a list - return leftmost
+test conn_remote_ip1.3 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set peeraddr "30.30.30.30"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-For" "20.20.20.20,10.10.10.10" \
+                             ]
+        return [qc::conn_remote_ip]
+    } \
+    -result {20.20.20.20}
+
+# X-Forwarded-For is not an IP
+test conn_remote_ip1.4 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set peeraddr "30.30.30.30"
+        ns_conn _set headers [ns_set create headers \
+                                "X-Forwarded-For" "not an ip" \
+                             ]
+        return [qc::conn_remote_ip]
+    } \
+    -result {not an ip}
+
+# X-Forwarded-For is lower case
+test conn_remote_ip1.5 \
+    {} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        ns_conn _set peeraddr "30.30.30.30"
+        ns_conn _set headers [ns_set create headers \
+                                "x-forwarded-for" "10.10.10.10" \
+                             ]
+        return [qc::conn_remote_ip]
+    } \
+    -result {10.10.10.10}
+
+cleanupTests


### PR DESCRIPTION
…'t be used for anything sensitive

```
[david@juno:~/qcode-tcl]$ tclsh test/conn_remote_ip.test
conn_remote_ip.test:	Total	6	Passed	6	Skipped	0	Failed	0
```