### PR TITLE
use x-forwarded-for only when valid

### DIFF
--- a/tcl/conn.tcl
+++ b/tcl/conn.tcl
@@ -4,15 +4,26 @@ namespace eval qc {
 
 proc qc::conn_remote_ip {} {
     #| Try to return the remote IP address of the current connection
+
+    # Get direct peer IP
+    set ip [ns_conn peeraddr]
+
+    # Check for X-Forwarded-For header
     set headers [ns_conn headers]
     if { [ns_set ifind $headers X-Forwarded-For]!=-1 } {
 	# Proxied so use X-Forwarded-For
-        # X-Forwarded-For can be a list of IPs. The client IP is always leftmost.
+
+        # X-Forwarded-For can be a list of IPs. Guess the client IP is leftmost.
 	set forwarded [split [ns_set iget $headers X-Forwarded-For] ,]
-        set ip [string trim [lindex $forwarded 0]]
-    } else {
-	set ip [ns_conn peeraddr]
+        set ip_forwarded [string trim [lindex $forwarded 0]]
+
+        # Validate X-Forwarded-For value
+        if { [qc::is ipv4 $ip_forwarded] } {
+            # Valid ipv4 so clobber peeraddr
+            set ip $ip_forwarded
+        }
     }
+
     return $ip
 }
 

--- a/test/conn_remote_ip.test
+++ b/test/conn_remote_ip.test
@@ -82,7 +82,7 @@ test conn_remote_ip1.4 \
                              ]
         return [qc::conn_remote_ip]
     } \
-    -result {not an ip}
+    -result {30.30.30.30}
 
 # X-Forwarded-For is lower case
 test conn_remote_ip1.5 \


### PR DESCRIPTION

```
============================================


Summary of Test Results
	Total	1722	Passed	1709	Skipped	13	Failed	0

Sourced 75 Test Files.


============================================

```