### PR TITLE
fix to case where url_path fails to match domain name with a dash in …

### DIFF
--- a/tcl/url.tcl
+++ b/tcl/url.tcl
@@ -174,7 +174,7 @@ proc qc::url_path {url} {
     if { ![qc::is uri $url] } {
         error "\"$url\" is not a valid URI."
     }  
-    if { [regexp {^https?://[a-z0-9_]+(?:\.[a-z0-9_\-]+)+(?::[0-9]+)?(/[^\?]*)} $url -> path] } {
+    if { [regexp {^https?://[a-z0-9_][a-z0-9_\-]*(?:\.[a-z0-9_\-]+)+(?::[0-9]+)?(/[^\?]*)} $url -> path] } {
 	return $path
     } elseif { [regexp {^(/?[^\?]*)} $url -> path] } {
 	return $path 

--- a/test/url.test
+++ b/test/url.test
@@ -34,6 +34,11 @@ test url_path-1.4 {url_path root url} -setup {
     url_path "https://www.domain.com/"
 } -cleanup {} -result {/}
 
+test url_path-1.5 {url_path contains dash} -setup {
+} -body {
+    url_path "https://domain-name99.co.uk/someplace.html?order_number=911&title=someTitle"
+} -cleanup {} -result {/someplace.html}
+
 # url_encode
 test url_encode-1.0 {url_encode utf-8 safe characters} -body {
     url_encode {.-_~abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789}


### PR DESCRIPTION
…the first part of domain

Previously

```
==== url_path-1.5 url_path contains dash FAILED
==== Contents of test case:

    url_path "https://domain-name99.co.uk/someplace.html?order_number=911&title=someTitle"

---- Result was:
https://domain-name99.co.uk/someplace.html
---- Result should have been (exact matching):
/someplace.html
==== url_path-1.5 FAILED

```

Now

```
$ tclsh test/url.test 
url.test:	Total	103	Passed	103	Skipped	0	Failed	0

```