### PR TITLE
downscale what conn_remote_ip does

### DIFF
--- a/tcl/conn.tcl
+++ b/tcl/conn.tcl
@@ -3,28 +3,8 @@ namespace eval qc {
 }
 
 proc qc::conn_remote_ip {} {
-    #| Try to return the remote IP address of the current connection
-
-    # Get direct peer IP
-    set ip [ns_conn peeraddr]
-
-    # Check for X-Forwarded-For header
-    set headers [ns_conn headers]
-    if { [ns_set ifind $headers X-Forwarded-For]!=-1 } {
-	# Proxied so use X-Forwarded-For
-
-        # X-Forwarded-For can be a list of IPs. Guess the client IP is leftmost.
-	set forwarded [split [ns_set iget $headers X-Forwarded-For] ,]
-        set ip_forwarded [string trim [lindex $forwarded 0]]
-
-        # Validate X-Forwarded-For value
-        if { [qc::is ipv4 $ip_forwarded] } {
-            # Valid ipv4 so clobber peeraddr
-            set ip $ip_forwarded
-        }
-    }
-
-    return $ip
+    #| Return the remote IP address of the current connection
+    return [ns_conn peeraddr]
 }
 
 proc qc::conn_url {args} {

--- a/test/conn_remote_ip.test
+++ b/test/conn_remote_ip.test
@@ -18,85 +18,15 @@ set cleanup {
     mock_ns::_reset
 }
 
-# Standard case where X-Forwarded-For overrides internal peeraddr
+# Standard case
 test conn_remote_ip1.0 \
     {} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
         ns_conn _set peeraddr "192.168.1.12"
-        ns_conn _set headers [ns_set create headers \
-                                "X-Forwarded-For" "10.10.10.10" \
-                             ]
         return [qc::conn_remote_ip]
     } \
-    -result {10.10.10.10}
-
-# Standard case where X-Forwarded-For overrides peeraddr
-test conn_remote_ip1.1 \
-    {} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        ns_conn _set peeraddr "30.30.30.30"
-        ns_conn _set headers [ns_set create headers \
-                                "X-Forwarded-For" "10.10.10.10" \
-                             ]
-        return [qc::conn_remote_ip]
-    } \
-    -result {10.10.10.10}
-
-# X-Forwarded-For not present so return peeraddr
-test conn_remote_ip1.2 \
-    {} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        ns_conn _set peeraddr "30.30.30.30"
-        return [qc::conn_remote_ip]
-    } \
-    -result {30.30.30.30}
-
-# X-Forwarded-For is a list - return leftmost
-test conn_remote_ip1.3 \
-    {} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        ns_conn _set peeraddr "30.30.30.30"
-        ns_conn _set headers [ns_set create headers \
-                                "X-Forwarded-For" "20.20.20.20,10.10.10.10" \
-                             ]
-        return [qc::conn_remote_ip]
-    } \
-    -result {20.20.20.20}
-
-# X-Forwarded-For is not an IP
-test conn_remote_ip1.4 \
-    {} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        ns_conn _set peeraddr "30.30.30.30"
-        ns_conn _set headers [ns_set create headers \
-                                "X-Forwarded-For" "not an ip" \
-                             ]
-        return [qc::conn_remote_ip]
-    } \
-    -result {30.30.30.30}
-
-# X-Forwarded-For is lower case
-test conn_remote_ip1.5 \
-    {} \
-    -setup $setup \
-    -cleanup $cleanup \
-    -body {
-        ns_conn _set peeraddr "30.30.30.30"
-        ns_conn _set headers [ns_set create headers \
-                                "x-forwarded-for" "10.10.10.10" \
-                             ]
-        return [qc::conn_remote_ip]
-    } \
-    -result {10.10.10.10}
+    -result {192.168.1.12}
 
 cleanupTests


### PR DESCRIPTION
Board Ticket #
--------------
* https://github.com/qcode-software/tlc/issues/8971

Git Release Type ( MAJOR | MINOR | PATCH )
--------------
(MINOR)

Description
--------------

Since Naviserver has been updated to handle X-Forwarded-For headers in reverseproxy mode all that conn_remote_ip needs to do is return the ```ns_conn peeraddr``` result.

Open to discussion.


Test Results
--------------
```
============================================


Summary of Test Results
        Total   1888    Passed  1875    Skipped 13      Failed  0

Sourced 86 Test Files.


============================================
```