### PR TITLE
Use HTTPS for S3 REST API calls

### DIFF
--- a/test/s3.test
+++ b/test/s3.test
@@ -613,7 +613,8 @@ test s3-exists-1.4 {qc::s3 exists: bucket remote_filename permissions failure} -
     return $result
 } -returnCodes {
     error
-} -result "RESPONSE 403 while contacting ${bucket}.s3.eu-west-1.amazonaws.com/s3_tools_test-exists-1.4-test"
+} -result "RESPONSE 403 while contacting\
+           https://${bucket}.s3.eu-west-1.amazonaws.com/s3_tools_test-exists-1.4-test"
 
 # Cleanup
 test s3-cleanup {Remove files from S3 uploaded by the s3_tools tests} -constraints {


### PR DESCRIPTION
Board Ticket #
--------------
https://github.com/qcode-software/qcode/issues/58

Git Release Type ( MAJOR | MINOR | PATCH )
--------------
(MINOR)

Description
--------------
The S3 REST API currently defaults to using HTTP which isn't secure. This update makes the existing API use HTTPS for all S3 API calls.

Test Results
--------------

### Integration Testing
- [x] Log the URL being used in `qc::http_curl`, run `tclsh test/s3.test`, and check URLs that were logged.

### Unit Testing
```
tclsh test/all.tcl
Tests running in interp:  /usr/bin/tclsh
Tests located in:  /home/nick/qcode-tcl/test
Tests running in:  /home/nick/qcode-tcl
Temporary files stored in /home/nick/qcode-tcl
Test files run in separate interpreters
Running tests that match:  *
Skipping test files that match:  l.*.test
Only running test files that match:  *.test
Tests began at Thu Jun 22 17:46:28 BST 2023
_s3.test
args.test
auth.test
aws.test
aws_s3_ls.test
aws_s3_rest_api.test
aws_s3_s3_uri_parse.test
aws_s3_xml.test
binary_convert.test
cast.test
castable.test
check.test
conn.test
conn_host.test
conn_location.test
conn_port.test
conn_protocol.test
conn_remote_ip.test
cookie.test
crypt.test
css_selector2xpath.test
csv.test
date.test
db.test
db_file.test
writing /tmp/SGZpiKyNPT ...
written
Timeout set at 60 seconds
writing /tmp/aaIztNGlZi ...
written
Timeout set at 60 seconds
writing /tmp/H7K8NYx3Bv ...
written
db_introspection.test
db_trans.test
dict.test
dict_intersect.test
dict_is_subset.test
dicts_diff_any.test
email.test
file.test
writing /tmp/0W1GqGEvHk ...
written
writing /tmp/wYPT9Qvtvz ...
written
form_layout.test
format.test
format_date.test
format_timestamp.test
html.test
html_options.test
html_table.test
html_table_doc.test
html_table_scroll.test
http.test
Docker installed...
Image kennethreitz/httpbin:latest present...
httpbin not running - starting...
writing /tmp/http_put-1.5.txt ...
written
Shutting down httpbin...
image_cache.test
image_file.test
image_resize_task.test
is.test
writing /tmp/KUprcNcYHd ...
written
ldict.test
ldicts_diff_any.test
ll.test
math.test
mime.test
multimap.test
my.test
password.test
perl.test
perm.test
pgpass.test
response.test
response_login.test
response_redirect.test
return_next.test
s3.test
writing /tmp/ZZHDBLUXQF ...
written
writing /tmp/bRvu65bvif ...
written
writing /tmp/drXDIIfauF ...
written
writing /tmp/C4V6qqKR9r ...
written
writing /tmp/JUVC3jfOUW ...
written
writing /tmp/R6XnYGhDgo ...
written
Timeout set at 60 seconds
writing /tmp/kiNDzF3pWy ...
written
Timeout set at 60 seconds
writing /tmp/XV30h3m740 ...
written
writing /tmp/gJEzS70OdG ...
written
writing /tmp/dUash9wHBw ...
written
writing /tmp/XM6TAjYGzg ...
written
writing /tmp/QI5VdHd3NY ...
written
writing /tmp/KzU2A2jsK5 ...
written
Upload init for s3_tools_test-upload-1.0-test to qcodetcl-tcltest-s3-mla.
Upload_id: 0oVrfeDSGitJLAHdOjOinRtG3Y41PYnSnAckfnFxtAEiq1nU3wf6zPAJkg5wObcEjozzOn6PWhsaXVhgBKfmS2.TkwK4Wqdf9LmqZQR9XnQ8qUPAZ82TsSa5Dms2y1BTc.i5lGJQ2bQ15fvHsbt2dQ--
Timeout set as 10000 ms
Uploading /tmp/KzU2A2jsK5: Sending part 1 of 1
Completing Upload to s3_tools_test-upload-1.0-test in qcodetcl-tcltest-s3-mla.
writing /tmp/6xuwvrN1Yj ...
written
Upload init for s3_tools_test-upload-1.0-test to qcodetcl-tcltest-s3-mla.
Upload_id: d.uzIU5Aryu_ONOgX5.vneePAvUzKBnvNCrvVDs7bLab2oqiXYTujHQXeSGf766QBYbOklB4kuzAkCoC.Ajn686shcmpKgqGN6DCzWNrEFYcAirI3IUKL..mgrHZmbmht9N_iT9Ipw.8CzIq.sXvTQ--
Timeout set as 10000 ms
Uploading /tmp/6xuwvrN1Yj: Sending part 1 of 1
Completing Upload to s3_tools_test-upload-1.0-test in qcodetcl-tcltest-s3-mla.
writing /tmp/kTgIc0NjUZ ...
written
Upload init for s3_tools_test-upload-1.2-test to qcodetcl-tcltest-s3-mla.
Upload_id: trfBHTpV_tMpk__cJ.VSc3k7eqfh_XsuAtjACdGH2PvtL10Uk8E11gFpXfQxkFpKeRDnHkIZi7k0eNWhAXK0z0gOrseAIxJw3.ppnxoaSb5iOR0jim0mkMujxZ0eoM82HaOw5r59cxaTSrdz1siY_A--
writing /tmp/jDZqWbscSC ...
written
Upload init for s3_tools_test-upload-1.3-test to qcodetcl-tcltest-s3-mla.
Upload_id: Sd20NRW_idP6EDKLFlZqLOtte0Fn8xa.AaHRvjLA1GlCOgWfTyo7RBD5XQTriTai4VLHvP_0gc8_B6iL0XPekTY6tUQKgrfH0Imqg_bLhPyx3LyFZstPma9tIVL4o6YEvHD5qMqsOrEa2yWFOFOMpA--
writing /tmp/kyXU2VE1KJ ...
written
Upload init for s3_tools_test-upload-1.4-test to qcodetcl-tcltest-s3-mla.
Upload_id: hJryi470dINF3eyT_4DJ_hFxpJMdoB5O_zJTJy9Clq8RNdtBJYLNzesqorTQe00pwae6UTx2gs0Y3NiNdKTbObdsHoRfvPpV0R0RNCSY8B6hgc.lCyTkUduR5bEd41ZpES8md_CXvS9qspI_2AlLdg--
writing /tmp/qXnHqElvzI ...
written
Upload init for s3_tools_test-upload-1.5-test to qcodetcl-tcltest-s3-mla.
Upload_id: 0ZIZArzmn8ZbVK_Syvy84MDEYyaBrtTMSWFFaU9KHB0njhXwoKLLvcqnjDr5Yd5E.WayptYPuixpwOnqL.DILf9jhFtv72EKDi8hBVHmzPpxniJ6JovbZPGHxH1nR4arLWDprJQFmouWSbcAAU6mjA--
Timeout set as 10000 ms
Uploading /tmp/qXnHqElvzI: Sending part 1 of 1
writing /tmp/AU4qXwUsN7 ...
written
Upload init for s3_tools_test-upload-1.6-test to qcodetcl-tcltest-s3-mla.
Upload_id: noV83CSk_sy_1_XE0iPLr18Hmv5UZ8.C_V8oAvPdegt4LYjLiB6onbopPCv7kXtyn_vvZqzZDkO.5dRLZ7HMzCXyREqpPv0.eTPgokZkr8y7Bh1nKBoHtnzU1QRhHr.olqAiKkw.TVWQqaawSvcmIA--
writing /tmp/cQKgLeAec0 ...
written
writing /tmp/NLQknofRnQ ...
written
writing /tmp/YACLrrSJq2 ...
written
s3_uri.test
soap.test
sort.test
sql.test
sql_where.test
sql_where_in.test
style.test
table.test
tabular_text.test
tson.test
upset.test
url.test
user_agent.test
util.test
util_list.test
util_string.test
validate.test
webp.test
widget.test
xml.test

Tests ended at Thu Jun 22 17:47:29 BST 2023
all.tcl:	Total	1882	Passed	1869	Skipped	13	Failed	0
Sourced 83 Test Files.
Number of tests skipped for each constraint:
	1	earlier_than_8.5
	12	knownBug


============================================


Summary of Test Results
	Total	1882	Passed	1869	Skipped	13	Failed	0

Sourced 83 Test Files.


============================================
```