### PR TITLE
soft file deletion

### DIFF
--- a/tcl/db_file.tcl
+++ b/tcl/db_file.tcl
@@ -181,3 +181,32 @@ proc qc::db_file_delete {file_id} {
     }
     db_dml {delete from file where file_id=:file_id}
 }
+
+proc qc::db_file_delete_soft { file_id } {
+    #| Soft deleted file by updateing file.deleted
+    db_dml {
+        update file
+        set deleted=true
+        where file_id=:file_id
+    }
+}
+
+proc qc::db_file_delete_s3 { file_id } {
+    #| Delete from S3 store and update file.deleted & file.s3_deleted
+    db_1row {
+        select
+        s3_location
+        from file
+        where
+        file_id=:file_id
+    }
+
+    qc::aws_credentials_set_from_ec2_role
+    qc::s3 delete $s3_location
+    
+    db_dml {
+        update file
+        set deleted=true, s3_deleted=true
+        where file_id=:file_id
+    }
+}

--- a/tcl/db_init.tcl
+++ b/tcl/db_init.tcl
@@ -138,7 +138,9 @@ proc qc::db_init {} {
 					 data bytea,
                                          s3_location text,
 					 upload_date timestamp without time zone DEFAULT now(),
-					 mime_type text NOT NULL
+					 mime_type text NOT NULL,
+                     deleted boolean not null default false,
+                     s3_deleted boolean not null default false
 					 );
 
         CREATE TABLE IF NOT EXISTS image (

--- a/test/db_file.test
+++ b/test/db_file.test
@@ -172,4 +172,38 @@ test db_file_legacy_export {Export a file from data} \
     } \
     -result "Hello World"
 
+test db_file_delete_soft-1.0 {soft delete db file} \
+    -setup [join [list $setup $setup_no_file_encryption]] \
+    -cleanup [join [list $cleanup $cleanup_no_file_encryption]] \
+    -body {
+        set filepath [qc::file_temp "Hello World"]
+        file rename $filepath ${filepath}.txt
+        set filepath ${filepath}.txt
+
+        set file_id [qc::db_file_insert -user_id 0 $filepath]
+        file delete $filepath
+
+        qc::db_file_delete_soft $file_id
+        
+        return true
+    } \
+    -result true
+
+test db_file_delete_s3-1.0 {delete db file from s3 file store} \
+    -setup [join [list $setup $setup_no_file_encryption]] \
+    -cleanup [join [list $cleanup $cleanup_no_file_encryption]] \
+    -body {
+        set filepath [qc::file_temp "Hello World"]
+        file rename $filepath ${filepath}.txt
+        set filepath ${filepath}.txt
+
+        set file_id [qc::db_file_insert -user_id 0 $filepath]
+        file delete $filepath
+
+        qc::db_file_delete_s3 $file_id
+        
+        return true
+    } \
+    -result true
+
 cleanupTests


### PR DESCRIPTION
Board Ticket #
--------------
https://github.com/qcode-software/tlc-erp-nsd/pull/4370

Git Release Type ( MAJOR | MINOR )
--------------
(MINOR)

Description
--------------
`qc::db_file_delete` - unchanged to not add breaking changes

`qc::db_file_delete_soft` - will be used by 1st scheduled task to mark files as deleted in db as per file lifecycle requirements.

`qc::db_file_delete_s3` - will be used by 2nd independent scheduled task to perform s3 file deletion for files where `deleted=true and s3_deleted=false`
