### PR TITLE
Update qc::reload to use fileutil::findByPattern

### DIFF
--- a/tcl/reload.tcl
+++ b/tcl/reload.tcl
@@ -1,6 +1,7 @@
 namespace eval qc {
     namespace export reload
 }
+package require fileutil
 
 proc qc::reload {args} {
     #| Source files that have changed in this project
@@ -10,7 +11,7 @@ proc qc::reload {args} {
     set reloaded false
     foreach dir $args {
         nsv_set tcl_libs $dir 1
-        set files [glob_recursive -nocomplain -directory $dir *.tcl]
+        set files [fileutil::findByPattern $dir "*.tcl"]
         foreach file $files {
             set fh [open $file r]
             set md5 [qc::md5 [read $fh]]


### PR DESCRIPTION
Board Ticket #
--------------
[Refactor tlc/erp tlc/www tlc/lib to comply with linter. #7712](https://github.com/qcode-software/tlc/issues/7712)

Git Release Type ( MAJOR | MINOR | PATCH )
--------------
(MINOR)

Description
--------------
Update qc::reload to use fileutil::findByPattern

Test Results
--------------
![image](https://github.com/qcode-software/qcode-tcl/assets/15873671/d71682ae-30e9-4833-a216-8b9f2d4399cf)
