### PR TITLE
Add encryption to qc::db_file_insert, qc::db_file_copy and qc::db_file_export

### DIFF
--- a/tcl/db_file.tcl
+++ b/tcl/db_file.tcl
@@ -16,10 +16,16 @@ proc qc::db_file_insert {args} {
     }
    
     set file_id [db_seq file_id_seq]
+    set s3_filename $file_id
+    set encrypted false
+    if { [param_exists file_encryption_key] } {
+        append s3_filename ".enc"
+        set encrypted true
+    }
     qc::aws_credentials_set_from_ec2_role
-    set s3_location [qc::s3 uri [qc::param_get s3_file_bucket] $file_id]
+    set s3_location [qc::s3 uri [qc::param_get s3_file_bucket] $s3_filename]
     # upload file to amazon s3
-    qc::s3 put $s3_location $file_path
+    qc::s3 put $s3_location $file_path $encrypted
     
     set qry {
 	insert into file 
@@ -82,7 +88,12 @@ proc qc::db_file_export {args} {
     } else {
         # file exists on amazon s3
         qc::aws_credentials_set_from_ec2_role
-        qc::s3 get $s3_location $tmp_file
+        if { [regexp -nocase {\.enc$} $s3_location] } {
+            set encrypted true
+        } else {
+            set encrypted false
+        }
+        qc::s3 get $s3_location $tmp_file $encrypted
     }
     return $tmp_file
 }

--- a/test/db_file.test
+++ b/test/db_file.test
@@ -11,6 +11,26 @@ source ~/qcode-tcl/test/db_file_setup.tcl
 ###   TESTS
 ################################################################################
 test db_file_insert-1.0 {Upload a file to s3 and record the file info in the database} \
+    -setup [join [list $setup $setup_no_file_encryption]] \
+    -cleanup [join [list $cleanup $cleanup_no_file_encryption]] \
+    -body {
+        set filepath [qc::file_temp "Hello World"]
+        file rename $filepath ${filepath}.txt
+        set filepath ${filepath}.txt
+
+        set file_id [qc::db_file_insert -user_id 0 $filepath]
+        file delete $filepath
+
+        set filepath [qc::db_file_export $file_id]
+        set result [qc::cat $filepath]
+        file delete $filepath
+        qc::db_file_delete $file_id
+        
+        return $result        
+    } \
+    -result "Hello World"
+
+test db_file_insert-1.1 {Upload a file to s3 and record the file info in the database - encrypted} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
@@ -31,6 +51,29 @@ test db_file_insert-1.0 {Upload a file to s3 and record the file info in the dat
     -result "Hello World"
 
 test db_file_copy-1.0 {Make a copy of a file on s3 and record the new file info in the database} \
+    -setup [join [list $setup $setup_no_file_encryption]] \
+    -cleanup [join [list $cleanup $cleanup_no_file_encryption]] \
+    -body {
+        set filepath [qc::file_temp "Hello World"]
+        file rename $filepath ${filepath}.txt
+        set filepath ${filepath}.txt
+
+        set file_id [qc::db_file_insert -user_id 0 $filepath]
+        file delete $filepath
+
+        set new_file_id [qc::db_file_copy $file_id]
+        set filepath [qc::db_file_export $new_file_id]
+        set result [qc::cat $filepath]
+        file delete $filepath
+
+        qc::db_file_delete $new_file_id
+        qc::db_file_delete $file_id
+        
+        return $result        
+    } \
+    -result "Hello World"
+
+test db_file_copy-1.1 {Make a copy of a file on s3 and record the new file info in the database - encrypted} \
     -setup $setup \
     -cleanup $cleanup \
     -body {
@@ -53,10 +96,9 @@ test db_file_copy-1.0 {Make a copy of a file on s3 and record the new file info 
     } \
     -result "Hello World"
 
-
 test db_file_migrate-1.0 {Migrate a file from data to S3} \
-    -setup $setup \
-    -cleanup $cleanup \
+    -setup [join [list $setup $setup_no_file_encryption]] \
+    -cleanup [join [list $cleanup $cleanup_no_file_encryption]] \
     -body {
         set filepath [qc::file_temp "Hello World"]
         file rename $filepath ${filepath}.txt
@@ -94,8 +136,8 @@ test db_file_migrate-1.0 {Migrate a file from data to S3} \
     -result "Hello World"
 
 test db_file_legacy_export {Export a file from data} \
-    -setup $setup \
-    -cleanup $cleanup \
+    -setup [join [list $setup $setup_no_file_encryption]] \
+    -cleanup [join [list $cleanup $cleanup_no_file_encryption]] \
     -body {
         set filepath [qc::file_temp "Hello World"]
         file rename $filepath ${filepath}.txt

--- a/test/db_file_setup.tcl
+++ b/test/db_file_setup.tcl
@@ -71,7 +71,8 @@ set setup {
     
     # Establish a connection the qc::db way
     qc::db_connect {*}[array get ::conn_info_test]
-
+    qc::db_trans_start    
+    qc::param_set file_encryption_key "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     # Local config
     if { [file exists ~/.qcode-tcl] } {
         source ~/.qcode-tcl
@@ -96,6 +97,7 @@ set setup {
 
 set cleanup {
     # Cleanup the qc::db connection
+    qc::db_trans_abort
     qc::db_disconnect
     
     qc::db_connect {*}[array get ::conn_info_superuser_test_db]
@@ -108,4 +110,21 @@ set cleanup {
     db_dml {DROP DATABASE IF EXISTS test_database}
     db_dml {DROP ROLE IF EXISTS test_user;}
     qc::db_disconnect    
+}
+
+
+set setup_no_file_encryption {
+    rename qc::param_exists qc::param_exists_old
+    proc qc::param_exists {param_name} {
+        if { $param_name eq "file_encryption_key" } {
+            return false
+        } else {
+            return [qc::param_exists_old $param_name]
+        }
+    }
+}
+
+set cleanup_no_file_encryption {
+    rename qc::param_exists ""
+    rename qc::param_exists_old qc::param_exists
 }


### PR DESCRIPTION
Board Ticket #
--------------
https://github.com/qcode-software/mla/issues/6192

Git Release Type ( MAJOR | MINOR )
--------------
(MINOR)

Description
--------------
Add encryption to qc::db_file_insert, qc::db_file_copy and qc::db_file_export

Test Results
--------------
<img width="853" height="481" alt="image" src="https://github.com/user-attachments/assets/9fb761a6-3206-4a36-bb44-836ee9838f12" />
