### PR TITLE
Update Linting Workflow to Check Changed Tcl Files within the "tcl" Directory & Subdirectories

### DIFF
--- a/.github/workflows/pull-request-linting.yml
+++ b/.github/workflows/pull-request-linting.yml
@@ -11,7 +11,7 @@ jobs:
     uses: qcode-software/ci-development/.github/workflows/qcode-ci.yml@v2.0.0
     with:
       files: |
-        tcl/**.tcl
+        tcl/**/*.tcl
       tcl_directory: tcl
       test_directory: test
       max_line_length: 100


### PR DESCRIPTION
The pattern used to determine which files to check for changes didn't include subdirectories within the `tcl` directory.

This updated pattern will check all Tcl files within the `tcl` directory and all levels of subdirectories.