### PR TITLE
add timeout to aws s3 http_get

### DIFF
--- a/tcl/aws_s3_ls.tcl
+++ b/tcl/aws_s3_ls.tcl
@@ -10,14 +10,14 @@ namespace eval qc::aws::s3 {
         #| Lists the contents of a bucket optionally filtered by objects 
         #| starting with object_key_prefix
         #| Usage: qc::aws s3 ls mybucket ?prefix?
-        qc::args $args -max_keys 1000 -- bucket {object_key_prefix ""}
+        qc::args $args -max_keys 1000 -timeout 60 -- bucket {object_key_prefix ""}
 
         set query_params [dict create \
                             max-keys $max_keys \
                             prefix $object_key_prefix \
                          ]
         set s3_uri [qc::cast s3_uri $bucket]
-        set response [qc::aws s3 rest_api http_get $s3_uri $query_params]
+        set response [qc::aws s3 rest_api http_get -timeout $timeout $s3_uri $query_params]
         return [qc::aws s3 xml2ldict $response {/ns:ListBucketResult/ns:Contents}]
     }
 }

--- a/tcl/aws_s3_rest_api.tcl
+++ b/tcl/aws_s3_rest_api.tcl
@@ -12,9 +12,10 @@ namespace eval qc::aws::s3::rest_api {
     namespace export http_get
     namespace ensemble create
 
-    proc http_get { s3_uri query_params } {
+    proc http_get { args } {
         #| Makes http GET request (including auth headers) to 
         #| S3 API endpoint and returns result.
+        qc::args $args -timeout 60 -- s3_uri query_params
         set headers [_http_headers \
                         GET \
                         $s3_uri \

--- a/tcl/aws_s3_rest_api.tcl
+++ b/tcl/aws_s3_rest_api.tcl
@@ -23,6 +23,7 @@ namespace eval qc::aws::s3::rest_api {
                         ]
         set url [_endpoint $s3_uri $query_params]
         set result [qc::http_get \
+                        -timeout $timeout \
                         -headers $headers \
                         $url \
                     ]

--- a/test/aws_s3_ls.test
+++ b/test/aws_s3_ls.test
@@ -92,7 +92,7 @@ test aws_s3_ls-1.4 \
     -setup $setup \
     -cleanup $cleanup \
     -body {
-        set response [qc::aws s3 ls -max_keys 2 $bucket "aws_s3_ls/testfile"] 
+        set response [qc::aws s3 ls -max_keys 2 $bucket "aws_s3_ls/testfile"]
         set keys [qc::ldict_values response Key]
         set expected_keys [list \
                             "aws_s3_ls/testfile1.txt" \
@@ -103,4 +103,19 @@ test aws_s3_ls-1.4 \
     } \
     -result 2
 
+test aws_s3_ls-1.5 \
+    {Timeout} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        set response [qc::aws s3 ls -timeout 10 -max_keys 2 $bucket "aws_s3_ls/testfile"]
+        set keys [qc::ldict_values response Key]
+        set expected_keys [list \
+                            "aws_s3_ls/testfile1.txt" \
+                            "aws_s3_ls/testfile2.txt" \
+                            "aws_s3_ls/testfile3.txt" \
+                          ]
+        return [llength [qc::lintersect $keys $expected_keys]]
+    } \
+    -result 2
 cleanupTests

--- a/test/aws_s3_rest_api.test
+++ b/test/aws_s3_rest_api.test
@@ -87,4 +87,24 @@ test aws_s3_rest_api_http_get-1.2 \
     } \
     -result "1"
 
+test aws_s3_rest_api_http_get-1.3 \
+    {GET against root with timeout} \
+    -setup $setup \
+    -cleanup $cleanup \
+    -body {
+        set s3_uri [qc::s3 uri ${bucket}]
+        set query_params [list prefix "aws_s3_rest_api/" max-keys 1]
+        set response [qc::aws s3 rest_api http_get -timeout 10 $s3_uri $query_params]
+
+        set ldict [qc::aws s3 xml2ldict $response {/ns:ListBucketResult/ns:Contents}]
+        set keys [qc::ldict_values ldict Key]
+        set expected_keys [list \
+                            "aws_s3_rest_api/testfile1.txt" \
+                            "aws_s3_rest_api/testfile2.txt" \
+                            "aws_s3_rest_api/testfile3.txt" \
+                          ]
+        return [llength [qc::lintersect $keys $expected_keys]]
+    } \
+    -result "1"
+
 cleanupTests


### PR DESCRIPTION
#### Description

Add ability to change http_get timeout when calling ```qc::aws s3 ls```

#### Tests

```
Tests ended at Wed Mar 08 10:36:49 GMT 2023
all.tcl:	Total	1864	Passed	1851	Skipped	13	Failed	0
Sourced 81 Test Files.
Number of tests skipped for each constraint:
	1	earlier_than_8.5
	12	knownBug


============================================


Summary of Test Results
	Total	1864	Passed	1851	Skipped	13	Failed	0

Sourced 81 Test Files.


============================================

```