### PR TITLE
Add max keys to lsbucket

### DIFF
--- a/tcl/s3.tcl
+++ b/tcl/s3.tcl
@@ -26,7 +26,10 @@ proc qc::s3 { args } {
         }
         ls {
             # usage: s3 ls 
-            set nodes [qc::s3_xml_select [qc::_s3_get "" ""] {/ns:ListAllMyBucketsResult/ns:Buckets/ns:Bucket}]
+            set nodes [qc::s3_xml_select \
+                        [qc::_s3_get "" ""] \
+                        {/ns:ListAllMyBucketsResult/ns:Buckets/ns:Bucket} \
+                      ]
             return [qc::lapply qc::s3_xml_node2dict $nodes]
         }
         lsbucket {

--- a/tcl/s3.tcl
+++ b/tcl/s3.tcl
@@ -52,7 +52,10 @@ proc qc::s3 { args } {
                 set object_string [string cat "?" [join $object_string "&"]]
             }
             set xmlDoc [qc::_s3_get $bucket $object_string]
-	    return [qc::lapply qc::s3_xml_node2dict [qc::s3_xml_select $xmlDoc {/ns:ListBucketResult/ns:Contents}]]
+	    return [qc::lapply \
+                        qc::s3_xml_node2dict \
+                        [qc::s3_xml_select $xmlDoc {/ns:ListBucketResult/ns:Contents}] \
+                   ]
         }
         get {
             # usage:

--- a/test/s3.test
+++ b/test/s3.test
@@ -79,6 +79,7 @@ test s3-lsbucket-1.0 {qc::s3 lsbucket: List files in a bucket} -constraints {
     requires_s3
     requires_test_bucket
 } -body {
+    qc::s3 lsbucket $bucket
     return 1
 } -result {1}
 

--- a/test/s3.test
+++ b/test/s3.test
@@ -79,7 +79,6 @@ test s3-lsbucket-1.0 {qc::s3 lsbucket: List files in a bucket} -constraints {
     requires_s3
     requires_test_bucket
 } -body {
-    qc::s3 lsbucket $bucket
     return 1
 } -result {1}
 
@@ -88,6 +87,24 @@ test s3-lsbucket-1.1 {qc::s3 lsbucket: List files in a bucket with prefix} -cons
     requires_test_bucket
 } -body {
     qc::s3 lsbucket $bucket "test"
+    testConstraint requires_s3_lsbucket true
+    return 1
+} -result {1}
+
+test s3-lsbucket-1.2 {qc::s3 lsbucket: List files in a bucket with max keys} -constraints {
+    requires_s3
+    requires_test_bucket
+} -body {
+    qc::s3 lsbucket -max_keys 1 $bucket
+    testConstraint requires_s3_lsbucket true
+    return 1
+} -result {1}
+
+test s3-lsbucket-1.3 {qc::s3 lsbucket: List files in a bucket with max keys and prefix} -constraints {
+    requires_s3
+    requires_test_bucket
+} -body {
+    qc::s3 lsbucket -max_keys 1 $bucket "test"
     testConstraint requires_s3_lsbucket true
     return 1
 } -result {1}


### PR DESCRIPTION
Allow ```qc::s3 lsbucket``` to be called with a ```-max_keys``` argument to limit the number of results returned.
Default when unspecified is 1000 records.

#### Tests

```
Tests ended at Tue Feb 21 14:45:03 GMT 2023
all.tcl:	Total	1844	Passed	1831	Skipped	13	Failed	0
Sourced 77 Test Files.
Number of tests skipped for each constraint:
	1	earlier_than_8.5
	12	knownBug


============================================


Summary of Test Results
	Total	1844	Passed	1831	Skipped	13	Failed	0

Sourced 77 Test Files.


============================================

```