### PR TITLE
S3 save update

### DIFF
--- a/tcl/_s3.tcl
+++ b/tcl/_s3.tcl
@@ -215,13 +215,12 @@ proc qc::_s3_save { args } {
     qc::args $args -timeout 60 -- bucket object_key filename
     set tmp_file "/tmp/s3-[qc::uuid]"
     set headers [_s3_auth_headers GET $object_key $bucket] 
-    set return_headers [qc::http_save \
-                            -timeout $timeout \
-                            -headers $headers \
-                            -response_headers "true" \
-                            [_s3_endpoint $bucket $object_key] \
-                            $tmp_file
-                       ]
+    qc::http_save \
+        -timeout $timeout \
+        -headers $headers \
+        -return_headers_var return_headers \
+        [_s3_endpoint $bucket $object_key] \
+        $tmp_file
     if { [dict exists $return_headers x-amz-meta-content-md5] } {
         set base64_md5 [dict get $return_headers x-amz-meta-content-md5]
         if { [qc::_s3_base64_md5 -file $tmp_file] ne $base64_md5 } {

--- a/tcl/_s3.tcl
+++ b/tcl/_s3.tcl
@@ -215,19 +215,21 @@ proc qc::_s3_save { args } {
     qc::args $args -timeout 60 -- bucket object_key filename
     set tmp_file "/tmp/s3-[qc::uuid]"
     set headers [_s3_auth_headers GET $object_key $bucket] 
-    set result [qc::http_save \
-                    -timeout $timeout \
-                    -headers $headers \
-                    -headervar return_headers \
-                    [_s3_endpoint $bucket $object_key] \
-                    $tmp_file 
-               ]
+    set return_headers [qc::http_save \
+                            -timeout $timeout \
+                            -headers $headers \
+                            -response_headers "true" \
+                            [_s3_endpoint $bucket $object_key] \
+                            $tmp_file
+                       ]
     if { [dict exists $return_headers x-amz-meta-content-md5] } {
         set base64_md5 [dict get $return_headers x-amz-meta-content-md5]
-        if { [qc::_s3_base64_md5 -file $tmp_file]] ne $base64_md5 } {
+        if { [qc::_s3_base64_md5 -file $tmp_file] ne $base64_md5 } {
             file delete -force $tmp_file
             error "qc::_s3_save: md5 of downloaded file does not match x-amz-meta-content-md5 ($base64_md5)."
         }
+    } else {
+        log Notice "qc::_s3_save: unable to verify downloaded file md5: $filename"
     }
     file copy $tmp_file $filename
     file delete -force $tmp_file

--- a/tcl/http.tcl
+++ b/tcl/http.tcl
@@ -696,7 +696,7 @@ proc qc::http_save {args} {
         -sslversion tlsv1 \
         -sslverifypeer 0 \
         -sslverifyhost 0 \
-        -response_headers false \
+        -return_headers_var {} \
         -- \
         url \
         file
@@ -731,11 +731,10 @@ proc qc::http_save {args} {
     switch $curlErrorNumber {
 	0 {
 	    # OK
-            if { $response_headers } {
-                return $return_headers
-            } else {
-	        return 1
+            if { $return_headers_var ne {} } {
+                upset 1 $return_headers_var $return_headers
             }
+	    return 1
 	}
 	default {
 	    file delete $file

--- a/tcl/s3.tcl
+++ b/tcl/s3.tcl
@@ -75,26 +75,11 @@ proc qc::s3 { args } {
                 error "File $local_filename already exists."
             }
             set head_dict [qc::s3 head $s3_uri]
-            if { [dict exists $head_dict x-amz-meta-content-md5] } {
-                set base64_md5 [dict get $head_dict x-amz-meta-content-md5]
-            }
             set file_size [dict get $head_dict Content-Length]
-            if { $file_size == 0 } {
-                error "Empty file at s3 location $s3_uri"
-            }
             # set timeout - allow 1Mb/s
             set timeout_secs [expr {max( (${file_size}*8)/1000000 , 60)} ]
             log Debug "Timeout set at $timeout_secs seconds"
             qc::_s3_save -timeout $timeout_secs $bucket $object_key $local_filename
-            if { [info exists base64_md5] } {
-                # Check the base64 md5 of the downloaded file matches what we put in the x-amz-meta-content-md5 metadata on upload
-                if { [set local_md5 [qc::_s3_base64_md5 -file $local_filename]] ne $base64_md5 } {
-                    error "qc::s3 get: md5 of downloaded file $local_filename ($local_md5) does not match x-amz-meta-content-md5 ($base64_md5)."
-                }
-            }
-            if { $file_size != [file size $local_filename] } {
-                error "qc::s3 get: size of downloaded file ([file size $local_filename]) $local_filename does not match expected $file_size of $s3_uri"
-            }
         }
         exists {
             # usage:

--- a/test/http.test
+++ b/test/http.test
@@ -232,4 +232,40 @@ test http_patch-1.1  \
         return true
     } -result true
 
+test http_save-1.0 {http_save} -body {
+    set tmp_file /tmp/[qc::uuid]
+    http_save \
+        -timeout 5 \
+        -- \
+        http://httpbin.org/html \
+        $tmp_file
+    set fh [open $tmp_file r]
+    set data [read $fh]
+    close $fh
+    file delete -force $tmp_file
+    return [string bytelength $data]
+} -result {3741}
+
+test http_save-1.1 {http_save no exists} -body {
+    http_save \
+        -timeout 5 \
+        -- \
+        http://httpbin.org/dontexist \
+        $tmp_file
+} -returnCodes {error} \
+  -result {URL NOT FOUND http://httpbin.org/dontexist}
+
+test http_save-1.2 {http_save with headers} -body {
+    set tmp_file /tmp/[qc::uuid]
+    set return_headers [http_save \
+                            -timeout 5 \
+                            -response_headers true \
+                            -- \
+                            http://httpbin.org/html \
+                            $tmp_file
+                       ]
+    file delete -force $tmp_file
+    return [dict get $return_headers Content-Length]
+} -result {3741}
+
 cleanupTests

--- a/test/http.test
+++ b/test/http.test
@@ -257,13 +257,12 @@ test http_save-1.1 {http_save no exists} -body {
 
 test http_save-1.2 {http_save with headers} -body {
     set tmp_file /tmp/[qc::uuid]
-    set return_headers [http_save \
-                            -timeout 5 \
-                            -response_headers true \
-                            -- \
-                            http://httpbin.org/html \
-                            $tmp_file
-                       ]
+    http_save \
+        -timeout 5 \
+        -return_headers_var return_headers \
+        -- \
+        http://httpbin.org/html \
+        $tmp_file
     file delete -force $tmp_file
     return [dict get $return_headers Content-Length]
 } -result {3741}


### PR DESCRIPTION
Rather than ```s3 get``` using a 2-step verification of file md5 (vulnerable to race conditions), move the logic into ```_s3_save``` where we use the ```http_save``` response headers to check md5 value in a single step.
Warn if we cannot check md5.
http_save tests would be better with mock responses but using httpbin as an interim.

```
============================================


Summary of Test Results
	Total	1823	Passed	1810	Skipped	13	Failed	0

Sourced 76 Test Files.


============================================

```