### PR TITLE
New Procs for Getting & Evaluating Database Table Check Constraints

### DIFF
--- a/tcl/db_introspection.tcl
+++ b/tcl/db_introspection.tcl
@@ -955,3 +955,105 @@ proc qc::db_is {data_type value} {
         return f
     }
 }
+
+proc qc::db_table_check_constraints {schema table} {
+    #| Get all check constraints for the given table.
+    #| Return value is a list of constraints where each constraint is a dict
+    #| with the following keys:
+    #|   constraint_name - The name of the check constraint.
+    #|   check_clause    - The check constraint clause.
+    #|   column_names    - The columns used in the check constraint clause.
+
+    set qry {
+        select
+        cc.constraint_name,
+        check_clause,
+        array_agg(ccu.column_name) as column_names
+
+        from
+        information_schema.check_constraints cc
+        join information_schema.constraint_column_usage ccu
+            on cc.constraint_name=ccu.constraint_name
+            and ccu.constraint_schema=cc.constraint_schema
+
+        where
+        ccu.table_schema=:schema
+        and ccu.table_name=:table
+
+        group by
+        cc.constraint_name,
+        check_clause
+    }
+
+    set constraints [list]
+
+    qc::db_cache_foreach -ttl 86400 $qry {
+        lappend constraints [dict create \
+                                 constraint_name $constraint_name \
+                                 check_clause $check_clause \
+                                 column_names [qc::sql_array2list $column_names]]
+    }
+
+    return $constraints
+}
+
+proc qc::db_table_check_constraints_eval {
+    schema
+    table
+    column_values
+} {
+    #| Evaluate check constraints in the given table that use columns specified in column_values.
+    #| Returns a dict of passed and failed check constraints e.g.:
+    #| {
+    #|   passed {
+    #|     customer_firstname_check {firstname Joe}
+    #|     customer_surname_check   {surname Bloggs}
+    #|   }
+    #|   failed {
+    #|     customer_invoice_email_check {
+    #|       send_invoice_by EMAIL
+    #|       invoice_email   {}
+    #|     }
+    #|   }
+    #| }
+    set constraints [qc::memoize db_table_check_constraints $schema $table]
+    set results [dict create \
+                     passed [dict create] \
+                     failed [dict create]]
+
+    foreach constraint $constraints {
+
+        qc::dict2vars $constraint {*}{
+            constraint_name
+            check_clause
+            column_names
+        }
+
+        # Narrow down values to pass to db_eval_constraint.
+        # Evaluating a check constraint is much quicker if only the necessary values are given.
+        set check_column_values [dict create]
+
+        dict for {column value} $column_values {
+            if { $column in $column_names } {
+                dict set check_column_values $column $value
+            }
+        }
+
+        if { [dict size $check_column_values] == 0 } {
+            continue
+        }
+
+        if { [qc::db_eval_constraint \
+                 -schema $schema \
+                 -- \
+                 $table \
+                 $check_clause \
+                 {*}$check_column_values] } {
+            dict set results passed $constraint_name $check_column_values
+        } else {
+            dict set results failed $constraint_name $check_column_values
+        }
+    }
+
+    return $results
+}

--- a/tcl/db_introspection.tcl
+++ b/tcl/db_introspection.tcl
@@ -1016,7 +1016,7 @@ proc qc::db_table_check_constraints_eval {
     #|     }
     #|   }
     #| }
-    set constraints [qc::memoize db_table_check_constraints $schema $table]
+    set constraints [qc::memoize qc::db_table_check_constraints $schema $table]
     set results [dict create \
                      passed [dict create] \
                      failed [dict create]]

--- a/test/db_introspection.test
+++ b/test/db_introspection.test
@@ -306,4 +306,112 @@ test db_user_is_member-1.3 {} -setup $setup -cleanup $cleanup -body {
     qc::db_user_is_member not_a_user test_user
 } -result "false"
 
+set setup_extra $setup
+append setup_extra {
+    db_cache_clear
+
+    db_dml {
+        alter table students add constraint nohtml check(surname !~ '[<>]')
+    }
+
+    set expected [dict create \
+                      constraint_name nohtml \
+                      check_clause {(((surname)::text !~ '[<>]'::text))} \
+                      column_names [list surname]]
+}
+
+test db_table_check_constraints-1.0 \
+    {Get check constraints for a table} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        set constraints [qc::db_table_check_constraints public students]
+
+        return [expr {[llength $constraints] == 1
+                      && [qc::dicts_diff_any $expected [lindex $constraints 0]] eq ""}]
+    } \
+    -result 1
+
+set setup_extra $setup
+append setup_extra {
+    db_cache_clear
+
+    db_dml {
+        alter table students
+        add constraint firstname_not_root check(firstname != 'root'),
+        add constraint surname_not_html check(surname !~ '[<>]');
+    }
+}
+
+test db_table_check_constraints_eval-1.0 \
+    {Evaluate check constraints for a table - All pass} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        set results [qc::db_table_check_constraints_eval \
+                         public \
+                         students \
+                         [dict create \
+                              firstname John \
+                              surname Doe]]
+
+        return [expr {
+                      [dict exists $results passed firstname_not_root firstname]
+                      && [dict get $results passed firstname_not_root firstname] eq "John"
+                      && [dict exists $results passed surname_not_html surname]
+                      && [dict get $results passed surname_not_html surname] eq "Doe"
+                      && [dict size [dict get $results passed]] == 2
+                      && [dict exists $results failed]
+                      && [dict size [dict get $results failed]] == 0
+                  }]
+    } \
+    -result 1
+
+test db_table_check_constraints_eval-1.1 \
+    {Evaluate check constraints for a table - All fail} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        set results [qc::db_table_check_constraints_eval \
+                         public \
+                         students \
+                         [dict create \
+                              firstname root \
+                              surname {<html>}]]
+
+        return [expr {
+                      [dict exists $results passed]
+                      && [dict size [dict get $results passed]] == 0
+                      && [dict exists $results failed firstname_not_root firstname]
+                      && [dict get $results failed firstname_not_root firstname] eq "root"
+                      && [dict exists $results failed surname_not_html surname]
+                      && [dict get $results failed surname_not_html surname] eq {<html>}
+                      && [dict size [dict get $results failed]] == 2
+                  }]
+    } \
+    -result 1
+
+test db_table_check_constraints_eval-1.2 \
+    {Evaluate check constraints for a table - One pass one fail} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        set results [qc::db_table_check_constraints_eval \
+                         public \
+                         students \
+                         [dict create \
+                              firstname John \
+                              surname {<html>}]]
+
+        return [expr {
+                      [dict exists $results passed firstname_not_root firstname]
+                      && [dict get $results passed firstname_not_root firstname] eq "John"
+                      && [dict exists $results failed surname_not_html surname]
+                      && [dict get $results failed surname_not_html surname] eq {<html>}
+                      && [dict size [dict get $results passed]] == 1
+                      && [dict size [dict get $results failed]] == 1
+                  }]
+    } \
+    -result 1
+
 cleanupTests

--- a/test/validate.test
+++ b/test/validate.test
@@ -1,0 +1,116 @@
+package require tcltest
+package require Pgtcl
+namespace import {*}{
+    ::tcltest::test
+    ::tcltest::cleanupTests
+    ::tcltest::testConstraint
+}
+
+source ~/qcode-tcl/test/db_setup.tcl
+
+set setup_extra $setup
+append setup_extra {
+    db_cache_clear
+
+    db_dml {
+        create table validation_messages (
+            table_name text not null,
+            column_name text not null,
+            message text not null
+        );
+
+        alter table students
+        add constraint firstname_not_root check(firstname != 'root'),
+        add constraint surname_not_html check(surname !~ '[<>]');
+    }
+
+    set dict [dict create \
+                  students.student_id 1 \
+                  students.firstname Test \
+                  students.surname Tester \
+                  students.dob 2000-01-1 \
+                  courses.course_id 10 \
+                  courses.title Testing]
+}
+
+append cleanup_qry {
+    drop table validation_messages;
+}
+
+test validate2model-1.0 \
+    {Pass type and check constraint validation.} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        set result [qc::validate2model $dict]
+
+        if { $result } {
+            global data
+            return [expr {
+                          [dict get $data status] eq "valid"
+                          && [dict get $data record student_id valid]
+                          && [dict get $data record firstname valid]
+                          && [dict get $data record surname valid]
+                          && [dict get $data record dob valid]
+                          && [dict get $data record course_id valid]
+                          && [dict get $data record title valid]
+                      }]
+        } else {
+            return 0
+        }
+    } \
+    -result 1
+
+test validate2model-1.1 \
+    {Fail type validation.} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        dict set dict students.firstname ""
+        dict set dict students.dob Test
+        set result [qc::validate2model $dict]
+
+        if { !$result } {
+            global data
+            return [expr {
+                          [dict get $data status] eq "invalid"
+                          && [dict get $data record student_id valid]
+                          && ![dict get $data record firstname valid]
+                          && [dict get $data record surname valid]
+                          && ![dict get $data record dob valid]
+                          && [dict get $data record course_id valid]
+                          && [dict get $data record title valid]
+                      }]
+        } else {
+            return 0
+        }
+    } \
+    -result 1
+
+test validate2model-1.2 \
+    {Fail check constraint validation.} \
+    -setup $setup_extra \
+    -cleanup $cleanup \
+    -body {
+        dict set dict students.firstname root
+        dict set dict students.surname <test>
+        set result [qc::validate2model $dict]
+        
+        if { !$result } {
+            global data
+            return [expr {
+                          [dict get $data status] eq "invalid"
+                          && [dict get $data record student_id valid]
+                          && ![dict get $data record firstname valid]
+                          && ![dict get $data record surname valid]
+                          && [dict get $data record dob valid]
+                          && [dict get $data record course_id valid]
+                          && [dict get $data record title valid]
+                      }]
+        } else {
+            return 0
+        }
+    } \
+    -result 1
+
+cleanupTests


### PR DESCRIPTION
The new `qc::db_table_check_constraints_*` procs are more efficient than making multiple calls to `qc::db_column_constraints` and `qc::db_eval_column_constraints` due to reducing database queries for fetching check constraints (1 per table instead of 1 per column) and using only the necessary args for evaluating each check constraint.

### `qc::validate2model` Timings

#### 1 Column, 1 Check Constraint
&nbsp; | First Run (s) | Subsequent Runs (s)
-|-|-
**Old** | 0.2 | 0.006
**New** | 0.17 | 0.005

#### 74 Columns, 35 Check Constraints
&nbsp; | First Run (s) | Subsequent Runs (s)
-|-|-
**Old** | 3.87 | 1.86
**New** | 2.04 | 0.07

## Unit Testing
```
tclsh db_introspection.test
db_introspection.test:	Total	58	Passed	58	Skipped	0	Failed	0

tclsh validate.test
validate.test:	Total	3	Passed	3	Skipped	0	Failed	0
```