### PR TITLE
Throw INVALID_REQUEST Error If Missing Args on Validation Call

### DIFF
--- a/tcl/handlers.tcl
+++ b/tcl/handlers.tcl
@@ -230,7 +230,10 @@ namespace eval qc::handlers {
                 }
                 
                 # arg wasn't optional and didn't appear in form
-                return -code error "No matching arg value for \"$arg\" in form." 
+                return \
+                    -code error \
+                    -errorcode INVALID_REQUEST \
+                    "No matching arg value for \"$arg\" in form."
             }
             return $result
         }


### PR DESCRIPTION
Board Ticket #
--------------

Git Release Type ( MAJOR | MINOR | PATCH )
--------------
(MINOR)

Description
--------------
Regular handlers throw an `INVALID_REQUEST` error code when args are missing. This change makes the validation handler call throw the same error code.

Test Results
--------------
- [x] Set up a validation URL handler and made a request to it without a required form variable.

![image](https://github.com/qcode-software/qcode-tcl/assets/8330836/8ea148d4-38ce-4c8c-b70d-7d368b5128f4)

